### PR TITLE
refactor: usecase for cli commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
 # To-dos
 - [x] Check if youtube transcription already exists in database before adding it and process it
 - [ ] Send email with articles briefings; use my `personal-sendmail-api`
-- [ ] Convert cli commands to use usecase so it's more decoupled and easy to reuse
+- [x] Convert cli commands to use usecase so it's more decoupled and easy to reuse
 - [ ] Isolate prompts configs from config.service.ts to separate files, so it's easier to mantain; also do this for the other configs
 - [x] Add articles manually
 - [ ] Star/bookmark/save for later an article

--- a/prompts/cli_usecases_refactor_7a4b8e8a.plan.md
+++ b/prompts/cli_usecases_refactor_7a4b8e8a.plan.md
@@ -1,0 +1,299 @@
+---
+name: CLI Usecases Refactor
+overview: Refactor CLI scripts to use dedicated usecases in src/usecases for better decoupling, reusability, and testability. Create both individual stage usecases and orchestrator usecases with input/output DTOs.
+todos:
+  - id: create-module
+    content: Create UsecasesModule and directory structure
+    status: pending
+  - id: briefing-dtos
+    content: Create DTOs for all briefing usecases
+    status: pending
+  - id: briefing-individual
+    content: Implement individual briefing usecases (scrape, process, rate, categorize, generate)
+    status: pending
+  - id: briefing-orchestrator
+    content: Implement RunBriefingUseCase orchestrator
+    status: pending
+  - id: youtube-dtos
+    content: Create DTOs for YouTube transcription usecases
+    status: pending
+  - id: youtube-usecases
+    content: Implement YouTube transcription usecases (extract, process, list)
+    status: pending
+  - id: refactor-cli-briefing
+    content: Refactor runBriefing.ts to use usecases
+    status: pending
+  - id: refactor-cli-youtube
+    content: Refactor YouTube CLI scripts to use usecases
+    status: pending
+  - id: update-app-module
+    content: Import UsecasesModule in AppModule
+    status: pending
+  - id: test-integration
+    content: Test all CLI commands to ensure they work with new usecases
+    status: pending
+---
+
+# CLI to Usecases Refactoring Plan
+
+## Overview
+Convert the 4 CLI scripts into reusable usecases with clear contracts, making the business logic decoupled from CLI execution and easily testable.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph cli [CLI Scripts Layer]
+        runBriefing[runBriefing.ts]
+        runYT[runYoutubeTranscripts.ts]
+        runProcess[runProcessTranscriptions.ts]
+        runList[runListTranscriptions.ts]
+    end
+    
+    subgraph usecases [Usecases Layer]
+        subgraph briefingUC [Briefing Usecases]
+            RunBriefingUC[RunBriefingUseCase]
+            ScrapeUC[ScrapeArticlesUseCase]
+            ProcessUC[ProcessArticlesUseCase]
+            RateUC[RateArticlesUseCase]
+            CategorizeUC[CategorizeArticlesUseCase]
+            GenerateUC[GenerateBriefUseCase]
+            GenerateSimpleUC[GenerateSimpleBriefUseCase]
+        end
+        
+        subgraph ytUC [YouTube Usecases]
+            ExtractUC[ExtractYoutubeTranscriptsUseCase]
+            ProcessFilesUC[ProcessTranscriptionFilesUseCase]
+            ListUC[ListTranscriptionsUseCase]
+        end
+    end
+    
+    subgraph services [Services Layer]
+        ScraperSvc[ScraperService]
+        ProcessorSvc[ProcessorService]
+        BriefingSvc[BriefingService]
+        YoutubeSvc[YoutubeTranscriptionsService]
+        ProfilesSvc[ProfilesService]
+    end
+    
+    runBriefing --> RunBriefingUC
+    runBriefing --> ScrapeUC
+    runBriefing --> ProcessUC
+    runBriefing --> RateUC
+    runBriefing --> CategorizeUC
+    runBriefing --> GenerateUC
+    runBriefing --> GenerateSimpleUC
+    
+    RunBriefingUC --> ScrapeUC
+    RunBriefingUC --> ProcessUC
+    RunBriefingUC --> RateUC
+    RunBriefingUC --> CategorizeUC
+    RunBriefingUC --> GenerateUC
+    
+    ScrapeUC --> ScraperSvc
+    ScrapeUC --> ProfilesSvc
+    ProcessUC --> ProcessorSvc
+    RateUC --> ProcessorSvc
+    CategorizeUC --> ProcessorSvc
+    GenerateUC --> BriefingSvc
+    GenerateSimpleUC --> BriefingSvc
+    
+    runYT --> ExtractUC
+    runProcess --> ProcessFilesUC
+    runList --> ListUC
+    
+    ExtractUC --> YoutubeSvc
+    ProcessFilesUC --> YoutubeSvc
+    ListUC --> YoutubeSvc
+```
+
+## Directory Structure
+
+Create new directory structure:
+
+```
+src/usecases/
+├── briefing/
+│   ├── dto/
+│   │   ├── scrape-articles.dto.ts
+│   │   ├── process-articles.dto.ts
+│   │   ├── rate-articles.dto.ts
+│   │   ├── categorize-articles.dto.ts
+│   │   ├── generate-brief.dto.ts
+│   │   └── run-briefing.dto.ts
+│   ├── scrape-articles.usecase.ts
+│   ├── process-articles.usecase.ts
+│   ├── rate-articles.usecase.ts
+│   ├── categorize-articles.usecase.ts
+│   ├── generate-brief.usecase.ts
+│   ├── generate-simple-brief.usecase.ts
+│   └── run-briefing.usecase.ts (orchestrator)
+├── youtube-transcriptions/
+│   ├── dto/
+│   │   ├── extract-youtube-transcripts.dto.ts
+│   │   ├── process-transcription-files.dto.ts
+│   │   └── list-transcriptions.dto.ts
+│   ├── extract-youtube-transcripts.usecase.ts
+│   ├── process-transcription-files.usecase.ts
+│   └── list-transcriptions.usecase.ts
+└── usecases.module.ts
+```
+
+## Implementation Steps
+
+### 1. Create Usecases Module
+- Create [`src/usecases/usecases.module.ts`](src/usecases/usecases.module.ts)
+- Import all necessary service modules (ScraperModule, ProcessorModule, BriefingModule, YoutubeTranscriptionsModule, ProfilesModule)
+- Export all usecases for consumption by CLI scripts
+
+### 2. Briefing Usecases
+
+#### Individual Stage Usecases
+Extract business logic from [`src/scripts/runBriefing.ts`](src/scripts/runBriefing.ts):
+
+- **ScrapeArticlesUseCase**: Lines 62-68
+  - Input: `{ feedProfile: FeedProfile, feedUrls: string[] }`
+  - Output: `{ newArticles: number, errors: number }`
+  - Depends on: ScraperService
+
+- **ProcessArticlesUseCase**: Lines 70-74
+  - Input: `{ feedProfile: FeedProfile }`
+  - Output: `{ articlesProcessed: number, errors: number }`
+  - Depends on: ProcessorService
+
+- **RateArticlesUseCase**: Lines 77-82
+  - Input: `{ feedProfile: FeedProfile }`
+  - Output: `{ articlesRated: number, errors: number }`
+  - Depends on: ProcessorService
+
+- **CategorizeArticlesUseCase**: Lines 84-89
+  - Input: `{ feedProfile: FeedProfile }`
+  - Output: `{ articlesCategorized: number, errors: number }`
+  - Depends on: ProcessorService
+
+- **GenerateBriefUseCase**: Lines 91-106
+  - Input: `{ feedProfile: FeedProfile }`
+  - Output: `{ success: boolean, briefingId?: string, stats?: {...}, error?: string }`
+  - Depends on: BriefingService
+
+- **GenerateSimpleBriefUseCase**: Lines 177-187
+  - Input: `{ feedProfile: FeedProfile }`
+  - Output: `{ success: boolean, briefingId?: string, error?: string }`
+  - Depends on: BriefingService
+
+#### Orchestrator Usecase
+- **RunBriefingUseCase**: Lines 41-115 (runAll function)
+  - Orchestrates all stages in sequence
+  - Input: `{ feedProfile: FeedProfile }`
+  - Output: Combined statistics from all stages
+  - Depends on: All individual briefing usecases + ProfilesService
+
+### 3. YouTube Transcription Usecases
+
+#### ExtractYoutubeTranscriptsUseCase
+From [`src/scripts/runYoutubeTranscripts.ts`](src/scripts/runYoutubeTranscripts.ts) lines 20-73:
+- Input: `{ channels: ChannelConfig[] }`
+- Output: `{ success: boolean, channelsProcessed: number }`
+- Depends on: YoutubeTranscriptionsService, ConfigService
+- Logic: Filter enabled channels and call extractAll
+
+#### ProcessTranscriptionFilesUseCase
+From [`src/scripts/runProcessTranscriptions.ts`](src/scripts/runProcessTranscriptions.ts) lines 31-157:
+- Input: `{ transcriptsDir?: string }` (defaults to ./transcripts)
+- Output: `{ totalFiles: number, processed: number, skipped: number, errors: number, errorDetails: Array<...> }`
+- Depends on: YoutubeTranscriptionsService, ConfigService
+- Logic: Read JSON files, validate channels, process each file
+
+#### ListTranscriptionsUseCase
+From [`src/scripts/runListTranscriptions.ts`](src/scripts/runListTranscriptions.ts) lines 17-90:
+- Input: None (or optional filters in the future)
+- Output: `{ transcriptions: YoutubeTranscription[], statistics: { total: number, withSummary: number, channelCounts: Record<string, number> } }`
+- Depends on: YoutubeTranscriptionsService
+- Logic: Get all transcriptions and compute statistics
+
+### 4. Refactor CLI Scripts
+
+Update all 4 scripts to be thin wrappers:
+1. Parse command line arguments
+2. Initialize NestJS context
+3. Get usecase from DI container
+4. Execute usecase with input DTO
+5. Format and display output
+6. Handle errors
+
+Example pattern for [`src/scripts/runBriefing.ts`](src/scripts/runBriefing.ts):
+```typescript
+// Parse with Commander (keep existing)
+const options = program.opts();
+
+// Initialize
+const app = await NestFactory.createApplicationContext(AppModule);
+const runBriefingUseCase = app.get(RunBriefingUseCase);
+const scrapeUseCase = app.get(ScrapeArticlesUseCase);
+// ... etc
+
+// Execute based on flags
+if (options.scrape) {
+  const result = await scrapeUseCase.execute({ feedProfile, feedUrls });
+  console.log(`Scraping completed. New articles: ${result.newArticles}`);
+}
+```
+
+### 5. Update AppModule
+
+Import UsecasesModule into [`src/app.module.ts`](src/app.module.ts):
+```typescript
+@Module({
+  imports: [
+    // ... existing modules
+    UsecasesModule,
+  ],
+})
+```
+
+## DTO Pattern
+
+Each usecase will have:
+- **Input DTO**: Defines required parameters (use class-validator decorators)
+- **Output DTO**: Defines return structure (typed interface or class)
+
+Example:
+```typescript
+// scrape-articles.dto.ts
+export class ScrapeArticlesInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+  
+  @IsArray()
+  @IsString({ each: true })
+  feedUrls: string[];
+}
+
+export interface ScrapeArticlesOutputDto {
+  newArticles: number;
+  errors: number;
+}
+```
+
+## Benefits
+
+1. **Decoupling**: Business logic separated from CLI concerns
+2. **Reusability**: Usecases can be called from HTTP controllers, queues, or other scripts
+3. **Testability**: Easy to unit test usecases without dealing with CLI parsing
+4. **Type Safety**: Input/output DTOs provide clear contracts
+5. **Composability**: Orchestrator usecases can combine individual usecases
+6. **Maintainability**: Single responsibility - each usecase does one thing well
+
+## Testing Strategy
+
+Each usecase should have a corresponding `.spec.ts` file:
+- Mock service dependencies
+- Test various input scenarios
+- Verify output DTOs
+- Test error handling
+
+## Notes
+
+- Keep CLI scripts for backward compatibility with existing npm scripts in [`package.json`](package.json)
+- Usecases are also useful if you want to expose these operations via HTTP API later
+- Consider adding validation pipes to usecases if input validation is needed

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { ProfilesModule } from './profiles/profiles.module';
 import { QueueModule } from './queue/queue.module';
 import { ScraperModule } from './scraper/scraper.module';
 import { TechModule } from './tech/tech.module';
+import { UsecasesModule } from './usecases/usecases.module';
 import { YoutubeTranscriptionsModule } from './youtube-transcriptions/youtube-transcriptions.module';
 
 @Module({
@@ -28,6 +29,7 @@ import { YoutubeTranscriptionsModule } from './youtube-transcriptions/youtube-tr
     TechModule,
     YoutubeTranscriptionsModule,
     QueueModule,
+    UsecasesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/scripts/runBriefing.ts
+++ b/src/scripts/runBriefing.ts
@@ -114,16 +114,18 @@ async function main(): Promise<void> {
           `Simple brief generated successfully. ID: ${result.briefingId}`,
         );
       } else {
-        console.error(`Simple brief generation failed: ${result.error}`);
+        console.error(`Simple brief generation failed: ${result.error || 'Unknown error'}`);
       }
     } else if (shouldRunAll) {
       console.log(`\n>>> Running ALL stages for [${feedProfile}] <<<`);
-      const startTime = new Date();
 
       try {
-        const result = await services.runBriefingUseCase.execute({
-          feedProfile,
-        });
+        const result = await services.runBriefingUseCase.execute({ feedProfile });
+
+        if (!result.success || !result.stages) {
+          console.error(`Briefing run failed: ${result.error || 'Unknown error'}`);
+          process.exit(1);
+        }
 
         console.log(
           `\nScraping completed. New articles: ${result.stages.scraping.newArticles}, Errors: ${result.stages.scraping.errors}`,

--- a/src/scripts/runListTranscriptions.ts
+++ b/src/scripts/runListTranscriptions.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import * as dotenv from 'dotenv';
 
 import { AppModule } from '../app.module';
-import { YoutubeTranscriptionsService } from '../youtube-transcriptions/youtube-transcriptions.service';
+import { ListTranscriptionsUseCase } from '../usecases/youtube-transcriptions/list-transcriptions.usecase';
 
 dotenv.config();
 
@@ -10,7 +10,7 @@ async function initialize() {
   const app = await NestFactory.createApplicationContext(AppModule);
   return {
     app,
-    youtubeTranscriptionsService: app.get(YoutubeTranscriptionsService),
+    listTranscriptionsUseCase: app.get(ListTranscriptionsUseCase),
   };
 }
 
@@ -22,33 +22,42 @@ async function main() {
   try {
     const services = await initialize();
 
-    // Get all transcriptions from the database
-    const transcriptions =
-      await services.youtubeTranscriptionsService.getAllTranscriptions();
+    // Execute the usecase
+    const result = await services.listTranscriptionsUseCase.execute({});
 
-    if (transcriptions.length === 0) {
+    if (result.statistics.total === 0) {
       console.log('No transcriptions found in the database.');
       await services.app.close();
       return;
     }
 
-    console.log(`Found ${transcriptions.length} transcription(s)\n`);
+    console.log(`Found ${result.statistics.total} transcription(s)\n`);
     console.log(`========================================\n`);
 
     // Log each transcription with formatted details
-    transcriptions.forEach((transcription, index) => {
+    result.transcriptions.forEach((transcription, index) => {
       console.log(`\n${index + 1}. ID: ${transcription.id}`);
       console.log(`   Channel: ${transcription.channelName}`);
       console.log(`   Channel ID: ${transcription.channelId}`);
       console.log(`   Video Title: ${transcription.videoTitle}`);
       console.log(`   Video URL: ${transcription.videoUrl}`);
-      console.log(`   Posted At: ${transcription.postedAt?.toISOString() || 'N/A'}`);
-      console.log(`   Processed At: ${transcription.processedAt.toISOString()}`);
-      console.log(`   Transcription Length: ${transcription.transcriptionText?.length || 0} chars`);
-      console.log(`   Has Summary: ${transcription.transcriptionSummary ? 'Yes' : 'No'}`);
+      console.log(
+        `   Posted At: ${transcription.postedAt?.toISOString() || 'N/A'}`,
+      );
+      console.log(
+        `   Processed At: ${transcription.processedAt.toISOString()}`,
+      );
+      console.log(
+        `   Transcription Length: ${transcription.transcriptionText?.length || 0} chars`,
+      );
+      console.log(
+        `   Has Summary: ${transcription.transcriptionSummary ? 'Yes' : 'No'}`,
+      );
 
       if (transcription.transcriptionSummary) {
-        console.log(`   Summary Preview: ${transcription.transcriptionSummary.substring(0, 150)}...`);
+        console.log(
+          `   Summary Preview: ${transcription.transcriptionSummary.substring(0, 150)}...`,
+        );
       }
 
       console.log(`   ----------------------------------------`);
@@ -57,28 +66,16 @@ async function main() {
     console.log(`\n========================================`);
     console.log(`📊 Summary`);
     console.log(`========================================`);
-    console.log(`Total transcriptions: ${transcriptions.length}`);
-
-    const withSummary = transcriptions.filter(
-      (t) => t.transcriptionSummary,
-    ).length;
-    const withoutSummary = transcriptions.length - withSummary;
-
-    console.log(`With summary: ${withSummary}`);
-    console.log(`Without summary: ${withoutSummary}`);
-
-    const channelCounts = transcriptions.reduce(
-      (acc, t) => {
-        acc[t.channelName] = (acc[t.channelName] || 0) + 1;
-        return acc;
-      },
-      {} as Record<string, number>,
-    );
+    console.log(`Total transcriptions: ${result.statistics.total}`);
+    console.log(`With summary: ${result.statistics.withSummary}`);
+    console.log(`Without summary: ${result.statistics.withoutSummary}`);
 
     console.log(`\nTranscriptions by channel:`);
-    Object.entries(channelCounts).forEach(([channel, count]) => {
-      console.log(`  - ${channel}: ${count}`);
-    });
+    Object.entries(result.statistics.channelCounts).forEach(
+      ([channel, count]) => {
+        console.log(`  - ${channel}: ${count}`);
+      },
+    );
 
     console.log(`\n✓ Script finished - ${new Date().toISOString()}\n`);
 

--- a/src/usecases/briefing/categorize-articles.usecase.ts
+++ b/src/usecases/briefing/categorize-articles.usecase.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { ProcessorService } from '../../processor/processor.service';
+import {
+  CategorizeArticlesInputDto,
+  CategorizeArticlesOutputDto,
+} from './dto/categorize-articles.dto';
+
+@Injectable()
+export class CategorizeArticlesUseCase {
+  constructor(private readonly processorService: ProcessorService) { }
+
+  async execute(
+    input: CategorizeArticlesInputDto,
+  ): Promise<CategorizeArticlesOutputDto> {
+    const stats = await this.processorService.categorizeArticles(
+      input.feedProfile,
+    );
+
+    return {
+      articlesCategorized: stats.articlesCategorized,
+      errors: stats.errors,
+    };
+  }
+}

--- a/src/usecases/briefing/dto/categorize-articles.dto.ts
+++ b/src/usecases/briefing/dto/categorize-articles.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum } from 'class-validator';
+import { FeedProfile } from '../../../shared/types/feed';
+
+export class CategorizeArticlesInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+}
+
+export interface CategorizeArticlesOutputDto {
+  articlesCategorized: number;
+  errors: number;
+}

--- a/src/usecases/briefing/dto/generate-brief.dto.ts
+++ b/src/usecases/briefing/dto/generate-brief.dto.ts
@@ -1,0 +1,21 @@
+import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
+import { FeedProfile } from '../../../shared/types/feed';
+
+export class GenerateBriefInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+
+  @IsOptional()
+  @IsBoolean()
+  simple?: boolean;
+}
+
+export interface GenerateBriefOutputDto {
+  success: boolean;
+  briefingId?: number;
+  stats?: {
+    articlesAnalyzed: number;
+    clustersUsed: number;
+  };
+  error?: string;
+}

--- a/src/usecases/briefing/dto/process-articles.dto.ts
+++ b/src/usecases/briefing/dto/process-articles.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum } from 'class-validator';
+import { FeedProfile } from '../../../shared/types/feed';
+
+export class ProcessArticlesInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+}
+
+export interface ProcessArticlesOutputDto {
+  articlesProcessed: number;
+  errors: number;
+}

--- a/src/usecases/briefing/dto/rate-articles.dto.ts
+++ b/src/usecases/briefing/dto/rate-articles.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum } from 'class-validator';
+import { FeedProfile } from '../../../shared/types/feed';
+
+export class RateArticlesInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+}
+
+export interface RateArticlesOutputDto {
+  articlesRated: number;
+  errors: number;
+}

--- a/src/usecases/briefing/dto/run-briefing.dto.ts
+++ b/src/usecases/briefing/dto/run-briefing.dto.ts
@@ -1,0 +1,39 @@
+import { IsEnum } from 'class-validator';
+import { FeedProfile } from '../../../shared/types/feed';
+
+export class RunBriefingInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+}
+
+export interface RunBriefingOutputDto {
+  success: boolean;
+  duration: number;
+  stages: {
+    scraping: {
+      newArticles: number;
+      errors: number;
+    };
+    processing: {
+      articlesProcessed: number;
+      errors: number;
+    };
+    rating: {
+      articlesRated: number;
+      errors: number;
+    };
+    categorization: {
+      articlesCategorized: number;
+      errors: number;
+    };
+    briefGeneration: {
+      success: boolean;
+      briefingId?: number;
+      stats?: {
+        articlesAnalyzed: number;
+        clustersUsed: number;
+      };
+      error?: string;
+    };
+  };
+}

--- a/src/usecases/briefing/dto/run-briefing.dto.ts
+++ b/src/usecases/briefing/dto/run-briefing.dto.ts
@@ -9,7 +9,8 @@ export class RunBriefingInputDto {
 export interface RunBriefingOutputDto {
   success: boolean;
   duration: number;
-  stages: {
+  error?: string;
+  stages?: {
     scraping: {
       newArticles: number;
       errors: number;

--- a/src/usecases/briefing/dto/scrape-articles.dto.ts
+++ b/src/usecases/briefing/dto/scrape-articles.dto.ts
@@ -1,0 +1,16 @@
+import { IsArray, IsEnum, IsString } from 'class-validator';
+import { FeedProfile } from '../../../shared/types/feed';
+
+export class ScrapeArticlesInputDto {
+  @IsEnum(FeedProfile)
+  feedProfile: FeedProfile;
+
+  @IsArray()
+  @IsString({ each: true })
+  feedUrls: string[];
+}
+
+export interface ScrapeArticlesOutputDto {
+  newArticles: number;
+  errors: number;
+}

--- a/src/usecases/briefing/generate-brief.usecase.ts
+++ b/src/usecases/briefing/generate-brief.usecase.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { BriefingService } from '../../briefing/briefing.service';
+import {
+  GenerateBriefInputDto,
+  GenerateBriefOutputDto,
+} from './dto/generate-brief.dto';
+
+@Injectable()
+export class GenerateBriefUseCase {
+  constructor(private readonly briefingService: BriefingService) { }
+
+  async execute(
+    input: GenerateBriefInputDto,
+  ): Promise<GenerateBriefOutputDto> {
+    const result = await this.briefingService.generateBrief(input.feedProfile);
+
+    return {
+      success: result.success,
+      briefingId: result.briefingId,
+      stats: result.stats,
+      error: result.error,
+    };
+  }
+}

--- a/src/usecases/briefing/generate-simple-brief.usecase.ts
+++ b/src/usecases/briefing/generate-simple-brief.usecase.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { BriefingService } from '../../briefing/briefing.service';
+import {
+  GenerateBriefInputDto,
+  GenerateBriefOutputDto,
+} from './dto/generate-brief.dto';
+
+@Injectable()
+export class GenerateSimpleBriefUseCase {
+  constructor(private readonly briefingService: BriefingService) { }
+
+  async execute(
+    input: GenerateBriefInputDto,
+  ): Promise<GenerateBriefOutputDto> {
+    const result = await this.briefingService.generateSimpleBrief(
+      input.feedProfile,
+    );
+
+    return {
+      success: result.success,
+      briefingId: result.briefingId,
+      error: result.error,
+    };
+  }
+}

--- a/src/usecases/briefing/process-articles.usecase.ts
+++ b/src/usecases/briefing/process-articles.usecase.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { ProcessorService } from '../../processor/processor.service';
+import {
+  ProcessArticlesInputDto,
+  ProcessArticlesOutputDto,
+} from './dto/process-articles.dto';
+
+@Injectable()
+export class ProcessArticlesUseCase {
+  constructor(private readonly processorService: ProcessorService) { }
+
+  async execute(
+    input: ProcessArticlesInputDto,
+  ): Promise<ProcessArticlesOutputDto> {
+    const stats = await this.processorService.processArticles(
+      input.feedProfile,
+    );
+
+    return {
+      articlesProcessed: stats.articlesProcessed,
+      errors: stats.errors,
+    };
+  }
+}

--- a/src/usecases/briefing/rate-articles.usecase.ts
+++ b/src/usecases/briefing/rate-articles.usecase.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { ProcessorService } from '../../processor/processor.service';
+import {
+  RateArticlesInputDto,
+  RateArticlesOutputDto,
+} from './dto/rate-articles.dto';
+
+@Injectable()
+export class RateArticlesUseCase {
+  constructor(private readonly processorService: ProcessorService) { }
+
+  async execute(input: RateArticlesInputDto): Promise<RateArticlesOutputDto> {
+    const stats = await this.processorService.rateArticles(input.feedProfile);
+
+    return {
+      articlesRated: stats.articlesRated,
+      errors: stats.errors,
+    };
+  }
+}

--- a/src/usecases/briefing/run-briefing.usecase.ts
+++ b/src/usecases/briefing/run-briefing.usecase.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { ProfilesService } from '../../profiles/profiles.service';
+import { CategorizeArticlesUseCase } from './categorize-articles.usecase';
+import {
+  RunBriefingInputDto,
+  RunBriefingOutputDto,
+} from './dto/run-briefing.dto';
+import { GenerateBriefUseCase } from './generate-brief.usecase';
+import { ProcessArticlesUseCase } from './process-articles.usecase';
+import { RateArticlesUseCase } from './rate-articles.usecase';
+import { ScrapeArticlesUseCase } from './scrape-articles.usecase';
+
+@Injectable()
+export class RunBriefingUseCase {
+  constructor(
+    private readonly scrapeArticlesUseCase: ScrapeArticlesUseCase,
+    private readonly processArticlesUseCase: ProcessArticlesUseCase,
+    private readonly rateArticlesUseCase: RateArticlesUseCase,
+    private readonly categorizeArticlesUseCase: CategorizeArticlesUseCase,
+    private readonly generateBriefUseCase: GenerateBriefUseCase,
+    private readonly profilesService: ProfilesService,
+  ) { }
+
+  async execute(input: RunBriefingInputDto): Promise<RunBriefingOutputDto> {
+    const startTime = new Date();
+
+    // Get enabled feeds for the profile
+    const enabledFeeds = this.profilesService.getEnabledFeedsForProfile(
+      input.feedProfile,
+    );
+
+    if (enabledFeeds.length === 0) {
+      throw new Error(
+        `No enabled feeds found for profile '${input.feedProfile}'.`,
+      );
+    }
+
+    const feedUrls = enabledFeeds.map((f) => f.url);
+
+    // Stage 1: Scraping
+    const scrapingStats = await this.scrapeArticlesUseCase.execute({
+      feedProfile: input.feedProfile,
+      feedUrls,
+    });
+
+    // Stage 2: Processing
+    const processingStats = await this.processArticlesUseCase.execute({
+      feedProfile: input.feedProfile,
+    });
+
+    // Stage 3: Rating
+    const ratingStats = await this.rateArticlesUseCase.execute({
+      feedProfile: input.feedProfile,
+    });
+
+    // Stage 4: Categorization
+    const categorizationStats = await this.categorizeArticlesUseCase.execute({
+      feedProfile: input.feedProfile,
+    });
+
+    // Stage 5: Brief Generation
+    const briefResult = await this.generateBriefUseCase.execute({
+      feedProfile: input.feedProfile,
+    });
+
+    const endTime = new Date();
+    const duration = (endTime.getTime() - startTime.getTime()) / 1000;
+
+    return {
+      success: briefResult.success,
+      duration,
+      stages: {
+        scraping: scrapingStats,
+        processing: processingStats,
+        rating: ratingStats,
+        categorization: categorizationStats,
+        briefGeneration: briefResult,
+      },
+    };
+  }
+}

--- a/src/usecases/briefing/run-briefing.usecase.ts
+++ b/src/usecases/briefing/run-briefing.usecase.ts
@@ -30,9 +30,13 @@ export class RunBriefingUseCase {
     );
 
     if (enabledFeeds.length === 0) {
-      throw new Error(
-        `No enabled feeds found for profile '${input.feedProfile}'.`,
-      );
+      console.log(`No enabled feeds found for profile '${input.feedProfile}'.`);
+
+      return {
+        success: false,
+        duration: 0,
+        error: `No enabled feeds found for profile '${input.feedProfile}'.`
+      };
     }
 
     const feedUrls = enabledFeeds.map((f) => f.url);

--- a/src/usecases/briefing/scrape-articles.usecase.ts
+++ b/src/usecases/briefing/scrape-articles.usecase.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { ProfilesService } from '../../profiles/profiles.service';
+import { ScraperService } from '../../scraper/scraper.service';
+import {
+  ScrapeArticlesInputDto,
+  ScrapeArticlesOutputDto,
+} from './dto/scrape-articles.dto';
+
+@Injectable()
+export class ScrapeArticlesUseCase {
+  constructor(
+    private readonly scraperService: ScraperService,
+    private readonly profilesService: ProfilesService,
+  ) { }
+
+  async execute(
+    input: ScrapeArticlesInputDto,
+  ): Promise<ScrapeArticlesOutputDto> {
+    const stats = await this.scraperService.scrapeArticles(
+      input.feedProfile,
+      input.feedUrls,
+    );
+
+    return {
+      newArticles: stats.newArticles,
+      errors: stats.errors,
+    };
+  }
+}

--- a/src/usecases/usecases.module.ts
+++ b/src/usecases/usecases.module.ts
@@ -1,0 +1,57 @@
+import { Module } from '@nestjs/common';
+import { BriefingModule } from '../briefing/briefing.module';
+import { ConfigModule } from '../config/config.module';
+import { ProcessorModule } from '../processor/processor.module';
+import { ProfilesModule } from '../profiles/profiles.module';
+import { ScraperModule } from '../scraper/scraper.module';
+import { YoutubeTranscriptionsModule } from '../youtube-transcriptions/youtube-transcriptions.module';
+import { CategorizeArticlesUseCase } from './briefing/categorize-articles.usecase';
+import { GenerateBriefUseCase } from './briefing/generate-brief.usecase';
+import { GenerateSimpleBriefUseCase } from './briefing/generate-simple-brief.usecase';
+import { ProcessArticlesUseCase } from './briefing/process-articles.usecase';
+import { RateArticlesUseCase } from './briefing/rate-articles.usecase';
+import { RunBriefingUseCase } from './briefing/run-briefing.usecase';
+import { ScrapeArticlesUseCase } from './briefing/scrape-articles.usecase';
+import { ExtractYoutubeTranscriptsUseCase } from './youtube-transcriptions/extract-youtube-transcripts.usecase';
+import { ListTranscriptionsUseCase } from './youtube-transcriptions/list-transcriptions.usecase';
+import { ProcessTranscriptionFilesUseCase } from './youtube-transcriptions/process-transcription-files.usecase';
+
+@Module({
+  imports: [
+    ScraperModule,
+    ProcessorModule,
+    BriefingModule,
+    ProfilesModule,
+    YoutubeTranscriptionsModule,
+    ConfigModule,
+  ],
+  providers: [
+    // Briefing usecases
+    ScrapeArticlesUseCase,
+    ProcessArticlesUseCase,
+    RateArticlesUseCase,
+    CategorizeArticlesUseCase,
+    GenerateBriefUseCase,
+    GenerateSimpleBriefUseCase,
+    RunBriefingUseCase,
+    // YouTube transcription usecases
+    ExtractYoutubeTranscriptsUseCase,
+    ProcessTranscriptionFilesUseCase,
+    ListTranscriptionsUseCase,
+  ],
+  exports: [
+    // Briefing usecases
+    ScrapeArticlesUseCase,
+    ProcessArticlesUseCase,
+    RateArticlesUseCase,
+    CategorizeArticlesUseCase,
+    GenerateBriefUseCase,
+    GenerateSimpleBriefUseCase,
+    RunBriefingUseCase,
+    // YouTube transcription usecases
+    ExtractYoutubeTranscriptsUseCase,
+    ProcessTranscriptionFilesUseCase,
+    ListTranscriptionsUseCase,
+  ],
+})
+export class UsecasesModule { }

--- a/src/usecases/youtube-transcriptions/dto/extract-youtube-transcripts.dto.ts
+++ b/src/usecases/youtube-transcriptions/dto/extract-youtube-transcripts.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsNotEmpty, ValidateNested } from 'class-validator';
+import { ChannelConfig } from '../../../shared/types/channel';
+
+export class ExtractYoutubeTranscriptsInputDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Object)
+  @IsNotEmpty()
+  channels: ChannelConfig[];
+}
+
+export interface ExtractYoutubeTranscriptsOutputDto {
+  success: boolean;
+  channelsProcessed: number;
+  message?: string;
+}

--- a/src/usecases/youtube-transcriptions/dto/list-transcriptions.dto.ts
+++ b/src/usecases/youtube-transcriptions/dto/list-transcriptions.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString } from 'class-validator';
+import { YoutubeTranscription } from '../../../youtube-transcriptions/entities/youtube-transcription.entity';
+
+export class ListTranscriptionsInputDto {
+  @IsOptional()
+  @IsString()
+  channelId?: string;
+
+  @IsOptional()
+  @IsString()
+  channelName?: string;
+}
+
+export interface ListTranscriptionsOutputDto {
+  transcriptions: YoutubeTranscription[];
+  statistics: {
+    total: number;
+    withSummary: number;
+    withoutSummary: number;
+    channelCounts: Record<string, number>;
+  };
+}

--- a/src/usecases/youtube-transcriptions/dto/process-transcription-files.dto.ts
+++ b/src/usecases/youtube-transcriptions/dto/process-transcription-files.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class ProcessTranscriptionFilesInputDto {
+  @IsOptional()
+  @IsString()
+  transcriptsDir?: string;
+}
+
+export interface ProcessTranscriptionFilesOutputDto {
+  totalFiles: number;
+  processed: number;
+  skipped: number;
+  errors: number;
+  errorDetails: Array<{ file: string; error: string }>;
+}

--- a/src/usecases/youtube-transcriptions/extract-youtube-transcripts.usecase.ts
+++ b/src/usecases/youtube-transcriptions/extract-youtube-transcripts.usecase.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { YoutubeTranscriptionsService } from '../../youtube-transcriptions/youtube-transcriptions.service';
+import {
+  ExtractYoutubeTranscriptsInputDto,
+  ExtractYoutubeTranscriptsOutputDto,
+} from './dto/extract-youtube-transcripts.dto';
+
+@Injectable()
+export class ExtractYoutubeTranscriptsUseCase {
+  constructor(
+    private readonly youtubeTranscriptionsService: YoutubeTranscriptionsService,
+  ) { }
+
+  async execute(
+    input: ExtractYoutubeTranscriptsInputDto,
+  ): Promise<ExtractYoutubeTranscriptsOutputDto> {
+    try {
+      await this.youtubeTranscriptionsService.extractAll(input.channels);
+
+      return {
+        success: true,
+        channelsProcessed: input.channels.length,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        channelsProcessed: 0,
+        message:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  }
+}

--- a/src/usecases/youtube-transcriptions/list-transcriptions.usecase.ts
+++ b/src/usecases/youtube-transcriptions/list-transcriptions.usecase.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { YoutubeTranscriptionsService } from '../../youtube-transcriptions/youtube-transcriptions.service';
+import {
+  ListTranscriptionsInputDto,
+  ListTranscriptionsOutputDto,
+} from './dto/list-transcriptions.dto';
+
+@Injectable()
+export class ListTranscriptionsUseCase {
+  constructor(
+    private readonly youtubeTranscriptionsService: YoutubeTranscriptionsService,
+  ) { }
+
+  async execute(
+    input: ListTranscriptionsInputDto,
+  ): Promise<ListTranscriptionsOutputDto> {
+    const transcriptions = await this.youtubeTranscriptionsService.getAllTranscriptions();
+
+    let filteredTranscriptions = transcriptions;
+
+    if (input.channelId) {
+      filteredTranscriptions = filteredTranscriptions.filter(
+        (t) => t.channelId === input.channelId,
+      );
+    }
+
+    if (input.channelName) {
+      filteredTranscriptions = filteredTranscriptions.filter(
+        (t) => t.channelName === input.channelName,
+      );
+    }
+
+    const withSummary = filteredTranscriptions.filter(
+      (t) => t.transcriptionSummary,
+    ).length;
+
+    const channelCounts = filteredTranscriptions.reduce(
+      (acc, t) => {
+        acc[t.channelName] = (acc[t.channelName] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    return {
+      transcriptions: filteredTranscriptions,
+      statistics: {
+        total: filteredTranscriptions.length,
+        withSummary,
+        withoutSummary: filteredTranscriptions.length - withSummary,
+        channelCounts,
+      },
+    };
+  }
+}

--- a/src/usecases/youtube-transcriptions/process-transcription-files.usecase.ts
+++ b/src/usecases/youtube-transcriptions/process-transcription-files.usecase.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { ConfigService } from '../../config/config.service';
+import { VideoWithTranscript } from '../../shared/types/video';
+import { YoutubeTranscriptionsService } from '../../youtube-transcriptions/youtube-transcriptions.service';
+import {
+  ProcessTranscriptionFilesInputDto,
+  ProcessTranscriptionFilesOutputDto,
+} from './dto/process-transcription-files.dto';
+
+@Injectable()
+export class ProcessTranscriptionFilesUseCase {
+  constructor(
+    private readonly youtubeTranscriptionsService: YoutubeTranscriptionsService,
+    private readonly configService: ConfigService,
+  ) { }
+
+  async execute(
+    input: ProcessTranscriptionFilesInputDto,
+  ): Promise<ProcessTranscriptionFilesOutputDto> {
+    const transcriptsDir = input.transcriptsDir || path.join(process.cwd(), 'transcripts');
+
+    const stats: ProcessTranscriptionFilesOutputDto = {
+      totalFiles: 0,
+      processed: 0,
+      skipped: 0,
+      errors: 0,
+      errorDetails: [],
+    };
+
+    try {
+      await fs.access(transcriptsDir);
+    } catch {
+      return stats;
+    }
+
+    const ytConfig = this.configService.getYoutubeChannelsConfig();
+    const files = await fs.readdir(transcriptsDir);
+    const jsonFiles = files.filter((file) => file.endsWith('.json') && !file.startsWith('.'));
+
+    stats.totalFiles = jsonFiles.length;
+
+    for (const filename of jsonFiles) {
+      try {
+        const filePath = path.join(transcriptsDir, filename);
+        const fileContent = await fs.readFile(filePath, 'utf-8');
+        const videoData: VideoWithTranscript = JSON.parse(fileContent);
+
+        if (!videoData.channel?.id) {
+          stats.skipped++;
+          continue;
+        }
+
+        const channelData = ytConfig.channels[videoData.channel.id];
+
+        if (!channelData || channelData.enabled === false) {
+          stats.skipped++;
+          continue;
+        }
+
+        const result = await this.youtubeTranscriptionsService.processTranscriptionFile(videoData);
+
+        if (result.success) {
+          stats.processed++;
+        } else {
+          stats.errors++;
+          stats.errorDetails.push({
+            file: filename,
+            error: result.error || 'Unknown error',
+          });
+        }
+      } catch (error) {
+        stats.errors++;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        stats.errorDetails.push({ file: filename, error: errorMessage });
+      }
+    }
+
+    return stats;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a dedicated usecases layer (briefing + YouTube with DTOs and orchestrator) and refactors all CLI scripts to execute these usecases via a new UsecasesModule wired into AppModule.
> 
> - **Backend**:
>   - **Usecases Layer**:
>     - Briefing: add DTOs and usecases `scrape-articles`, `process-articles`, `rate-articles`, `categorize-articles`, `generate-brief`, `generate-simple-brief`, and orchestrator `run-briefing`.
>     - YouTube: add DTOs and usecases `extract-youtube-transcripts`, `process-transcription-files`, `list-transcriptions` (with summary stats computation).
>     - Add `UsecasesModule` exporting all usecases; import it in `src/app.module.ts`.
> - **CLI**:
>   - Refactor `src/scripts/runBriefing.ts`, `runYoutubeTranscripts.ts`, `runProcessTranscriptions.ts`, `runListTranscriptions.ts` to resolve and execute usecases, standardizing outputs.
> - **Docs/Planning**:
>   - Add refactor plan `prompts/cli_usecases_refactor_7a4b8e8a.plan.md` and update `README.md` to mark the CLI usecase migration as done.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 010c00c6c876b86e4029be96849ecd28a3a35fb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->