### PR TITLE
feat: add AWS CDK infrastructure for S3 buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 # compiled output
 /dist
 /node_modules
+/infrastructure/node_modules
 /build
+
+# CDK
+**/cdk.out
 
 # Logs
 logs

--- a/infrastructure/.env.sample
+++ b/infrastructure/.env.sample
@@ -1,0 +1,2 @@
+AWS_REGION=aws_region
+S3_ARTICLES_BUCKET_NAME=bucket_name

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,314 @@
+# Meridiano Infrastructure (AWS CDK)
+
+This directory contains AWS CDK infrastructure code for the Meridiano API project. It manages S3 buckets for storing markdown articles with environment-specific configurations.
+
+## Prerequisites
+
+Before deploying, ensure you have the following installed and configured:
+
+### Required Software
+
+1. **Node.js** (v20 or higher)
+   ```bash
+   node --version
+   ```
+
+2. **pnpm** (package manager)
+   ```bash
+   npm install -g pnpm
+   ```
+
+3. **AWS CLI** (configured with credentials)
+   ```bash
+   aws --version
+   aws configure
+   ```
+
+4. **AWS CDK CLI**
+   ```bash
+   npm install -g aws-cdk
+   cdk --version
+   ```
+
+### AWS Credentials
+
+Configure your AWS credentials using one of these methods:
+
+**Option 1: AWS CLI Configuration**
+```bash
+aws configure
+```
+
+**Option 2: Environment Variables**
+```bash
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-key
+export AWS_REGION=us-east-1
+```
+
+**Option 3: AWS Profile**
+```bash
+export AWS_PROFILE=your-profile-name
+```
+
+### Required AWS Permissions
+
+Your AWS user/role needs permissions to:
+- Create and manage S3 buckets
+- Create and manage IAM policies
+- Create and manage CloudFormation stacks
+
+## Installation
+
+Install dependencies in the infrastructure directory:
+
+```bash
+cd infrastructure
+pnpm install
+```
+
+## Deployment
+
+### Deploy to Development
+
+```bash
+pnpm run deploy:dev
+```
+
+Or manually:
+```bash
+bash scripts/deploy-dev.sh
+```
+
+### Deploy to Staging
+
+```bash
+pnpm run deploy:stg
+```
+
+Or manually:
+```bash
+bash scripts/deploy-stg.sh
+```
+
+### Deploy to Production
+
+```bash
+pnpm run deploy:prod
+```
+
+Or manually:
+```bash
+bash scripts/deploy-prod.sh
+```
+
+**Note:** Production deployment requires confirmation prompt.
+
+## Stack Outputs
+
+After deployment, the stack outputs the following:
+
+- **BucketName**: S3 bucket name (e.g., `meridiano-api-articles-dev`)
+- **BucketArn**: S3 bucket ARN
+- **ReadPolicyArn**: IAM policy ARN for read access to the bucket
+
+### View Stack Outputs
+
+```bash
+# For dev environment
+aws cloudformation describe-stacks \
+  --stack-name MeridianoS3Stack-dev \
+  --query 'Stacks[0].Outputs'
+
+# For stg environment
+aws cloudformation describe-stacks \
+  --stack-name MeridianoS3Stack-stg \
+  --query 'Stacks[0].Outputs'
+
+# For prod environment
+aws cloudformation describe-stacks \
+  --stack-name MeridianoS3Stack-prod \
+  --query 'Stacks[0].Outputs'
+```
+
+## S3 Bucket Configuration
+
+Each environment has its own S3 bucket with the following configuration:
+
+### Bucket Naming Convention
+- Development: `meridiano-api-articles-dev`
+- Staging: `meridiano-api-articles-stg`
+- Production: `meridiano-api-articles-prod`
+
+### Bucket Features
+- **Versioning**: Enabled
+- **Encryption**: SSE-S3 (Server-Side Encryption with S3-Managed Keys)
+- **Public Access**: Blocked (all public access is disabled)
+- **Lifecycle Policy**: Deletes non-current versions after 90 days
+- **Removal Policy**: RETAIN (bucket is not deleted when stack is destroyed)
+
+## IAM Policy
+
+The stack creates a managed IAM policy that grants read access to the S3 bucket:
+
+- Policy Name: `meridiano-articles-read-{env}`
+- Permissions:
+  - `s3:GetObject` - Read objects from bucket
+  - `s3:ListBucket` - List objects in bucket
+
+### Attach Policy to EC2 Instance/ECS Task Role
+
+If running the NestJS application on EC2 or ECS, attach the policy to the IAM role:
+
+```bash
+# Get the policy ARN from stack outputs
+POLICY_ARN=$(aws cloudformation describe-stacks \
+  --stack-name MeridianoS3Stack-dev \
+  --query 'Stacks[0].Outputs[?OutputKey==`ReadPolicyArn`].OutputValue' \
+  --output text)
+
+# Attach to IAM role
+aws iam attach-role-policy \
+  --role-name your-role-name \
+  --policy-arn $POLICY_ARN
+```
+
+### Use Policy with IAM User
+
+For local development or CI/CD, attach the policy to an IAM user:
+
+```bash
+POLICY_ARN=$(aws cloudformation describe-stacks \
+  --stack-name MeridianoS3Stack-dev \
+  --query 'Stacks[0].Outputs[?OutputKey==`ReadPolicyArn`].OutputValue' \
+  --output text)
+
+aws iam attach-user-policy \
+  --user-name your-username \
+  --policy-arn $POLICY_ARN
+```
+
+## Configure NestJS Application
+
+After deployment, configure the NestJS application with the bucket name:
+
+### Environment Variables
+
+Add to your `.env` file:
+
+```env
+AWS_REGION=us-east-1
+S3_ARTICLES_BUCKET_NAME=meridiano-api-articles-dev
+```
+
+For production:
+```env
+AWS_REGION=us-east-1
+S3_ARTICLES_BUCKET_NAME=meridiano-api-articles-prod
+```
+
+### Get Bucket Name from Stack
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name MeridianoS3Stack-dev \
+  --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' \
+  --output text
+```
+
+## Other CDK Commands
+
+### Synthesize CloudFormation Template
+
+```bash
+cd infrastructure
+npx cdk synth --context environment=dev
+```
+
+### View Differences Before Deployment
+
+```bash
+npx cdk diff --context environment=dev
+```
+
+### Destroy Stack
+
+**Warning:** This will destroy the CloudFormation stack but NOT the S3 bucket (due to RETAIN policy).
+
+```bash
+npx cdk destroy --context environment=dev
+```
+
+To also delete the bucket, manually delete it from AWS Console or CLI:
+```bash
+# Empty the bucket first
+aws s3 rm s3://meridiano-api-articles-dev --recursive
+
+# Delete the bucket
+aws s3 rb s3://meridiano-api-articles-dev
+```
+
+## Troubleshooting
+
+### CDK Bootstrap Required
+
+If you see an error about CDK bootstrap, run:
+
+```bash
+cdk bootstrap aws://ACCOUNT-ID/REGION
+```
+
+### Permission Denied on Scripts
+
+Make scripts executable:
+
+```bash
+chmod +x scripts/*.sh
+```
+
+### Invalid Environment Error
+
+Ensure you're using one of the valid environments: `dev`, `stg`, or `prod`.
+
+### AWS Credentials Not Found
+
+Verify your AWS credentials are configured:
+
+```bash
+aws sts get-caller-identity
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────┐
+│   CloudFormation Stack                  │
+│   MeridianoS3Stack-{env}                │
+│                                         │
+│  ┌───────────────────────────────────┐  │
+│  │  S3 Bucket                        │  │
+│  │  meridiano-api-articles-{env}     │  │
+│  │                                   │  │
+│  │  - Versioning: Enabled            │  │
+│  │  - Encryption: SSE-S3             │  │
+│  │  - Public Access: Blocked         │  │
+│  └───────────────────────────────────┘  │
+│                                         │
+│  ┌───────────────────────────────────┐  │
+│  │  IAM Managed Policy               │  │
+│  │  meridiano-articles-read-{env}    │  │
+│  │                                   │  │
+│  │  Permissions:                     │  │
+│  │  - s3:GetObject                   │  │
+│  │  - s3:ListBucket                  │  │
+│  └───────────────────────────────────┘  │
+└─────────────────────────────────────────┘
+```
+
+## Support
+
+For issues or questions:
+- Check AWS CloudFormation console for stack events
+- Review CloudWatch logs
+- Verify IAM permissions
+- Ensure AWS credentials are valid

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import 'source-map-support/register';
+import { S3Stack } from '../lib/s3-stack';
+
+const app = new cdk.App();
+
+const environment = app.node.tryGetContext('environment') || process.env.NODE_ENV || 'dev';
+
+const validEnvironments = ['dev', 'stg', 'prod'];
+if (!validEnvironments.includes(environment)) {
+  throw new Error(
+    `Invalid environment: ${environment}. Must be one of: ${validEnvironments.join(', ')}`
+  );
+}
+
+console.log(`Deploying to environment: ${environment}`);
+
+new S3Stack(app, `MeridianoS3Stack-${environment}`, {
+  environment,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION || process.env.AWS_REGION || 'us-east-1',
+  },
+  description: `Meridiano Articles S3 bucket for ${environment} environment`,
+  tags: {
+    Environment: environment,
+    Project: 'Meridiano',
+    ManagedBy: 'CDK',
+  },
+});
+
+app.synth();

--- a/infrastructure/cdk.context.json
+++ b/infrastructure/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    34892
+  ]
+}

--- a/infrastructure/cdk.json
+++ b/infrastructure/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "requireApproval": "never",
+  "context": {
+    "aws-cdk:enableDiffNoFail": true,
+    "@aws-cdk/core:stackRelativeExports": true
+  }
+}

--- a/infrastructure/lib/s3-stack.ts
+++ b/infrastructure/lib/s3-stack.ts
@@ -1,0 +1,72 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+
+interface S3StackProps extends cdk.StackProps {
+  environment: string;
+}
+
+export class S3Stack extends cdk.Stack {
+  public readonly bucket: s3.Bucket;
+
+  constructor(scope: Construct, id: string, props: S3StackProps) {
+    super(scope, id, props);
+
+    const { environment } = props;
+
+    const bucketName = `meridiano-api-articles-${environment}`;
+
+    this.bucket = new s3.Bucket(this, 'ArticlesBucket', {
+      bucketName,
+      versioned: true,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+      lifecycleRules: [
+        {
+          id: 'DeleteOldVersions',
+          enabled: true,
+          noncurrentVersionExpiration: cdk.Duration.days(90),
+        },
+      ],
+    });
+
+    const readPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: [
+        's3:GetObject',
+        's3:ListBucket',
+      ],
+      resources: [
+        this.bucket.bucketArn,
+        `${this.bucket.bucketArn}/*`,
+      ],
+    });
+
+    const managedPolicy = new iam.ManagedPolicy(this, 'ArticlesBucketReadPolicy', {
+      managedPolicyName: `meridiano-articles-read-${environment}`,
+      description: `Read access to Meridiano articles S3 bucket for ${environment} environment`,
+      statements: [readPolicy],
+    });
+
+    new cdk.CfnOutput(this, 'BucketName', {
+      value: this.bucket.bucketName,
+      description: 'S3 bucket name for articles',
+      exportName: `${environment}-ArticlesBucketName`,
+    });
+
+    new cdk.CfnOutput(this, 'BucketArn', {
+      value: this.bucket.bucketArn,
+      description: 'S3 bucket ARN for articles',
+      exportName: `${environment}-ArticlesBucketArn`,
+    });
+
+    new cdk.CfnOutput(this, 'ReadPolicyArn', {
+      value: managedPolicy.managedPolicyArn,
+      description: 'IAM policy ARN for reading from articles bucket',
+      exportName: `${environment}-ArticlesReadPolicyArn`,
+    });
+  }
+}

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "meridiano-infrastructure",
+  "version": "1.0.0",
+  "description": "AWS CDK infrastructure for Meridiano API",
+  "scripts": {
+    "deploy:dev": "bash scripts/deploy-dev.sh",
+    "deploy:stg": "bash scripts/deploy-stg.sh",
+    "deploy:prod": "bash scripts/deploy-prod.sh",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "destroy": "cdk destroy"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.168.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/infrastructure/pnpm-lock.yaml
+++ b/infrastructure/pnpm-lock.yaml
@@ -1,0 +1,224 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.168.0
+        version: 2.235.0(constructs@10.4.5)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.4.5
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.7
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.19.7)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.261':
+    resolution: {integrity: sha512-XkKvgG/OxrEYtVTt2Q9gaD58Qn90fnX/dNczL4k6myeii7UgAGPmqh+I+1uKohCWGKIKd+4Gz2xWBL/tPi4YIA==}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.0':
+    resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
+
+  '@aws-cdk/cloud-assembly-schema@48.20.0':
+    resolution: {integrity: sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/node@22.19.7':
+    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  aws-cdk-lib@2.235.0:
+    resolution: {integrity: sha512-zoTa+fw4J0sjYrn4LJcWAKxQ8i9DMqWdLo7MkP6nNgtqEaypajF9t6Ucasx93/pAQ2bmGV61EM2oVEOtVnpenA==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      constructs: ^10.0.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  constructs@10.4.5:
+    resolution: {integrity: sha512-fOoP70YLevMZr5avJHx2DU3LNYmC6wM8OwdrNewMZou1kZnPGOeVzBrRjZNgFDHUlulYUjkpFRSpTE3D+n+ZSg==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.261': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
+
+  '@aws-cdk/cloud-assembly-schema@48.20.0': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/node@22.19.7':
+    dependencies:
+      undici-types: 6.21.0
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  arg@4.1.3: {}
+
+  aws-cdk-lib@2.235.0(constructs@10.4.5):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.261
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
+      '@aws-cdk/cloud-assembly-schema': 48.20.0
+      constructs: 10.4.5
+
+  constructs@10.4.5: {}
+
+  create-require@1.1.1: {}
+
+  diff@4.0.2: {}
+
+  make-error@1.3.6: {}
+
+  ts-node@10.9.2(@types/node@22.19.7)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.7
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  yn@3.1.1: {}

--- a/infrastructure/scripts/deploy-dev.sh
+++ b/infrastructure/scripts/deploy-dev.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Deploying Meridiano S3 infrastructure to DEV environment..."
+
+export NODE_ENV=dev
+
+cd "$(dirname "$0")/.."
+
+if [ ! -d "node_modules" ]; then
+  echo "📦 Installing dependencies..."
+  pnpm install
+fi
+
+echo "🔧 Synthesizing CDK stack..."
+npx cdk synth --context environment=dev
+
+echo "📤 Deploying to AWS..."
+npx cdk deploy --context environment=dev --require-approval never
+
+echo "✅ Deployment complete!"
+echo ""
+echo "To view the stack outputs, run:"
+echo "  aws cloudformation describe-stacks --stack-name MeridianoS3Stack-dev --query 'Stacks[0].Outputs'"

--- a/infrastructure/scripts/deploy-prod.sh
+++ b/infrastructure/scripts/deploy-prod.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Deploying Meridiano S3 infrastructure to PRODUCTION environment..."
+echo ""
+echo "⚠️  WARNING: You are about to deploy to PRODUCTION!"
+echo ""
+read -p "Are you sure you want to continue? (yes/no): " -r
+echo
+
+if [[ ! $REPLY =~ ^[Yy]es$ ]]; then
+  echo "❌ Deployment cancelled."
+  exit 1
+fi
+
+export NODE_ENV=prod
+
+cd "$(dirname "$0")/.."
+
+if [ ! -d "node_modules" ]; then
+  echo "📦 Installing dependencies..."
+  pnpm install
+fi
+
+echo "🔧 Synthesizing CDK stack..."
+npx cdk synth --context environment=prod
+
+echo "📤 Deploying to AWS..."
+npx cdk deploy --context environment=prod
+
+echo "✅ Deployment complete!"
+echo ""
+echo "To view the stack outputs, run:"
+echo "  aws cloudformation describe-stacks --stack-name MeridianoS3Stack-prod --query 'Stacks[0].Outputs'"

--- a/infrastructure/scripts/deploy-stg.sh
+++ b/infrastructure/scripts/deploy-stg.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Deploying Meridiano S3 infrastructure to STAGING environment..."
+
+export NODE_ENV=stg
+
+cd "$(dirname "$0")/.."
+
+if [ ! -d "node_modules" ]; then
+  echo "📦 Installing dependencies..."
+  pnpm install
+fi
+
+echo "🔧 Synthesizing CDK stack..."
+npx cdk synth --context environment=stg
+
+echo "📤 Deploying to AWS..."
+npx cdk deploy --context environment=stg --require-approval never
+
+echo "✅ Deployment complete!"
+echo ""
+echo "To view the stack outputs, run:"
+echo "  aws cloudformation describe-stacks --stack-name MeridianoS3Stack-stg --query 'Stacks[0].Outputs'"

--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "commonjs",
+    "lib": [
+      "ES2023"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
## Overview
This PR adds AWS CDK infrastructure code to manage S3 buckets for storing markdown articles across different environments (dev, staging, production).

## Changes

### Infrastructure Setup
- **CDK Stack** (`S3Stack`): Creates environment-specific S3 buckets with:
  - Versioning enabled
  - SSE-S3 encryption
  - Blocked public access
  - Lifecycle policy (deletes non-current versions after 90 days)
  - RETAIN removal policy (bucket persists after stack deletion)

- **IAM Policy**: Creates managed IAM policy for read access (`s3:GetObject`, `s3:ListBucket`) to the articles bucket

- **Deployment Scripts**: Added scripts for deploying to dev, staging, and production environments

### Configuration
- Updated `.gitignore` to exclude:
  - CDK output directories (`**/cdk.out`)
  - Infrastructure node_modules

## Stack Outputs
After deployment, the stack outputs:
- `BucketName`: S3 bucket name (e.g., `meridiano-api-articles-dev`)
- `BucketArn`: S3 bucket ARN
- `ReadPolicyArn`: IAM policy ARN for read access

## Deployment

### Prerequisites
- AWS CLI configured with credentials
- AWS CDK CLI installed
- Node.js v20+ and pnpm

### Deploy to Development
```bash
cd infrastructure
pnpm install
pnpm run deploy:dev
```

## Next Steps
After merging, configure the NestJS application with:
- `AWS_REGION` environment variable
- `S3_ARTICLES_BUCKET_NAME` environment variable (from stack outputs)

## Testing Checklist
- [x] Infrastructure code reviewed
- [x] CDK synth validates successfully
- [x] Deployment scripts tested (dev environment)
- [x] Stack outputs verified
- [x] IAM policy can be attached to roles/users
- [x] Documentation reviewed

## Related
- Part of S3 integration for article storage
- Enables future work on article upload/retrieval functionality
