### PR TITLE
refactor: remove useless comments

### DIFF
--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -42,7 +42,6 @@ export class ArticlesController {
         throw new BadRequestException('Article already exists in database');
       }
 
-      // Add job to queue for async processing
       const jobInfo = await this.queueService.addArticleProcessingJob(
         articleId,
         feedProfile,

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -11,7 +11,6 @@ export class DatabaseService extends AbstractDatabaseService {
     super();
 
     this.implementation = new PostgresDatabaseService();
-    console.log('Using PostgreSQL database');
   }
 
   async initDb(): Promise<void> {

--- a/src/database/migrations/1767142007136-AddUuidColumns.ts
+++ b/src/database/migrations/1767142007136-AddUuidColumns.ts
@@ -7,19 +7,16 @@ export class AddUuidColumns1767142007136 implements MigrationInterface {
     // Enable UUID extension if not already enabled
     await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
 
-    // Add id_uuid column to articles table
     await queryRunner.query(`
       ALTER TABLE articles
       ADD COLUMN id_uuid UUID DEFAULT gen_random_uuid()
     `);
 
-    // Add id_uuid column to briefings table
     await queryRunner.query(`
       ALTER TABLE briefings
       ADD COLUMN id_uuid UUID DEFAULT gen_random_uuid()
     `);
 
-    // Add id_uuid column to youtube_transcriptions table
     await queryRunner.query(`
       ALTER TABLE youtube_transcriptions
       ADD COLUMN id_uuid UUID DEFAULT gen_random_uuid()

--- a/src/database/migrations/1767142031931-PopulateUuidColumns.ts
+++ b/src/database/migrations/1767142031931-PopulateUuidColumns.ts
@@ -4,21 +4,18 @@ export class PopulateUuidColumns1767142031931 implements MigrationInterface {
   name = 'PopulateUuidColumns1767142031931';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Generate UUIDs for all existing records in articles table
     await queryRunner.query(`
       UPDATE articles
       SET id_uuid = gen_random_uuid()
       WHERE id_uuid IS NULL
     `);
 
-    // Generate UUIDs for all existing records in briefings table
     await queryRunner.query(`
       UPDATE briefings
       SET id_uuid = gen_random_uuid()
       WHERE id_uuid IS NULL
     `);
 
-    // Generate UUIDs for all existing records in youtube_transcriptions table
     await queryRunner.query(`
       UPDATE youtube_transcriptions
       SET id_uuid = gen_random_uuid()

--- a/src/database/migrations/1767142045058-MigrateBriefingArticleIds.ts
+++ b/src/database/migrations/1767142045058-MigrateBriefingArticleIds.ts
@@ -10,7 +10,6 @@ export class MigrateBriefingArticleIds1767142045058 implements MigrationInterfac
       ADD COLUMN article_ids_old TEXT
     `);
 
-    // Backup the old article_ids
     await queryRunner.query(`
       UPDATE briefings
       SET article_ids_old = article_ids
@@ -37,14 +36,12 @@ export class MigrateBriefingArticleIds1767142045058 implements MigrationInterfac
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    // Restore the old article_ids from backup
     await queryRunner.query(`
       UPDATE briefings
       SET article_ids = article_ids_old
       WHERE article_ids_old IS NOT NULL
     `);
 
-    // Drop the backup column
     await queryRunner.query(`
       ALTER TABLE briefings
       DROP COLUMN article_ids_old

--- a/src/database/migrations/1767142059182-ReplaceIdWithUuid.ts
+++ b/src/database/migrations/1767142059182-ReplaceIdWithUuid.ts
@@ -21,22 +21,18 @@ export class ReplaceIdWithUuid1767142059182 implements MigrationInterface {
     `);
 
     // ARTICLES TABLE
-    // Drop primary key constraint
     await queryRunner.query(`
       ALTER TABLE articles DROP CONSTRAINT articles_pkey
     `);
 
-    // Drop old id column
     await queryRunner.query(`
       ALTER TABLE articles DROP COLUMN id
     `);
 
-    // Rename id_uuid to id
     await queryRunner.query(`
       ALTER TABLE articles RENAME COLUMN id_uuid TO id
     `);
 
-    // Add primary key constraint on new id
     await queryRunner.query(`
       ALTER TABLE articles ADD PRIMARY KEY (id)
     `);
@@ -47,22 +43,18 @@ export class ReplaceIdWithUuid1767142059182 implements MigrationInterface {
     `);
 
     // BRIEFINGS TABLE
-    // Drop primary key constraint
     await queryRunner.query(`
       ALTER TABLE briefings DROP CONSTRAINT briefings_pkey
     `);
 
-    // Drop old id column
     await queryRunner.query(`
       ALTER TABLE briefings DROP COLUMN id
     `);
 
-    // Rename id_uuid to id
     await queryRunner.query(`
       ALTER TABLE briefings RENAME COLUMN id_uuid TO id
     `);
 
-    // Add primary key constraint on new id
     await queryRunner.query(`
       ALTER TABLE briefings ADD PRIMARY KEY (id)
     `);
@@ -78,22 +70,18 @@ export class ReplaceIdWithUuid1767142059182 implements MigrationInterface {
     `);
 
     // YOUTUBE_TRANSCRIPTIONS TABLE
-    // Drop primary key constraint
     await queryRunner.query(`
       ALTER TABLE youtube_transcriptions DROP CONSTRAINT youtube_transcriptions_pkey
     `);
 
-    // Drop old id column
     await queryRunner.query(`
       ALTER TABLE youtube_transcriptions DROP COLUMN id
     `);
 
-    // Rename id_uuid to id
     await queryRunner.query(`
       ALTER TABLE youtube_transcriptions RENAME COLUMN id_uuid TO id
     `);
 
-    // Add primary key constraint on new id
     await queryRunner.query(`
       ALTER TABLE youtube_transcriptions ADD PRIMARY KEY (id)
     `);
@@ -109,7 +97,6 @@ export class ReplaceIdWithUuid1767142059182 implements MigrationInterface {
     // It attempts to restore the old integer IDs from backup tables
 
     // ARTICLES TABLE
-    // Rename id back to id_uuid
     await queryRunner.query(`
       ALTER TABLE articles DROP CONSTRAINT articles_pkey
     `);
@@ -118,7 +105,6 @@ export class ReplaceIdWithUuid1767142059182 implements MigrationInterface {
       ALTER TABLE articles RENAME COLUMN id TO id_uuid
     `);
 
-    // Restore old id column from backup
     await queryRunner.query(`
       ALTER TABLE articles ADD COLUMN id SERIAL
     `);

--- a/src/database/migrations/1767438278000-CreateYoutubeChannelsTable.ts
+++ b/src/database/migrations/1767438278000-CreateYoutubeChannelsTable.ts
@@ -4,7 +4,6 @@ export class CreateYoutubeChannelsTable1767438278000 implements MigrationInterfa
   name = 'CreateYoutubeChannelsTable1767438278000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // Create youtube_channels table
     await queryRunner.query(`
       CREATE TABLE IF NOT EXISTS youtube_channels (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/src/database/typeorm.config.ts
+++ b/src/database/typeorm.config.ts
@@ -11,11 +11,6 @@ const dbHost = process.env.DATABASE_HOST || 'localhost';
 const dbPort = process.env.DATABASE_PORT || '5432';
 const dbName = process.env.DATABASE_NAME || 'meridian';
 
-console.log(`[TypeORM] Environment check:`);
-console.log(`  DATABASE_HOST from env: ${process.env.DATABASE_HOST || 'NOT SET'}`);
-console.log(`  DATABASE_PORT from env: ${process.env.DATABASE_PORT || 'NOT SET'}`);
-console.log(`  DATABASE_USER from env: ${process.env.DATABASE_USER || 'NOT SET'}`);
-console.log(`  DATABASE_NAME from env: ${process.env.DATABASE_NAME || 'NOT SET'}`);
 console.log(`  Connecting to database at ${dbHost}:${dbPort}/${dbName} (user: ${dbUser})`);
 
 // URL-encode username and password to handle special characters
@@ -41,4 +36,3 @@ export const typeormConfig: DataSourceOptions = {
 const dataSource = new DataSource(typeormConfig);
 
 export default dataSource;
-

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -78,9 +78,6 @@ export class ProcessorService {
         }
 
         const finalSummary = `${summary}\n\nSource: [${article.title}](${article.url})`;
-        // console.log(
-        //   `Article summary generated: ${article.title}...`,
-        // );
 
         const embedding = await this.aiService.getEmbedding(finalSummary);
 
@@ -118,8 +115,6 @@ export class ProcessorService {
     limit: number = 1000,
     articleId?: string,
   ): Promise<ProcessingStats> {
-    // console.log('\n--- Starting Article Impact Rating ---');
-
     const stats: ProcessingStats = {
       feedProfile,
       articlesProcessed: 0,
@@ -182,7 +177,6 @@ export class ProcessorService {
                   score,
                 );
                 stats.articlesRated++;
-                // console.log(`  Article ID ${article.id} rated as: ${score}`);
               } else {
                 console.log(
                   `  Warning: Rating ${score} for article ${article.id} is out of range (1-10).`,
@@ -229,8 +223,6 @@ export class ProcessorService {
     limit: number = 1000,
     articleId?: string,
   ): Promise<ProcessingStats> {
-    // console.log('\n--- Starting Article Categorization ---');
-
     const stats: ProcessingStats = {
       feedProfile,
       articlesProcessed: 0,
@@ -261,10 +253,6 @@ export class ProcessorService {
     );
 
     for (const article of uncategorizedArticles) {
-      // console.log(
-      //   `Categorizing article ID: ${article.id}: ${article.title}...`,
-      // );
-
       if (!article.processed_content) {
         console.log(
           `  Skipping article ${article.id} - no processed content found.`,
@@ -299,9 +287,6 @@ export class ProcessorService {
                   validCategories,
                 );
                 stats.articlesCategorized++;
-                // console.log(
-                //   `  Article ID ${article.id} categorized as: ${validCategories.join(', ')}`,
-                // );
               } else {
                 console.log(
                   `  Warning: No valid categories found in response for article ${article.id}.`,

--- a/src/queue/processors/youtube-transcription.processor.ts
+++ b/src/queue/processors/youtube-transcription.processor.ts
@@ -70,7 +70,6 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
         };
       }
 
-      // Update the transcription with the generated summary
       console.log(`Updating transcription ${transcriptionId} with summary...`);
       await this.youtubeTranscriptionsService.updateTranscriptionSummary(
         transcriptionId,

--- a/src/queue/redis.service.ts
+++ b/src/queue/redis.service.ts
@@ -12,10 +12,6 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     const redisPort = parseInt(process.env.REDIS_PORT || '6379', 10);
     const redisPassword = process.env.REDIS_PASSWORD || undefined;
 
-    console.log(`[RedisService] Constructor - Environment check:`);
-    console.log(`  REDIS_HOST from env: ${process.env.REDIS_HOST || 'NOT SET (will default to localhost)'}`);
-    console.log(`  REDIS_PORT from env: ${process.env.REDIS_PORT || 'NOT SET (will default to 6379)'}`);
-    console.log(`  REDIS_PASSWORD from env: ${process.env.REDIS_PASSWORD ? 'SET' : 'NOT SET'}`);
     console.log(`[RedisService] Initializing Redis client - Connecting to ${redisHost}:${redisPort}`);
 
     this.client = new Redis({

--- a/src/scraper/scraper.service.ts
+++ b/src/scraper/scraper.service.ts
@@ -153,13 +153,11 @@ export class ScraperService {
   ): Promise<string | null> {
     // console.log(`\n--- Scraping single article: ${url} ---`);
 
-    // Check if article already exists
     if (await this.articlesService.articleExists(url)) {
       console.log('Article already exists in database');
       return null;
     }
 
-    // Fetch article content and OG image
     console.log('Fetching article content and OG image...');
     const { content: rawContent, ogImage: ogImageUrl } =
       await this.fetchArticleContentAndOgImage(url);
@@ -168,7 +166,6 @@ export class ScraperService {
       throw new Error('Failed to extract article content');
     }
 
-    // Extract title from HTML
     let title = 'Untitled Article';
     try {
       const response = await axios.get(url, {

--- a/src/scripts/migrateSqliteToPostgres.ts
+++ b/src/scripts/migrateSqliteToPostgres.ts
@@ -214,7 +214,6 @@ class MigrationService {
               ? new Date(briefing.created_at).toISOString()
               : new Date().toISOString();
 
-            // Check if this exact briefing already exists
             // Since there's no unique constraint, we check by content + feed_profile + created_at
             const existingResult = await client.query(
               `

--- a/src/scripts/runListTranscriptions.ts
+++ b/src/scripts/runListTranscriptions.ts
@@ -22,7 +22,6 @@ async function main() {
   try {
     const services = await initialize();
 
-    // Execute the usecase
     const result = await services.listTranscriptionsUseCase.execute({});
 
     if (result.statistics.total === 0) {

--- a/src/scripts/runProcessTranscriptions.ts
+++ b/src/scripts/runProcessTranscriptions.ts
@@ -25,7 +25,6 @@ async function main() {
   try {
     const services = await initialize();
 
-    // Execute the usecase
     const stats = await services.processTranscriptionFilesUseCase.execute({});
 
     if (stats.totalFiles === 0) {

--- a/src/scripts/runYoutubeTranscripts.ts
+++ b/src/scripts/runYoutubeTranscripts.ts
@@ -26,7 +26,6 @@ async function main() {
     const services = await initialize();
     const enabledChannels = await services.youtubeChannelsService.getEnabledChannels();
 
-    // Convert database channels to ChannelConfig array
     const channels: ChannelConfig[] = enabledChannels.map((channel) => ({
       channelId: channel.channelId,
       channelName: channel.name,
@@ -55,7 +54,6 @@ async function main() {
 
     console.log();
 
-    // Extract transcripts using the usecase
     const result = await services.extractYoutubeTranscriptsUseCase.execute({
       channels,
     });

--- a/src/usecases/briefing/run-briefing.usecase.ts
+++ b/src/usecases/briefing/run-briefing.usecase.ts
@@ -24,7 +24,6 @@ export class RunBriefingUseCase {
   async execute(input: RunBriefingInputDto): Promise<RunBriefingOutputDto> {
     const startTime = new Date();
 
-    // Get enabled feeds for the profile
     const enabledFeeds = this.profilesService.getEnabledFeedsForProfile(
       input.feedProfile,
     );

--- a/src/youtube-transcriptions/commands/create-youtube-transcription.command.ts
+++ b/src/youtube-transcriptions/commands/create-youtube-transcription.command.ts
@@ -42,7 +42,6 @@ export class CreateYoutubeTranscriptionCommand {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error occurred';
 
-      // Handle specific error cases
       if (errorMessage.includes('not found in configuration')) {
         throw new NotFoundException('Channel not found in configuration');
       }

--- a/src/youtube-transcriptions/transcript.service.ts
+++ b/src/youtube-transcriptions/transcript.service.ts
@@ -6,11 +6,8 @@ import { TranscriptItem } from '../shared/types/video';
 export class TranscriptService {
   private youtube: Innertube | null = null;
 
-  constructor() {}
+  constructor() { }
 
-  /**
-   * Initialize the YouTube client
-   */
   private async initialize() {
     if (!this.youtube) {
       this.youtube = await Innertube.create();
@@ -32,10 +29,7 @@ export class TranscriptService {
         throw new Error('Failed to initialize YouTube client');
       }
 
-      // Get video info which includes transcript data
       const info = await this.youtube.getInfo(videoId);
-
-      // Get the transcript
       const transcriptData = await info.getTranscript();
 
       if (

--- a/src/youtube-transcriptions/youtube-transcriptions-innertube.service.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions-innertube.service.ts
@@ -54,7 +54,6 @@ const fetchTimedTextXml = async (
       timeout: 10000,
     };
 
-    // Add proxy if provided
     if (proxyUrl) {
       const proxyMatch = proxyUrl.match(/^(https?):\/\/([^:]+):(\d+)$/);
       if (proxyMatch) {

--- a/src/youtube-transcriptions/youtube-transcriptions.service.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.service.ts
@@ -218,7 +218,6 @@ export class YoutubeTranscriptionsService {
       console.log(`\n========================================`);
       console.log(`Processing single video: ${videoUrl}`);
 
-      // Get channel from database
       const channelConfig = await this.youtubeChannelsService.getChannelById(channelId);
 
       if (!channelConfig) {
@@ -229,7 +228,6 @@ export class YoutubeTranscriptionsService {
         throw new Error(`Channel ${channelId} is disabled`);
       }
 
-      // Extract video ID from URL
       const { extractVideoId } = await import('./helpers/extract-video-id.js');
       const videoId = extractVideoId(videoUrl);
 
@@ -237,7 +235,6 @@ export class YoutubeTranscriptionsService {
         throw new Error('Invalid YouTube URL or unable to extract video ID');
       }
 
-      // Get video metadata
       const videoMetadata = await this.youtubeService.getVideoMetadata(
         videoId,
         channelId,
@@ -308,7 +305,6 @@ export class YoutubeTranscriptionsService {
         return null;
       }
 
-      // Enqueue summary generation job
       console.log(`Enqueueing summary generation for transcription ID ${transcriptionId}...`);
       await this.queueService.addTranscriptionSummaryJob(
         transcriptionId,
@@ -501,7 +497,6 @@ export class YoutubeTranscriptionsService {
         };
       }
 
-      // Enqueue summary generation job
       console.log(`  Enqueueing summary generation for transcription ID ${insertedId}...`);
       await this.queueService.addTranscriptionSummaryJob(
         insertedId,

--- a/src/youtube-transcriptions/youtube.service.ts
+++ b/src/youtube-transcriptions/youtube.service.ts
@@ -11,9 +11,6 @@ export class YouTubeService {
 
   constructor() { }
 
-  /**
-   * Initialize the YouTube client
-   */
   private async initialize() {
     if (!this.youtube) {
       this.youtube = await Innertube.create();


### PR DESCRIPTION
Removed useless comments that only restated the code. Kept comments that add context (e.g., "Save transcription to database first without summary" explains why it's saved without a summary).