### PR TITLE
feat: list and get detailed youtube transcription endpoints

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,9 @@ async function bootstrap() {
   console.log(`   GET /api/articles - List articles`);
   console.log(`   GET /api/articles/:id - Get article details`);
   console.log(`   GET /api/profiles - Get available feed profiles`);
+  console.log(`   GET /api/youtube/transcriptions - List youtube transcriptions`);
+  console.log(`   GET /api/youtube/transcriptions/:id - Get youtube transcription details`);
   console.log(`   GET /api/health - Health check`);
 }
+
 void bootstrap();

--- a/src/youtube-transcriptions/entities/youtube-transcription.entity.ts
+++ b/src/youtube-transcriptions/entities/youtube-transcription.entity.ts
@@ -21,3 +21,24 @@ export interface YoutubeTranscription {
   transcriptionText: string;
   transcriptionSummary?: string;
 }
+
+export interface PaginatedYoutubeTranscriptionInput {
+  page?: number;
+  perPage?: number;
+  sort_by?: string;
+  direction?: 'asc' | 'desc';
+  channel_id?: string;
+  channel_name?: string;
+  search?: string;
+  start_date?: string;
+  end_date?: string;
+  preset?: string;
+}
+
+export interface CountTotalTranscriptionsInput {
+  channel_id?: string;
+  channel_name?: string;
+  search?: string;
+  start_date?: string;
+  end_date?: string;
+}

--- a/src/youtube-transcriptions/queries/get-youtube-transcription-by-id.query.ts
+++ b/src/youtube-transcriptions/queries/get-youtube-transcription-by-id.query.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { YoutubeTranscription } from '../entities/youtube-transcription.entity';
+import { YoutubeTranscriptionsService } from '../youtube-transcriptions.service';
+
+export type GetYoutubeTranscriptionByIdResponse = {
+  transcription: YoutubeTranscription;
+};
+
+@Injectable()
+export class GetYoutubeTranscriptionByIdQuery {
+  constructor(private readonly service: YoutubeTranscriptionsService) {}
+
+  async execute(
+    id: number,
+  ): Promise<GetYoutubeTranscriptionByIdResponse | null> {
+    const transcription = await this.service.getTranscriptionById(id);
+
+    if (!transcription) {
+      return null;
+    }
+
+    return {
+      transcription,
+    };
+  }
+}

--- a/src/youtube-transcriptions/queries/list-youtube-transcriptions.query.ts
+++ b/src/youtube-transcriptions/queries/list-youtube-transcriptions.query.ts
@@ -61,14 +61,7 @@ export class ListYoutubeTranscriptionsQuery {
       }
     }
 
-    const availableChannelIds = await this.service.getDistinctChannelIds();
-    const availableChannelNames = await this.service.getDistinctChannelNames();
-
-    // Combine channel IDs and names into objects
-    const availableChannels = availableChannelIds.map((id, index) => ({
-      id,
-      name: availableChannelNames[index] || '',
-    }));
+    const availableChannels = await this.service.getDistinctChannels();
 
     const totalTranscriptions = await this.service.countTotalTranscriptions({
       channel_id: channel_id,

--- a/src/youtube-transcriptions/queries/list-youtube-transcriptions.query.ts
+++ b/src/youtube-transcriptions/queries/list-youtube-transcriptions.query.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@nestjs/common';
+import moment from 'moment';
+import { PaginatedYoutubeTranscriptionInput } from '../entities/youtube-transcription.entity';
+import { YoutubeTranscriptionsService } from '../youtube-transcriptions.service';
+
+export type ListYoutubeTranscriptionsRequest =
+  PaginatedYoutubeTranscriptionInput;
+
+export type ListYoutubeTranscriptionsResponse = {
+  transcriptions: any[];
+  pagination: {
+    page: number;
+    per_page: number;
+    total_pages: number;
+    total_transcriptions: number;
+  };
+  filters: {
+    sort_by: string;
+    direction: string;
+    channel_id: string;
+    channel_name: string;
+    search: string;
+    start_date: string;
+    end_date: string;
+    preset: string;
+  };
+  available_channels: { id: string; name: string }[];
+};
+
+@Injectable()
+export class ListYoutubeTranscriptionsQuery {
+  constructor(private readonly service: YoutubeTranscriptionsService) { }
+
+  async execute(
+    request: ListYoutubeTranscriptionsRequest,
+  ): Promise<ListYoutubeTranscriptionsResponse | null> {
+    const {
+      page = 1,
+      perPage = 20,
+      channel_id,
+      channel_name,
+      direction = 'desc',
+      end_date,
+      preset,
+      search,
+      sort_by = 'posted_at',
+      start_date,
+    } = request;
+
+    let startDateToSearch = start_date;
+    let endDateToSearch = end_date;
+
+    if (preset) {
+      const presetDates = this.parseDatePreset(preset);
+      if (presetDates.startDate) {
+        startDateToSearch = presetDates.startDate;
+      }
+
+      if (presetDates.endDate) {
+        endDateToSearch = presetDates.endDate;
+      }
+    }
+
+    const availableChannelIds = await this.service.getDistinctChannelIds();
+    const availableChannelNames = await this.service.getDistinctChannelNames();
+
+    // Combine channel IDs and names into objects
+    const availableChannels = availableChannelIds.map((id, index) => ({
+      id,
+      name: availableChannelNames[index] || '',
+    }));
+
+    const totalTranscriptions = await this.service.countTotalTranscriptions({
+      channel_id: channel_id,
+      channel_name: channel_name,
+      search: search,
+      start_date: startDateToSearch,
+      end_date: endDateToSearch,
+    });
+
+    const totalPages = Math.ceil(totalTranscriptions / perPage);
+
+    const transcriptions = await this.service.getTranscriptionsPaginated({
+      page,
+      perPage,
+      sort_by,
+      direction,
+      channel_id: channel_id,
+      channel_name: channel_name,
+      search: search,
+      start_date: startDateToSearch,
+      end_date: endDateToSearch,
+    });
+
+    return {
+      transcriptions,
+      pagination: {
+        page,
+        per_page: perPage,
+        total_pages: totalPages,
+        total_transcriptions: totalTranscriptions,
+      },
+      filters: {
+        sort_by: sort_by,
+        direction: direction,
+        channel_id: channel_id ?? '',
+        channel_name: channel_name ?? '',
+        search: search ?? '',
+        start_date: start_date ?? '',
+        end_date: end_date ?? '',
+        preset: preset ?? '',
+      },
+      available_channels: availableChannels,
+    };
+  }
+
+  private parseDatePreset(preset: string): {
+    startDate?: string;
+    endDate?: string;
+  } {
+    const now = moment();
+
+    switch (preset) {
+      case 'yesterday': {
+        const yesterday = now.clone().subtract(1, 'day');
+        return {
+          startDate: yesterday.format('YYYY-MM-DD'),
+          endDate: yesterday.format('YYYY-MM-DD'),
+        };
+      }
+      case 'last_week':
+        return {
+          startDate: now.clone().subtract(7, 'days').format('YYYY-MM-DD'),
+          endDate: now.format('YYYY-MM-DD'),
+        };
+      case 'last_30d':
+        return {
+          startDate: now.clone().subtract(30, 'days').format('YYYY-MM-DD'),
+          endDate: now.format('YYYY-MM-DD'),
+        };
+      case 'last_3m':
+        return {
+          startDate: now.clone().subtract(3, 'months').format('YYYY-MM-DD'),
+          endDate: now.format('YYYY-MM-DD'),
+        };
+      case 'last_12m':
+        return {
+          startDate: now.clone().subtract(12, 'months').format('YYYY-MM-DD'),
+          endDate: now.format('YYYY-MM-DD'),
+        };
+      default:
+        return {};
+    }
+  }
+}

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -1,0 +1,40 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GetYoutubeTranscriptionByIdQuery } from './queries/get-youtube-transcription-by-id.query';
+import { ListYoutubeTranscriptionsQuery } from './queries/list-youtube-transcriptions.query';
+import { YoutubeTranscriptionsController } from './youtube-transcriptions.controller';
+
+describe('YoutubeTranscriptionsController', () => {
+  let controller: YoutubeTranscriptionsController;
+
+  const mockListYoutubeTranscriptionsQuery = {
+    execute: jest.fn(),
+  };
+
+  const mockGetYoutubeTranscriptionByIdQuery = {
+    execute: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [YoutubeTranscriptionsController],
+      providers: [
+        {
+          provide: ListYoutubeTranscriptionsQuery,
+          useValue: mockListYoutubeTranscriptionsQuery,
+        },
+        {
+          provide: GetYoutubeTranscriptionByIdQuery,
+          useValue: mockGetYoutubeTranscriptionByIdQuery,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<YoutubeTranscriptionsController>(
+      YoutubeTranscriptionsController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -1,0 +1,35 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseIntPipe,
+  Query,
+} from '@nestjs/common';
+import type { PaginatedYoutubeTranscriptionInput } from './entities/youtube-transcription.entity';
+import { GetYoutubeTranscriptionByIdQuery } from './queries/get-youtube-transcription-by-id.query';
+import { ListYoutubeTranscriptionsQuery } from './queries/list-youtube-transcriptions.query';
+
+@Controller('api/youtube/transcriptions')
+export class YoutubeTranscriptionsController {
+  constructor(
+    private readonly listYoutubeTranscriptionsQuery: ListYoutubeTranscriptionsQuery,
+    private readonly getYoutubeTranscriptionByIdQuery: GetYoutubeTranscriptionByIdQuery,
+  ) { }
+
+  @Get()
+  async listTranscriptions(@Query() input: PaginatedYoutubeTranscriptionInput) {
+    return await this.listYoutubeTranscriptionsQuery.execute(input);
+  }
+
+  @Get(':id')
+  async getTranscription(@Param('id', ParseIntPipe) id: number) {
+    const data = await this.getYoutubeTranscriptionByIdQuery.execute(id);
+
+    if (!data || !data.transcription) {
+      throw new NotFoundException('YouTube transcription not found');
+    }
+
+    return data;
+  }
+}

--- a/src/youtube-transcriptions/youtube-transcriptions.module.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.module.ts
@@ -4,8 +4,11 @@ import { AiService } from '../ai/ai.service';
 import { ConfigModule } from '../config/config.module';
 import { ConfigService } from '../config/config.service';
 import { DatabaseModule } from '../database/database.module';
+import { GetYoutubeTranscriptionByIdQuery } from './queries/get-youtube-transcription-by-id.query';
+import { ListYoutubeTranscriptionsQuery } from './queries/list-youtube-transcriptions.query';
 import { StorageService } from './storage.service';
 import { TranscriptService } from './transcript.service';
+import { YoutubeTranscriptionsController } from './youtube-transcriptions.controller';
 import { YoutubeTranscriptionsService } from './youtube-transcriptions.service';
 import { YouTubeService } from './youtube.service';
 
@@ -18,7 +21,10 @@ import { YouTubeService } from './youtube.service';
     StorageService,
     AiService,
     ConfigService,
+    ListYoutubeTranscriptionsQuery,
+    GetYoutubeTranscriptionByIdQuery,
   ],
   exports: [YoutubeTranscriptionsService],
+  controllers: [YoutubeTranscriptionsController],
 })
 export class YoutubeTranscriptionsModule {}

--- a/src/youtube-transcriptions/youtube-transcriptions.service.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.service.ts
@@ -337,46 +337,31 @@ export class YoutubeTranscriptionsService {
   }
 
   /**
-   * Get distinct channel IDs from the database
-   * @returns Array of unique channel IDs
+   * Get distinct channels (ID and name pairs) from the database
+   * @returns Array of unique channels with id and name
    */
-  async getDistinctChannelIds(): Promise<string[]> {
+  async getDistinctChannels(): Promise<{ id: string; name: string }[]> {
     return new Promise((resolve, reject) => {
       const db = this.databaseService.getDbConnection();
 
       db.all(
-        'SELECT DISTINCT channel_id FROM youtube_transcriptions ORDER BY channel_id',
+        'SELECT DISTINCT channel_id, channel_name FROM youtube_transcriptions ORDER BY channel_name',
         [],
-        (err: Error | null, rows: { channel_id: string }[]) => {
+        (
+          err: Error | null,
+          rows: { channel_id: string; channel_name: string }[],
+        ) => {
           if (err) {
             reject(err);
             return;
           }
 
-          resolve(rows.map((row) => row.channel_id));
-        },
-      );
-    });
-  }
-
-  /**
-   * Get distinct channel names from the database
-   * @returns Array of unique channel names
-   */
-  async getDistinctChannelNames(): Promise<string[]> {
-    return new Promise((resolve, reject) => {
-      const db = this.databaseService.getDbConnection();
-
-      db.all(
-        'SELECT DISTINCT channel_name FROM youtube_transcriptions ORDER BY channel_name',
-        [],
-        (err: Error | null, rows: { channel_name: string }[]) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-
-          resolve(rows.map((row) => row.channel_name));
+          resolve(
+            rows.map((row) => ({
+              id: row.channel_id,
+              name: row.channel_name,
+            })),
+          );
         },
       );
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `/api/youtube/transcriptions` (paginated, filterable) and `/api/youtube/transcriptions/:id` endpoints with supporting queries, service methods, and module wiring.
> 
> - **API (YouTube Transcriptions)**
>   - **Endpoints**: `GET /api/youtube/transcriptions` (list with pagination/filters/date presets) and `GET /api/youtube/transcriptions/:id` (detail with 404 handling) via `YoutubeTranscriptionsController`.
>   - **Queries**: `ListYoutubeTranscriptionsQuery` (builds filters, pagination, available channels) and `GetYoutubeTranscriptionByIdQuery`.
>   - **Service**: Adds `getTranscriptionById`, `getTranscriptionsPaginated`, `countTotalTranscriptions`, `getDistinctChannelIds`, `getDistinctChannelNames`.
>   - **Entities**: Introduces `PaginatedYoutubeTranscriptionInput` and `CountTotalTranscriptionsInput` types.
>   - **Module**: Registers controller and query providers in `YoutubeTranscriptionsModule`.
>   - **Bootstrap**: Logs new endpoints in `src/main.ts`.
>   - **Tests**: Adds controller spec scaffold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73e20a94ad2d067c69e12163382bb186e4e37a69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->