### PR TITLE
test: refactor tests to use jest-mock-extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Breaking down this regex parttern:
 - [x] Make it possible to upload a markdown file to S3 with an article and send an event to the queue to process this md file
 - [x] Change the s3 upload to use the pre signed post from s3
 - [ ] Migrate feeds configs to a table
-- [ ] Refactor all tests to use jest-mock-extended
+- [x] Refactor all tests to use jest-mock-extended
 - [ ] Send email with articles briefings; use my `personal-sendmail-api` (create validation on aws SES for meridiano)
 - [x] Move the following modules to a libs structure inside this project:
   - [x] S3

--- a/libs/auth/guards/jwt-auth.guard.spec.ts
+++ b/libs/auth/guards/jwt-auth.guard.spec.ts
@@ -2,8 +2,8 @@ import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock } from 'jest-mock-extended';
-import { JwtAuthGuard } from './jwt-auth.guard';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 describe('JwtAuthGuard', () => {
   let guard: JwtAuthGuard;
@@ -11,6 +11,8 @@ describe('JwtAuthGuard', () => {
   const mockExecutionContext = mock<ExecutionContext>();
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         JwtAuthGuard,
@@ -34,8 +36,8 @@ describe('JwtAuthGuard', () => {
 
   describe('canActivate', () => {
     it('should return true when route is marked as public', () => {
-      const mockHandler = jest.fn();
-      const mockClass = class MockClass {};
+      const mockHandler = mock<(...args: unknown[]) => unknown>();
+      const mockClass = class MockClass { };
       mockExecutionContext.getHandler.mockReturnValue(mockHandler as any);
       mockExecutionContext.getClass.mockReturnValue(mockClass);
       mockReflector.getAllAndOverride.mockReturnValueOnce(true);

--- a/libs/database/database.module.spec.ts
+++ b/libs/database/database.module.spec.ts
@@ -15,13 +15,15 @@ jest.mock('typeorm', () => {
 });
 
 jest.mock('@nestjs/typeorm', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { DataSource } = require('typeorm');
-  const MockTypeOrmModule = class {} as any;
+  const MockTypeOrmModule = class { } as any;
   MockTypeOrmModule.forRoot = jest.fn(() => ({
     module: MockTypeOrmModule,
     providers: [
       {
         provide: DataSource,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         useFactory: () => new DataSource({} as any),
       },
     ],
@@ -37,15 +39,15 @@ jest.mock('@nestjs/typeorm', () => {
 
 describe('DatabaseModule', () => {
   let module: TestingModule;
-  const mockDatabaseService = {
-    initDb: jest.fn().mockResolvedValue(undefined),
-    getDbConnection: jest.fn(),
-    closeDb: jest.fn().mockResolvedValue(undefined),
-    onModuleDestroy: jest.fn().mockResolvedValue(undefined),
-  };
+  const mockDatabaseService = mock<DatabaseService>();
   const mockDataSource = mock<DataSource>();
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
+    mockDatabaseService.initDb.mockResolvedValue(undefined);
+    mockDatabaseService.closeDb.mockResolvedValue(undefined);
+    mockDatabaseService.onModuleDestroy.mockResolvedValue(undefined);
     mockDataSource.runMigrations.mockResolvedValue([]);
     mockDataSource.destroy.mockResolvedValue(undefined);
 

--- a/libs/database/database.service.spec.ts
+++ b/libs/database/database.service.spec.ts
@@ -1,12 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
 import { Pool } from 'pg';
 import { DatabaseService } from './database.service';
 
-const mockPoolInstance = {
-  connect: jest.fn(),
-  query: jest.fn(),
-  end: jest.fn(),
-};
+const mockPoolInstance = mock<Pool>();
 
 jest.mock('pg', () => {
   return {
@@ -67,9 +64,7 @@ describe('DatabaseService', () => {
 
     service = module.get<DatabaseService>(DatabaseService);
 
-    const mockClient = {
-      release: jest.fn(),
-    };
+    const mockClient = mock<{ release: () => void }>();
     mockPoolInstance.connect.mockResolvedValue(mockClient as never);
   });
 
@@ -151,7 +146,7 @@ describe('DatabaseService', () => {
 
     it('should handle connection errors', async () => {
       const error = new Error('Connection failed');
-      mockPoolInstance.connect.mockRejectedValueOnce(error);
+      mockPoolInstance.connect.mockRejectedValueOnce(error as unknown as never);
 
       await expect(service.initDb()).rejects.toThrow('Connection failed');
     });
@@ -178,7 +173,7 @@ describe('DatabaseService', () => {
 
   describe('closeDb', () => {
     it('should close database connection', async () => {
-      mockPoolInstance.end.mockResolvedValue(undefined);
+      mockPoolInstance.end.mockResolvedValue(undefined as unknown as never);
 
       await service.initDb();
       await service.closeDb();
@@ -188,7 +183,7 @@ describe('DatabaseService', () => {
 
     it('should handle close errors gracefully', async () => {
       const error = new Error('Close failed');
-      mockPoolInstance.end.mockRejectedValueOnce(error);
+      mockPoolInstance.end.mockRejectedValueOnce(error as unknown as never);
 
       await service.initDb();
       await expect(service.closeDb()).rejects.toThrow('Close failed');
@@ -201,7 +196,7 @@ describe('DatabaseService', () => {
 
   describe('onModuleDestroy', () => {
     it('should close database connection', async () => {
-      mockPoolInstance.end.mockResolvedValue(undefined);
+      mockPoolInstance.end.mockResolvedValue(undefined as unknown as never);
 
       await service.initDb();
       await service.onModuleDestroy();
@@ -211,7 +206,7 @@ describe('DatabaseService', () => {
 
     it('should handle errors during destroy', async () => {
       const error = new Error('Destroy failed');
-      mockPoolInstance.end.mockRejectedValueOnce(error);
+      mockPoolInstance.end.mockRejectedValueOnce(error as unknown as never);
 
       await service.initDb();
       await expect(service.onModuleDestroy()).rejects.toThrow('Destroy failed');

--- a/libs/redis/redis.service.spec.ts
+++ b/libs/redis/redis.service.spec.ts
@@ -1,17 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import Redis from 'ioredis';
+import { mock } from 'jest-mock-extended';
 import { RedisService } from './redis.service';
 
 jest.mock('ioredis');
 
 describe('RedisService', () => {
   let service: RedisService;
-  const mockRedisClient = {
-    on: jest.fn(),
-    disconnect: jest.fn(),
-  };
+  const mockRedisClient = mock<Redis>();
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     (Redis as unknown as jest.Mock).mockImplementation(() => mockRedisClient);
 
     const module: TestingModule = await Test.createTestingModule({

--- a/libs/s3/s3.service.spec.ts
+++ b/libs/s3/s3.service.spec.ts
@@ -12,7 +12,9 @@ describe('S3Service', () => {
   let mockSend: jest.Mock;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     mockSend = jest.fn();
+
     (S3Client as jest.Mock).mockImplementation(() => ({
       send: mockSend,
     }));
@@ -26,6 +28,9 @@ describe('S3Service', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    if (mockSend) {
+      mockSend.mockReset();
+    }
   });
 
   it('should be defined', () => {
@@ -40,7 +45,7 @@ describe('S3Service', () => {
 
       const mockStream = Readable.from([fileContent]);
 
-      mockSend.mockResolvedValueOnce({
+      mockSend.mockResolvedValue({
         Body: mockStream,
       });
 


### PR DESCRIPTION
## Refactor tests to use jest-mock-extended

### Summary
Refactors test files across multiple library modules to use `jest-mock-extended` instead of manual mocks, improving type safety, maintainability, and test isolation.

### Changes
- Replaced manual mock objects with `jest-mock-extended`'s `mock()` function in test files
- Added `jest.clearAllMocks()` calls in `beforeEach` hooks for better test isolation
- Improved type safety by leveraging TypeScript types with `jest-mock-extended`
- Updated README.md to mark the jest-mock-extended refactoring task as complete

### Affected modules
- `libs/auth` - JWT auth guard tests
- `libs/database` - Database module and service tests
- `libs/redis` - Redis service tests
- `libs/s3` - S3 service tests

### Benefits
- Better type safety: `jest-mock-extended` provides full TypeScript support
- Cleaner code: Less boilerplate compared to manual mock objects
- Better test isolation: Consistent mock clearing between tests
- Easier maintenance: Type-safe mocks reduce errors and improve IDE support

### Testing
- [x] All existing tests pass
- [x] No breaking changes to test behavior
- [x] Test coverage maintained

### Notes
This refactoring aligns with the project's testing standards and improves consistency across test suites. All tests continue to pass with the same behavior, but with improved type safety and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (mocking and setup/teardown) with no runtime/production logic impact; primary risk is minor test brittleness if mock expectations differ.
> 
> **Overview**
> Refactors unit tests across `libs/auth`, `libs/database`, `libs/redis`, and `libs/s3` to replace hand-rolled mocks with `jest-mock-extended` typed mocks, improving type safety and reducing boilerplate.
> 
> Improves test isolation by consistently clearing mocks in `beforeEach`/`afterEach`, and tweaks a few mock behaviors (e.g., `S3Service` `mockSend` setup/reset and resolved value setup) to avoid cross-test leakage. Updates `README.md` to mark the refactor task as completed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be0adf5c118f5517238c1407dcce1c2891af1cc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->