### PR TITLE
refactor: add youtube-transcript-plus as alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "rss-parser": "3.13.0",
     "rxjs": "7.8.1",
     "typeorm": "0.3.20",
+    "youtube-transcript-plus": "^1.0.0",
     "youtubei.js": "16.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       typeorm:
         specifier: 0.3.20
         version: 0.3.20(ioredis@5.8.2)(pg@8.11.3)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@22.10.7)(typescript@5.9.3))
+      youtube-transcript-plus:
+        specifier: ^1.0.0
+        version: 1.1.2
       youtubei.js:
         specifier: 16.0.1
         version: 16.0.1
@@ -4938,6 +4941,10 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  youtube-transcript-plus@1.1.2:
+    resolution: {integrity: sha512-bLlqkA6gVVUorZpcc+THuECXyAwOpnHqW2lOav9g6gGovxAP3FCD8s9GBFVjmSl3cWWwwPPXtG/zY1nD+GvQ7A==}
+    engines: {node: '>=18.0.0'}
 
   youtubei.js@16.0.1:
     resolution: {integrity: sha512-3802bCAGkBc2/G5WUTc0l/bO5mPYJbQAHL04d9hE9PnrDHoBUT8MN721Yqt4RCNncAXdHcfee9VdJy3Fhq1r5g==}
@@ -10862,6 +10869,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  youtube-transcript-plus@1.1.2: {}
 
   youtubei.js@16.0.1:
     dependencies:

--- a/src/youtube-transcriptions/services/youtube-transcriptions-alternative.service.ts
+++ b/src/youtube-transcriptions/services/youtube-transcriptions-alternative.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@nestjs/common';
+import { YoutubeTranscript } from 'youtube-transcript-plus';
+import { TranscriptItem } from '../../shared/types/video';
+
+interface FetchTranscriptOptions {
+  keepBrackets?: boolean;
+}
+
+interface CleanOptions {
+  keepBrackets?: boolean;
+}
+
+@Injectable()
+export class YoutubeTranscriptionsAlternativeService {
+  isYouTubeUrl(url: string): boolean {
+    return /(^https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//i.test(url);
+  }
+
+  extractYouTubeId(input: string): string | null {
+    if (!input) return null;
+    const raw = String(input).trim();
+    if (/^[a-zA-Z0-9_-]{11}$/.test(raw)) return raw;
+    const m = raw.match(/(?:v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    return m ? m[1] : null;
+  }
+
+  private decodeHtmlEntities(input: string): string {
+    if (!input) return input;
+    let text = input;
+    for (let i = 0; i < 2; i++) {
+      const decoded = text
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+        .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
+          String.fromCodePoint(parseInt(hex, 16)),
+        );
+      if (decoded === text) break;
+      text = decoded;
+    }
+    return text;
+  }
+
+  private cleanSegments(segments: string[], options?: CleanOptions): string[] {
+    const cleaned: string[] = [];
+    let prev = '';
+
+    for (const seg of segments) {
+      const s = String(seg || '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      if (!s) continue;
+
+      const withoutTags = s.replace(/<[^>]+>/g, '').trim();
+      const withoutBrackets = options?.keepBrackets
+        ? withoutTags
+        : withoutTags.replace(/\[[^\]]*\]/g, '').trim();
+      const withoutCurlies = withoutBrackets
+        .replace(/\{[^}]+\}/g, '')
+        .replace(/♪/g, '')
+        .trim();
+      const t = withoutCurlies.replace(/\s+/g, ' ').trim();
+
+      if (!t) continue;
+      if (t === prev) continue;
+      if (prev && t.startsWith(prev)) {
+        const newPart = t.slice(prev.length).trim();
+        if (newPart) cleaned.push(newPart);
+      } else if (prev && t.includes(prev)) {
+        const idx = t.indexOf(prev);
+        const newPart = (t.slice(0, idx) + t.slice(idx + prev.length)).trim();
+        if (newPart) cleaned.push(newPart);
+      } else {
+        cleaned.push(t);
+      }
+
+      prev = t;
+    }
+
+    return cleaned;
+  }
+
+  private toParagraph(segments: string[], options?: CleanOptions): string {
+    const cleaned = this.cleanSegments(segments, options);
+    return cleaned.join(' ').replace(/\s+/g, ' ').trim();
+  }
+
+  async fetchTranscript(videoId: string): Promise<TranscriptItem[]> {
+    const id = this.extractYouTubeId(videoId);
+    if (!id) {
+      throw new Error(`Invalid YouTube video ID: ${videoId}`);
+    }
+
+    const transcript = await YoutubeTranscript.fetchTranscript(id);
+
+    return transcript.map((entry) => {
+      const decodedText = this.decodeHtmlEntities(entry.text);
+      return {
+        text: decodedText,
+        duration: entry.duration ?? 0,
+        offset: entry.offset,
+      };
+    });
+  }
+
+  async fetchTranscriptAsText(
+    videoId: string,
+    options?: FetchTranscriptOptions,
+  ): Promise<string> {
+    const transcript = await this.fetchTranscript(videoId);
+    const segments = transcript.map((item) => item.text);
+    const paragraph = this.toParagraph(segments, {
+      keepBrackets: options?.keepBrackets,
+    });
+
+    if (!paragraph) {
+      throw new Error('Empty transcript');
+    }
+
+    return paragraph;
+  }
+}

--- a/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
+++ b/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
@@ -12,6 +12,7 @@ import {
 } from '../entities/youtube-transcription.entity';
 import { StorageService } from '../services/storage.service';
 import { TranscriptService } from '../services/transcript.service';
+import { YoutubeTranscriptionsAlternativeService } from './youtube-transcriptions-alternative.service';
 import { fetchTranscriptViaInnertube } from './youtube-transcriptions-innertube.service';
 import { YouTubeService } from './youtube.service';
 
@@ -50,6 +51,7 @@ export class YoutubeTranscriptionsService {
   constructor(
     private readonly youtubeService: YouTubeService,
     private readonly transcriptService: TranscriptService,
+    private readonly youtubeTranscriptionsAlternativeService: YoutubeTranscriptionsAlternativeService,
     private readonly storageService: StorageService,
     private readonly databaseService: DatabaseService,
     private readonly queueService: QueueService,
@@ -86,40 +88,57 @@ export class YoutubeTranscriptionsService {
           let transcript: TranscriptItem[] = [];
 
           try {
-            // Try primary method first (getInfo)
-            console.log('Attempting to fetch transcript using primary method...');
-            transcript = await this.transcriptService.getTranscript(video.videoId);
+            // Try alternative service first (youtube-transcript-plus)
+            console.log('Attempting to fetch transcript using alternative service...');
+            transcript = await this.youtubeTranscriptionsAlternativeService.fetchTranscript(video.videoId);
 
             if (!transcript || transcript.length === 0) {
-              throw new Error('Primary method returned empty transcript');
+              throw new Error('Alternative service returned empty transcript');
             }
 
-            console.log(`✓ Successfully fetched transcript using primary method (${transcript.length} items)`);
-          } catch (primaryError) {
-            // Fallback to alternative method (getBasicInfo + direct XML fetch)
-            console.log('Primary method failed, attempting fallback method...');
-            const primaryErrorMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
-            console.log(`  Primary error: ${primaryErrorMessage}`);
+            console.log(`✓ Successfully fetched transcript using alternative service (${transcript.length} items)`);
+          } catch (alternativeServiceError) {
+            // Fallback to primary method (TranscriptService)
+            console.log('Alternative service failed, attempting primary method...');
+            const alternativeServiceErrorMessage = alternativeServiceError instanceof Error ? alternativeServiceError.message : String(alternativeServiceError);
+            console.log(`  Alternative service error: ${alternativeServiceErrorMessage}`);
 
             try {
-              const alternativeSegments = await fetchTranscriptViaInnertube(video.videoId);
-              transcript = convertYouTubeSegmentsToTranscriptItems(alternativeSegments);
+              console.log('Attempting to fetch transcript using primary method...');
+              transcript = await this.transcriptService.getTranscript(video.videoId);
 
               if (!transcript || transcript.length === 0) {
-                throw new Error('Alternative method returned empty transcript');
+                throw new Error('Primary method returned empty transcript');
               }
 
-              console.log(`✓ Successfully fetched transcript using alternative method (${transcript.length} items)`);
-            } catch (alternativeError) {
-              // Both methods failed
-              const alternativeErrorMessage = alternativeError instanceof Error ? alternativeError.message : String(alternativeError);
-              console.error('Both transcript methods failed:');
-              console.error(`  Primary: ${primaryErrorMessage}`);
-              console.error(`  Alternative: ${alternativeErrorMessage}`);
+              console.log(`✓ Successfully fetched transcript using primary method (${transcript.length} items)`);
+            } catch (primaryError) {
+              // Fallback to innertube method
+              console.log('Primary method failed, attempting innertube method...');
+              const primaryErrorMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
+              console.log(`  Primary error: ${primaryErrorMessage}`);
 
-              throw new Error(
-                `Failed to fetch transcript using both methods. Primary: ${primaryErrorMessage}. Alternative: ${alternativeErrorMessage}`
-              );
+              try {
+                const innertubeSegments = await fetchTranscriptViaInnertube(video.videoId);
+                transcript = convertYouTubeSegmentsToTranscriptItems(innertubeSegments);
+
+                if (!transcript || transcript.length === 0) {
+                  throw new Error('Innertube method returned empty transcript');
+                }
+
+                console.log(`✓ Successfully fetched transcript using innertube method (${transcript.length} items)`);
+              } catch (innertubeError) {
+                // All three methods failed
+                const innertubeErrorMessage = innertubeError instanceof Error ? innertubeError.message : String(innertubeError);
+                console.error('All transcript methods failed:');
+                console.error(`  Alternative service: ${alternativeServiceErrorMessage}`);
+                console.error(`  Primary: ${primaryErrorMessage}`);
+                console.error(`  Innertube: ${innertubeErrorMessage}`);
+
+                throw new Error(
+                  `Failed to fetch transcript using all methods. Alternative service: ${alternativeServiceErrorMessage}. Primary: ${primaryErrorMessage}. Innertube: ${innertubeErrorMessage}`
+                );
+              }
             }
           }
 
@@ -247,40 +266,57 @@ export class YoutubeTranscriptionsService {
       let transcript: TranscriptItem[] = [];
 
       try {
-        // Try primary method first (getInfo)
-        console.log('Attempting to fetch transcript using primary method...');
-        transcript = await this.transcriptService.getTranscript(videoId);
+        // Try alternative service first (youtube-transcript-plus)
+        console.log('Attempting to fetch transcript using alternative service...');
+        transcript = await this.youtubeTranscriptionsAlternativeService.fetchTranscript(videoId);
 
         if (!transcript || transcript.length === 0) {
-          throw new Error('Primary method returned empty transcript');
+          throw new Error('Alternative service returned empty transcript');
         }
 
-        console.log(`✓ Successfully fetched transcript using primary method (${transcript.length} items)`);
-      } catch (primaryError) {
-        // Fallback to alternative method (getBasicInfo + direct XML fetch)
-        console.log('Primary method failed, attempting fallback method...');
-        const primaryErrorMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
-        console.log(`  Primary error: ${primaryErrorMessage}`);
+        console.log(`✓ Successfully fetched transcript using alternative service (${transcript.length} items)`);
+      } catch (alternativeServiceError) {
+        // Fallback to primary method (TranscriptService)
+        console.log('Alternative service failed, attempting primary method...');
+        const alternativeServiceErrorMessage = alternativeServiceError instanceof Error ? alternativeServiceError.message : String(alternativeServiceError);
+        console.log(`  Alternative service error: ${alternativeServiceErrorMessage}`);
 
         try {
-          const alternativeSegments = await fetchTranscriptViaInnertube(videoId, proxyUrl);
-          transcript = convertYouTubeSegmentsToTranscriptItems(alternativeSegments);
+          console.log('Attempting to fetch transcript using primary method...');
+          transcript = await this.transcriptService.getTranscript(videoId);
 
           if (!transcript || transcript.length === 0) {
-            throw new Error('Alternative method returned empty transcript');
+            throw new Error('Primary method returned empty transcript');
           }
 
-          console.log(`✓ Successfully fetched transcript using alternative method (${transcript.length} items)`);
-        } catch (alternativeError) {
-          // Both methods failed
-          const alternativeErrorMessage = alternativeError instanceof Error ? alternativeError.message : String(alternativeError);
-          console.error('Both transcript methods failed:');
-          console.error(`  Primary: ${primaryErrorMessage}`);
-          console.error(`  Alternative: ${alternativeErrorMessage}`);
+          console.log(`✓ Successfully fetched transcript using primary method (${transcript.length} items)`);
+        } catch (primaryError) {
+          // Fallback to innertube method
+          console.log('Primary method failed, attempting innertube method...');
+          const primaryErrorMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
+          console.log(`  Primary error: ${primaryErrorMessage}`);
 
-          throw new Error(
-            `Failed to fetch transcript using both methods. Primary: ${primaryErrorMessage}. Alternative: ${alternativeErrorMessage}`
-          );
+          try {
+            const innertubeSegments = await fetchTranscriptViaInnertube(videoId, proxyUrl);
+            transcript = convertYouTubeSegmentsToTranscriptItems(innertubeSegments);
+
+            if (!transcript || transcript.length === 0) {
+              throw new Error('Innertube method returned empty transcript');
+            }
+
+            console.log(`✓ Successfully fetched transcript using innertube method (${transcript.length} items)`);
+          } catch (innertubeError) {
+            // All three methods failed
+            const innertubeErrorMessage = innertubeError instanceof Error ? innertubeError.message : String(innertubeError);
+            console.error('All transcript methods failed:');
+            console.error(`  Alternative service: ${alternativeServiceErrorMessage}`);
+            console.error(`  Primary: ${primaryErrorMessage}`);
+            console.error(`  Innertube: ${innertubeErrorMessage}`);
+
+            throw new Error(
+              `Failed to fetch transcript using all methods. Alternative service: ${alternativeServiceErrorMessage}. Primary: ${primaryErrorMessage}. Innertube: ${innertubeErrorMessage}`
+            );
+          }
         }
       }
 

--- a/src/youtube-transcriptions/youtube-transcriptions.module.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.module.ts
@@ -13,6 +13,7 @@ import { ListAllYoutubeTranscriptionsQuery } from './queries/list-all-youtube-tr
 import { ListYoutubeTranscriptionsQuery } from './queries/list-youtube-transcriptions.query';
 import { StorageService } from './services/storage.service';
 import { TranscriptService } from './services/transcript.service';
+import { YoutubeTranscriptionsAlternativeService } from './services/youtube-transcriptions-alternative.service';
 import { YoutubeTranscriptionsService } from './services/youtube-transcriptions.service';
 import { YouTubeService } from './services/youtube.service';
 import { YoutubeTranscriptionsController } from './youtube-transcriptions.controller';
@@ -29,6 +30,7 @@ import { YoutubeTranscriptionsController } from './youtube-transcriptions.contro
     YoutubeTranscriptionsService,
     YouTubeService,
     TranscriptService,
+    YoutubeTranscriptionsAlternativeService,
     StorageService,
     AiService,
     ConfigService,


### PR DESCRIPTION

## Refactor: Add YouTube Transcript Alternative Service

### Summary
Adds `youtube-transcript-plus` as the first fallback for fetching YouTube transcripts, improving reliability and resilience.

### Changes
- Added `YoutubeTranscriptionsAlternativeService` using `youtube-transcript-plus`
- Updated transcript fetching order:
  1. Alternative service (`youtube-transcript-plus`) — tried first
  2. Primary method (`TranscriptService`) — existing fallback
  3. Innertube method — existing fallback
- Integrated the new service into `YoutubeTranscriptionsModule`

### Implementation Details
- `YoutubeTranscriptionsAlternativeService`:
  - Uses `youtube-transcript-plus` for fetching
  - Includes HTML entity decoding
  - Provides segment cleaning and paragraph formatting
  - Supports YouTube URL parsing and video ID extraction
- Updated `YoutubeTranscriptionsService` to try the alternative service first in both transcript fetching methods
- Error handling logs which method failed and attempts the next fallback

### Dependencies
- Added `youtube-transcript-plus` (^1.0.0) to `package.json`

### Testing Checklist
- [x] Unit tests pass
- [x] Manual testing completed with various YouTube videos
- [x] Verified fallback chain works when alternative service fails
- [x] Verified existing functionality still works

### Notes
- No breaking changes
- Backward compatible
- Improves reliability by adding another fallback option

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new alternative transcript fetching path and updates the fallback sequence for higher reliability.
> 
> - Adds `youtube-transcript-plus` dependency and new `YoutubeTranscriptionsAlternativeService` (ID extraction, HTML entity decoding, segment cleaning, `fetchTranscript`/`fetchTranscriptAsText`)
> - Updates `YoutubeTranscriptionsService` to try: 1) `YoutubeTranscriptionsAlternativeService`, 2) `TranscriptService`, 3) `fetchTranscriptViaInnertube`, with clearer logging and errors in both channel and single-video paths
> - Registers `YoutubeTranscriptionsAlternativeService` in `YoutubeTranscriptionsModule` providers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 513fc5f5614f94599daaa617b9c4b7d52467898c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->