### PR TITLE
fix: update yt-transcript script to include path alias for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "briefing:process": "ts-node -r tsconfig-paths/register src/scripts/runBriefing.ts --process",
     "briefing:rate": "ts-node -r tsconfig-paths/register src/scripts/runBriefing.ts --rate",
     "briefing:generate": "ts-node -r tsconfig-paths/register src/scripts/runBriefing.ts --generate",
-    "yt-transcript": "ts-node src/scripts/runYoutubeTranscripts.ts",
+    "yt-transcript": "ts-node -r tsconfig-paths/register src/scripts/runYoutubeTranscripts.ts",
     "process-transcriptions": "ts-node -r tsconfig-paths/register src/scripts/runProcessTranscriptions.ts",
     "list-transcriptions": "ts-node -r tsconfig-paths/register src/scripts/runListTranscriptions.ts",
     "set-password": "ts-node -r tsconfig-paths/register src/scripts/setUserPassword.ts",


### PR DESCRIPTION
# Fix: Update yt-transcript script to include path alias for consistency

## Summary

Fixes module resolution issue in the `yt-transcript` script by adding the `tsconfig-paths/register` flag, ensuring TypeScript path aliases (`@libs/*`) are properly resolved at runtime.

## Context

The `yt-transcript` script was failing with `Cannot find module '@libs/auth'` error because `ts-node` wasn't configured to resolve TypeScript path aliases. All other scripts in the project already use `-r tsconfig-paths/register` to enable path alias resolution, but this script was missing it.

## Changes

- Updated `package.json` script: `yt-transcript` now includes `-r tsconfig-paths/register` flag
- Ensures consistency with other scripts (`briefing`, `process-transcriptions`, `list-transcriptions`, `set-password`)

## Testing

- [x] Unit tests pass
- [x] Manual testing: Run `pnpm yt-transcript` and verify it executes without module resolution errors

## Breaking Changes

None - this is a bug fix that restores expected functionality.
