### PR TITLE
refactor(queue): extract audio generation to async job queue with retry logic

### DIFF
--- a/libs/queue/constants/queue.constants.ts
+++ b/libs/queue/constants/queue.constants.ts
@@ -6,3 +6,6 @@ export const PROCESS_MARKDOWN_ARTICLE_JOB = 'process-markdown-article';
 
 export const YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE = 'youtube-transcription-summary';
 export const PROCESS_TRANSCRIPTION_SUMMARY_JOB = 'process-transcription-summary';
+
+export const AUDIO_GENERATION_QUEUE = 'audio-generation';
+export const GENERATE_AUDIO_JOB = 'generate-audio';

--- a/libs/queue/index.ts
+++ b/libs/queue/index.ts
@@ -1,14 +1,22 @@
 export {
   ARTICLE_PROCESSING_QUEUE,
+  AUDIO_GENERATION_QUEUE,
+  GENERATE_AUDIO_JOB,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE, PROCESS_ARTICLE_JOB,
   PROCESS_MARKDOWN_ARTICLE_JOB,
   PROCESS_TRANSCRIPTION_SUMMARY_JOB, YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE
 } from './constants/queue.constants';
 
 export type { ProcessArticleJobData } from './interfaces/article-job.interface';
+export type {
+  AudioJobStatus,
+  EnqueueOptions,
+  GenerateAudioJobData,
+  JobInfo
+} from './interfaces/audio-job.interface';
 export type { ProcessMarkdownArticleJobData } from './interfaces/markdown-article-job.interface';
 export type { ProcessTranscriptionSummaryJobData } from './interfaces/youtube-transcription-job.interface';
 
 export { QueueModule } from './queue.module';
 export { QueueService } from './queue.service';
-
+export { AudioJobService } from './services/audio-job.service';

--- a/libs/queue/interfaces/audio-job.interface.ts
+++ b/libs/queue/interfaces/audio-job.interface.ts
@@ -2,7 +2,7 @@ export interface GenerateAudioJobData {
   sourceType: 'article' | 'transcription';
   sourceId: string;
   text: string;
-  date: Date;
+  date: Date | string;
   voice?: string;
 }
 

--- a/libs/queue/interfaces/audio-job.interface.ts
+++ b/libs/queue/interfaces/audio-job.interface.ts
@@ -1,0 +1,32 @@
+export interface GenerateAudioJobData {
+  sourceType: 'article' | 'transcription';
+  sourceId: string;
+  text: string;
+  date: Date;
+  voice?: string;
+}
+
+export interface AudioJobStatus {
+  jobId: string;
+  state: string;
+  progress: string | boolean | number | object;
+  result?: {
+    success: boolean;
+    audioFileId?: string;
+    error?: string;
+  };
+  error?: string;
+  data: GenerateAudioJobData;
+}
+
+export interface EnqueueOptions {
+  waitForCompletion?: boolean;
+  priority?: number;
+  delay?: number;
+  timeout?: number;
+}
+
+export interface JobInfo {
+  jobId: string;
+  status: string;
+}

--- a/libs/queue/processors/audio-generation.processor.ts
+++ b/libs/queue/processors/audio-generation.processor.ts
@@ -1,0 +1,271 @@
+import { RedisService } from '@libs/redis';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Job, Queue, Worker } from 'bullmq';
+import { GenerateAudioUseCase } from '../../../src/audio-files/usecases/generate-audio.usecase';
+import {
+  AUDIO_GENERATION_QUEUE
+} from '../constants/queue.constants';
+import { GenerateAudioJobData } from '../interfaces/audio-job.interface';
+
+type ErrorType = 'retryable' | 'fatal';
+
+interface ErrorClassification {
+  type: ErrorType;
+  shouldRetry: boolean;
+}
+
+@Injectable()
+export class AudioGenerationProcessor implements OnModuleInit {
+  private worker: Worker;
+  private readonly logger = new Logger(AudioGenerationProcessor.name);
+
+  private readonly retryablePatterns = [
+    /timeout/i,
+    /ETIMEDOUT/i,
+    /ECONNRESET/i,
+    /ECONNREFUSED/i,
+    /rate limit/i,
+    /throttl/i,
+    /too many requests/i,
+    /service unavailable/i,
+    /temporarily unavailable/i,
+    /network error/i,
+    /socket hang up/i,
+  ];
+
+  private readonly fatalPatterns = [
+    /invalid input/i,
+    /missing environment variable/i,
+    /authentication failed/i,
+    /unauthorized/i,
+    /invalid api key/i,
+    /malformed/i,
+    /validation error/i,
+  ];
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly generateAudioUseCase: GenerateAudioUseCase,
+    @Inject(AUDIO_GENERATION_QUEUE)
+    private readonly audioQueue: Queue,
+  ) { }
+
+  onModuleInit() {
+    this.worker = new Worker(
+      AUDIO_GENERATION_QUEUE,
+      async (job: Job<GenerateAudioJobData>) => {
+        return await this.processAudioGeneration(job);
+      },
+      {
+        connection: this.redisService.getClient(),
+        concurrency: 2, // Process 2 audio jobs in parallel
+      },
+    );
+
+    this.worker.on('completed', (job) => {
+      this.logger.log({
+        jobId: job.id,
+        sourceType: job.data.sourceType,
+        sourceId: job.data.sourceId,
+        operation: 'process',
+        status: 'completed',
+      });
+    });
+
+    this.worker.on('failed', (job, err) => {
+      this.logger.error({
+        jobId: job?.id,
+        sourceType: job?.data?.sourceType,
+        sourceId: job?.data?.sourceId,
+        operation: 'process',
+        status: 'failed',
+        error: err.message,
+      });
+    });
+
+    this.worker.on('progress', (job, progress) => {
+      this.logger.log({
+        jobId: job.id,
+        sourceType: job.data.sourceType,
+        sourceId: job.data.sourceId,
+        operation: 'progress',
+        progress,
+      });
+    });
+
+    this.logger.log('Audio generation processor worker initialized');
+  }
+
+  /**
+   * Process an audio generation job
+   * @param job - The BullMQ job containing audio generation data
+   * @returns The result of the audio generation
+   */
+  async processAudioGeneration(
+    job: Job<GenerateAudioJobData>,
+  ): Promise<{ success: boolean; audioFileId?: string; error?: string }> {
+    const { sourceType, sourceId, text, date } = job.data;
+    const startTime = Date.now();
+
+    this.logger.log({
+      jobId: job.id,
+      sourceType,
+      sourceId,
+      operation: 'start',
+      status: 'processing',
+    });
+
+    try {
+      await job.updateProgress(0);
+
+      if (!text || text.trim().length === 0) {
+        throw new Error('Invalid input: text is required and cannot be empty');
+      }
+
+      if (!sourceId) {
+        throw new Error('Invalid input: sourceId is required');
+      }
+
+      if (!sourceType || (sourceType !== 'article' && sourceType !== 'transcription')) {
+        throw new Error('Invalid input: sourceType must be "article" or "transcription"');
+      }
+
+      await job.updateProgress(25);
+
+      const result = await this.generateAudioUseCase.execute({
+        sourceType,
+        sourceId,
+        text,
+        date: date ? new Date(date) : new Date(),
+      });
+
+      await job.updateProgress(75);
+
+      const durationMs = Date.now() - startTime;
+
+      if (result.success) {
+        await job.updateProgress(100);
+
+        this.logger.log({
+          jobId: job.id,
+          sourceType,
+          sourceId,
+          operation: 'complete',
+          status: 'success',
+          durationMs,
+          audioFileId: result.audioFileId,
+        });
+
+        return {
+          success: true,
+          audioFileId: result.audioFileId,
+        };
+      } else {
+        const errorClassification = this.classifyError(result.error || 'Unknown error');
+
+        this.logger.error({
+          jobId: job.id,
+          sourceType,
+          sourceId,
+          operation: 'complete',
+          status: 'failed',
+          durationMs,
+          error: result.error,
+          errorType: errorClassification.type,
+          shouldRetry: errorClassification.shouldRetry,
+          attempt: job.attemptsMade + 1,
+        });
+
+        if (errorClassification.type === 'fatal') {
+          void job.discard();
+        }
+
+        return {
+          success: false,
+          error: result.error,
+        };
+      }
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      const errorClassification = this.classifyError(errorMessage);
+
+      this.logger.error({
+        jobId: job.id,
+        sourceType,
+        sourceId,
+        operation: 'complete',
+        status: 'error',
+        durationMs,
+        error: errorMessage,
+        errorType: errorClassification.type,
+        shouldRetry: errorClassification.shouldRetry,
+        attempt: job.attemptsMade + 1,
+      });
+
+      if (errorClassification.type === 'fatal') {
+        void job.discard();
+      }
+
+      throw error; // Re-throw to trigger BullMQ retry mechanism
+    }
+  }
+
+  /**
+   * Classify an error as retryable or fatal
+   * @param errorMessage - The error message to classify
+   * @returns Error classification
+   */
+  private classifyError(errorMessage: string): ErrorClassification {
+    for (const pattern of this.fatalPatterns) {
+      if (pattern.test(errorMessage)) {
+        return { type: 'fatal', shouldRetry: false };
+      }
+    }
+
+    for (const pattern of this.retryablePatterns) {
+      if (pattern.test(errorMessage)) {
+        return { type: 'retryable', shouldRetry: true };
+      }
+    }
+
+    return { type: 'retryable', shouldRetry: true };
+  }
+
+  /**
+   * Get queue metrics for monitoring
+   * @returns Queue metrics
+   */
+  async getQueueMetrics(): Promise<{
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    delayed: number;
+    paused: number;
+  }> {
+    const waiting = await this.audioQueue.getWaitingCount();
+    const active = await this.audioQueue.getActiveCount();
+    const completed = await this.audioQueue.getCompletedCount();
+    const failed = await this.audioQueue.getFailedCount();
+    const delayed = await this.audioQueue.getDelayedCount();
+    // paused count is not directly available on Queue, default to 0
+    const paused = 0;
+
+    return {
+      waiting,
+      active,
+      completed,
+      failed,
+      delayed,
+      paused,
+    };
+  }
+
+  async onModuleDestroy() {
+    if (this.worker) {
+      await this.worker.close();
+    }
+  }
+}

--- a/libs/queue/queue.module.spec.ts
+++ b/libs/queue/queue.module.spec.ts
@@ -109,6 +109,28 @@ jest.mock('./processors/article.processor', () => {
   };
 });
 
+// Mock AudioGenerationProcessor to avoid dependencies
+jest.mock('./processors/audio-generation.processor', () => {
+  return {
+    AudioGenerationProcessor: class MockAudioGenerationProcessor {
+      onModuleInit = jest.fn();
+      onModuleDestroy = jest.fn();
+    },
+  };
+});
+
+// Mock AudioJobService to avoid dependencies
+jest.mock('./services/audio-job.service', () => {
+  return {
+    AudioJobService: class MockAudioJobService {
+      enqueueAudioJob = jest.fn();
+      getJobStatus = jest.fn();
+      getJobsBySource = jest.fn();
+      cancelJob = jest.fn();
+    },
+  };
+});
+
 // Mock QueueService to avoid ConfigService dependency
 jest.mock('./queue.service', () => {
   return {
@@ -126,6 +148,7 @@ jest.mock('./queue.service', () => {
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   ARTICLE_PROCESSING_QUEUE,
+  AUDIO_GENERATION_QUEUE,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from './constants/queue.constants';
@@ -162,6 +185,9 @@ describe('QueueModule', () => {
 
     const transcriptionQueue = module.get(YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE);
     expect(transcriptionQueue).toBeDefined();
+
+    const audioQueue = module.get(AUDIO_GENERATION_QUEUE);
+    expect(audioQueue).toBeDefined();
   });
 
   it('should export QueueService', () => {

--- a/libs/queue/queue.module.ts
+++ b/libs/queue/queue.module.ts
@@ -3,19 +3,24 @@ import { RedisModule, RedisService } from '@libs/redis';
 import { S3Module } from '@libs/s3';
 import { Module, forwardRef } from '@nestjs/common';
 import { Queue } from 'bullmq';
+import { AudioFilesModule } from '../../src/audio-files/audio-files.module';
 import { ConfigModule } from '../../src/config/config.module';
 import { ProcessorModule } from '../../src/processor/processor.module';
 import {
   ARTICLE_PROCESSING_QUEUE,
+  AUDIO_GENERATION_QUEUE,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from './constants/queue.constants';
 import { ArticleProcessor } from './processors/article.processor';
+import { AudioGenerationProcessor } from './processors/audio-generation.processor';
 import { QueueService } from './queue.service';
+import { AudioJobService } from './services/audio-job.service';
 
 @Module({
   imports: [
     forwardRef(() => ProcessorModule),
+    forwardRef(() => AudioFilesModule), // Resolves circular dependency
     ConfigModule,
     EmailModule.forRoot(),
     S3Module,
@@ -49,13 +54,32 @@ import { QueueService } from './queue.service';
       },
       inject: [RedisService],
     },
+    {
+      provide: AUDIO_GENERATION_QUEUE,
+      useFactory: (redisService: RedisService) => {
+        return new Queue(AUDIO_GENERATION_QUEUE, {
+          connection: redisService.getClient(),
+          defaultJobOptions: {
+            attempts: 3,
+            backoff: { type: 'exponential', delay: 2000 },
+            removeOnComplete: { count: 100 },
+            removeOnFail: { count: 500 },
+          },
+        });
+      },
+      inject: [RedisService],
+    },
     ArticleProcessor,
+    AudioJobService,
+    AudioGenerationProcessor,
     QueueService,
   ],
   exports: [
     ARTICLE_PROCESSING_QUEUE,
     MARKDOWN_ARTICLE_PROCESSING_QUEUE,
     YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
+    AUDIO_GENERATION_QUEUE,
+    AudioJobService,
     QueueService,
   ],
 })

--- a/libs/queue/services/audio-job.service.ts
+++ b/libs/queue/services/audio-job.service.ts
@@ -1,0 +1,174 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Job, Queue } from 'bullmq';
+import {
+  AUDIO_GENERATION_QUEUE,
+  GENERATE_AUDIO_JOB,
+} from '../constants/queue.constants';
+import {
+  AudioJobStatus,
+  EnqueueOptions,
+  GenerateAudioJobData,
+  JobInfo,
+} from '../interfaces/audio-job.interface';
+
+@Injectable()
+export class AudioJobService {
+  private readonly logger = new Logger(AudioJobService.name);
+
+  constructor(
+    @Inject(AUDIO_GENERATION_QUEUE)
+    private readonly audioQueue: Queue,
+  ) { }
+
+  /**
+   * Enqueue an audio generation job
+   * @param data - The audio generation job data
+   * @param options - Optional enqueue options
+   * @returns JobInfo or AudioJobStatus if waitForCompletion is true
+   */
+  async enqueueAudioJob(
+    data: GenerateAudioJobData,
+    options?: EnqueueOptions,
+  ): Promise<JobInfo | AudioJobStatus> {
+    const job = await this.audioQueue.add(GENERATE_AUDIO_JOB, data, {
+      priority: options?.priority,
+      delay: options?.delay,
+    });
+
+    const jobId = String(job.id);
+
+    this.logger.log({
+      jobId,
+      sourceType: data.sourceType,
+      sourceId: data.sourceId,
+      operation: 'enqueue',
+      status: 'queued',
+    });
+
+    // Fire-and-forget mode (default)
+    if (!options?.waitForCompletion) {
+      return { jobId, status: 'queued' };
+    }
+
+    // Synchronous mode for backward compatibility
+    // Poll for job completion since waitUntilCompleted is not available
+    const DEFAULT_TIMEOUT_MS = 60000; // 1 minute default
+    const timeoutMs = options.timeout || DEFAULT_TIMEOUT_MS;
+    const pollIntervalMs = 500;
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      const currentJob = await this.audioQueue.getJob(jobId);
+      if (!currentJob) {
+        throw new Error(`Job ${jobId} not found`);
+      }
+
+      const state = await currentJob.getState();
+      if (state === 'completed') {
+        return this.mapJobToStatus(currentJob);
+      }
+      if (state === 'failed') {
+        return this.mapJobToStatus(currentJob);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new Error(`Timeout waiting for job ${jobId} to complete`);
+  }
+
+  /**
+   * Get the status of a job by ID
+   * @param jobId - The job ID
+   * @returns The job status
+   */
+  async getJobStatus(jobId: string): Promise<AudioJobStatus | null> {
+    const job = await this.audioQueue.getJob(jobId);
+
+    if (!job) {
+      return null;
+    }
+
+    return this.mapJobToStatus(job);
+  }
+
+  /**
+   * Get jobs by source type and source ID
+   * @param sourceType - The source type ('article' | 'transcription')
+   * @param sourceId - The source ID
+   * @returns Array of matching job statuses
+   */
+  async getJobsBySource(
+    sourceType: string,
+    sourceId: string,
+  ): Promise<AudioJobStatus[]> {
+    const jobs = await this.audioQueue.getJobs(['waiting', 'active', 'completed', 'failed', 'delayed', 'paused']);
+
+    const matchingJobs = jobs.filter((job) => {
+      const data = job.data as GenerateAudioJobData;
+      return data.sourceType === sourceType && data.sourceId === sourceId;
+    });
+
+    return matchingJobs.map((job) => this.mapJobToStatus(job));
+  }
+
+  /**
+   * Cancel a pending job
+   * @param jobId - The job ID to cancel
+   * @returns true if cancelled, false otherwise
+   */
+  async cancelJob(jobId: string): Promise<boolean> {
+    const job = await this.audioQueue.getJob(jobId);
+
+    if (!job) {
+      this.logger.warn({
+        jobId,
+        operation: 'cancel',
+        status: 'not_found',
+      });
+      return false;
+    }
+
+    const state = await job.getState();
+
+    if (state !== 'waiting' && state !== 'delayed') {
+      this.logger.warn({
+        jobId,
+        operation: 'cancel',
+        status: 'invalid_state',
+        currentState: state,
+      });
+      return false;
+    }
+
+    await job.remove();
+
+    this.logger.log({
+      jobId,
+      operation: 'cancel',
+      status: 'cancelled',
+    });
+
+    return true;
+  }
+
+  /**
+   * Map a BullMQ job to AudioJobStatus
+   * @param job - The BullMQ job
+   * @returns The audio job status
+   */
+  private mapJobToStatus(job: Job): AudioJobStatus {
+    const data = job.data as GenerateAudioJobData;
+    const returnValue = job.returnvalue;
+    const failedReason = job.failedReason;
+
+    return {
+      jobId: String(job.id),
+      state: job.finishedOn ? (job.returnvalue ? 'completed' : 'failed') : 'unknown',
+      progress: job.progress || 0,
+      result: returnValue,
+      error: failedReason,
+      data,
+    };
+  }
+}

--- a/libs/queue/services/audio-job.service.ts
+++ b/libs/queue/services/audio-job.service.ts
@@ -89,7 +89,7 @@ export class AudioJobService {
       return null;
     }
 
-    return this.mapJobToStatus(job);
+    return await this.mapJobToStatus(job);
   }
 
   /**
@@ -109,7 +109,7 @@ export class AudioJobService {
       return data.sourceType === sourceType && data.sourceId === sourceId;
     });
 
-    return matchingJobs.map((job) => this.mapJobToStatus(job));
+    return Promise.all(matchingJobs.map((job) => this.mapJobToStatus(job)));
   }
 
   /**
@@ -157,14 +157,24 @@ export class AudioJobService {
    * @param job - The BullMQ job
    * @returns The audio job status
    */
-  private mapJobToStatus(job: Job): AudioJobStatus {
+  private async mapJobToStatus(job: Job): Promise<AudioJobStatus> {
     const data = job.data as GenerateAudioJobData;
     const returnValue = job.returnvalue;
     const failedReason = job.failedReason;
+    const state = await job.getState();
+
+    let status: 'completed' | 'failed' | 'unknown';
+    if (state === 'completed') {
+      status = 'completed';
+    } else if (state === 'failed' || failedReason) {
+      status = 'failed';
+    } else {
+      status = 'unknown';
+    }
 
     return {
       jobId: String(job.id),
-      state: job.finishedOn ? (job.returnvalue ? 'completed' : 'failed') : 'unknown',
+      state: status,
       progress: job.progress || 0,
       result: returnValue,
       error: failedReason,

--- a/src/articles/processors/markdown-article.processor.spec.ts
+++ b/src/articles/processors/markdown-article.processor.spec.ts
@@ -1,9 +1,8 @@
 import { ProcessMarkdownArticleJobData } from '@libs/queue';
 import { RedisService } from '@libs/redis';
 import { S3Service } from '@libs/s3';
-import { Test, TestingModule } from '@nestjs/testing';
 import { Job, Worker } from 'bullmq';
-import { mock, mockReset } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
 import { ProcessorService } from '../../processor/processor.service';
 import { FeedProfile } from '../../shared/types/feed';
 import { ArticlesService } from '../articles.service';
@@ -19,37 +18,10 @@ describe('MarkdownArticleProcessor', () => {
   const mockProcessorService = mock<ProcessorService>();
   const mockWorker = mock<Worker>();
 
-  beforeEach(async () => {
+  beforeEach(() => {
     (Worker as unknown as jest.Mock).mockImplementation(() => mockWorker);
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        MarkdownArticleProcessor,
-        {
-          provide: RedisService,
-          useValue: mockRedisService,
-        },
-        {
-          provide: S3Service,
-          useValue: mockS3Service,
-        },
-        {
-          provide: ArticlesService,
-          useValue: mockArticlesService,
-        },
-        {
-          provide: ProcessorService,
-          useValue: mockProcessorService,
-        },
-      ],
-    }).compile();
-
-    processor = module.get<MarkdownArticleProcessor>(MarkdownArticleProcessor);
-    mockReset(mockRedisService);
-    mockReset(mockS3Service);
-    mockReset(mockArticlesService);
-    mockReset(mockProcessorService);
-    mockReset(mockWorker);
+    processor = new MarkdownArticleProcessor(mockRedisService, mockS3Service, mockArticlesService, mockProcessorService);
   });
 
   afterEach(() => {

--- a/src/processor/processor.module.ts
+++ b/src/processor/processor.module.ts
@@ -1,7 +1,7 @@
+import { QueueModule } from '@libs/queue';
 import { Module, forwardRef } from '@nestjs/common';
 import { AiModule } from '../ai/ai.module';
 import { ArticlesModule } from '../articles/articles.module';
-import { AudioFilesModule } from '../audio-files/audio-files.module';
 import { ConfigModule } from '../config/config.module';
 import { ProfilesModule } from '../profiles/profiles.module';
 import { ProcessorService } from './processor.service';
@@ -9,10 +9,10 @@ import { ProcessorService } from './processor.service';
 @Module({
   imports: [
     forwardRef(() => ArticlesModule),
+    forwardRef(() => QueueModule),
     AiModule,
     ConfigModule,
     ProfilesModule,
-    AudioFilesModule,
   ],
   providers: [ProcessorService],
   exports: [ProcessorService],

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -1,8 +1,8 @@
+import { AudioJobService } from '@libs/queue';
 import { Injectable } from '@nestjs/common';
 import { AiService } from '../ai/ai.service';
 import { ArticleCategory, DBArticle } from '../articles/article.entity';
 import { ArticlesService } from '../articles/articles.service';
-import { GenerateAudioUseCase } from '../audio-files/usecases/generate-audio.usecase';
 import { ConfigService } from '../config/config.service';
 import { ProfilesService } from '../profiles/profiles.service';
 import { ProcessingStats } from '../shared/types/ai';
@@ -15,7 +15,7 @@ export class ProcessorService {
     private readonly aiService: AiService,
     private readonly configService: ConfigService,
     private readonly profilesService: ProfilesService,
-    private readonly generateAudioUseCase: GenerateAudioUseCase,
+    private readonly audioJobService: AudioJobService,
   ) { }
 
   async processArticles(
@@ -101,21 +101,16 @@ export class ProcessorService {
         // Generate audio if flag is enabled
         if (generateAudio) {
           try {
-            console.log(`Generating audio for article ID: ${article.id}...`);
-            const audioResult = await this.generateAudioUseCase.execute({
+            console.log(`Enqueuing audio generation for article ID: ${article.id}...`);
+            const jobInfo = await this.audioJobService.enqueueAudioJob({
               sourceType: 'article',
               sourceId: article.id,
               text: summary,
               date: article.published_date ? new Date(article.published_date) : new Date(),
             });
-
-            if (audioResult.success) {
-              console.log(`Audio generated successfully for article ID: ${article.id}`);
-            } else {
-              console.error(`Audio generation failed for article ID: ${article.id}: ${audioResult.error}`);
-            }
+            console.log(`Audio generation job enqueued: ${jobInfo.jobId}`);
           } catch (audioError) {
-            console.error(`Error generating audio for article ID: ${article.id}:`, audioError);
+            console.error(`Error enqueuing audio generation for article ID: ${article.id}:`, audioError);
           }
         }
 

--- a/src/youtube-transcriptions/processors/youtube-transcription.processor.ts
+++ b/src/youtube-transcriptions/processors/youtube-transcription.processor.ts
@@ -1,4 +1,5 @@
 import {
+  AudioJobService,
   ProcessTranscriptionSummaryJobData,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from '@libs/queue';
@@ -6,7 +7,6 @@ import { RedisService } from '@libs/redis';
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { Job, Worker } from 'bullmq';
 import { AiService } from '../../ai/ai.service';
-import { GenerateAudioUseCase } from '../../audio-files/usecases/generate-audio.usecase';
 import { ConfigService } from '../../config/config.service';
 import { YoutubeTranscriptionsService } from '../services/youtube-transcriptions.service';
 
@@ -19,7 +19,7 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
     private readonly youtubeTranscriptionsService: YoutubeTranscriptionsService,
     private readonly aiService: AiService,
     private readonly configService: ConfigService,
-    private readonly generateAudioUseCase: GenerateAudioUseCase,
+    private readonly audioJobService: AudioJobService,
   ) { }
 
   onModuleInit() {
@@ -83,25 +83,20 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
       // Generate audio if flag is enabled
       if (job.data.generateAudio) {
         try {
-          console.log(`Generating audio for transcription ID: ${transcriptionId}...`);
+          console.log(`Enqueuing audio generation for transcription ID: ${transcriptionId}...`);
           const transcription = await this.youtubeTranscriptionsService.getTranscriptionById(transcriptionId);
 
           if (transcription) {
-            const audioResult = await this.generateAudioUseCase.execute({
+            const jobInfo = await this.audioJobService.enqueueAudioJob({
               sourceType: 'transcription',
               sourceId: transcriptionId,
               text: summary,
               date: transcription.processedAt,
             });
-
-            if (audioResult.success) {
-              console.log(`Audio generated successfully for transcription ID: ${transcriptionId}`);
-            } else {
-              console.error(`Audio generation failed for transcription ID: ${transcriptionId}: ${audioResult.error}`);
-            }
+            console.log(`Audio generation job enqueued: ${jobInfo.jobId}`);
           }
         } catch (audioError) {
-          console.error(`Error generating audio for transcription ID: ${transcriptionId}:`, audioError);
+          console.error(`Error enqueuing audio generation for transcription ID: ${transcriptionId}:`, audioError);
         }
       }
 

--- a/src/youtube-transcriptions/youtube-transcriptions.module.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.module.ts
@@ -4,7 +4,6 @@ import { RedisModule } from '@libs/redis';
 import { Module, forwardRef } from '@nestjs/common';
 import { AiModule } from '../ai/ai.module';
 import { AiService } from '../ai/ai.service';
-import { AudioFilesModule } from '../audio-files/audio-files.module';
 import { ConfigModule } from '../config/config.module';
 import { ConfigService } from '../config/config.service';
 import { YoutubeChannelsModule } from '../youtube-channels/youtube-channels.module';
@@ -33,7 +32,6 @@ import { ProcessTranscriptionFilesUseCase } from './usecases/process-transcripti
     ConfigModule,
     YoutubeChannelsModule,
     RedisModule,
-    AudioFilesModule,
     forwardRef(() => QueueModule),
   ],
   providers: [


### PR DESCRIPTION
### Summary

Refactors audio generation from direct synchronous calls to an async queue-based job system using BullMQ. Extracts audio generation logic into a reusable module that can be invoked from multiple locations.

### Context and Motivation

Previously, audio generation was tightly coupled to `ProcessorService` and `YoutubeTranscriptionProcessor`, with direct calls to `GenerateAudioUseCase`. This caused:
- Tight coupling between processors and audio generation
- Blocking synchronous execution
- No job status tracking or retrieval
- Limited reusability across the application

This refactor introduces a queue-based architecture that decouples audio generation, enables async processing, and provides job tracking capabilities.

### Changes

**New Infrastructure:**
- `AudioJobService` — service for enqueueing jobs and retrieving status
- `AudioGenerationProcessor` — BullMQ worker that processes audio generation jobs with retry logic
- `GenerateAudioJobData` and `AudioJobStatus` interfaces — type-safe job data structures
- Audio generation queue constants — added to queue constants

**Refactored Components:**
- `ProcessorService` — replaced direct `GenerateAudioUseCase` calls with `AudioJobService.enqueueAudioJob()`
- `YoutubeTranscriptionProcessor` — replaced direct `GenerateAudioUseCase` calls with `AudioJobService.enqueueAudioJob()`
- `QueueModule` — added audio generation queue provider, `AudioJobService`, and `AudioGenerationProcessor` with proper circular dependency handling

**Features:**
- Async job processing with configurable concurrency (2 parallel jobs)
- Retry logic with exponential backoff (3 attempts, 2s/4s/8s delays)
- Error classification (retryable vs fatal)
- Job status tracking and retrieval by job ID or source
- Structured logging with correlation IDs
- Backward compatibility mode (`waitForCompletion` option for synchronous behavior)

### Breaking Changes

- Audio generation is now asynchronous by default (fire-and-forget)
- Direct `GenerateAudioUseCase` calls replaced with `AudioJobService.enqueueAudioJob()`
- Consumers must use `getJobStatus()` to check completion instead of awaiting results

### Testing Checklist

- [x] Unit tests pass
- [ ] Manual testing completed
- [ ] Audio generation jobs enqueue successfully
- [ ] Job status retrieval works correctly
- [ ] Retry logic handles transient errors appropriately
- [ ] Fatal errors are properly discarded
- [ ] Queue metrics are accessible

### Migration Notes

- Existing `generateAudio` flags continue to work
- Jobs are enqueued asynchronously; use `AudioJobService.getJobStatus(jobId)` to check status
- For synchronous behavior, use `waitForCompletion: true` option (with timeout)
- Tests should mock `AudioJobService` instead of `GenerateAudioUseCase`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio generation job queue: enqueue audio generation tasks, optional wait-for-completion mode, job cancellation, and job status tracking.
  * Exposed queue metrics and structured job progress updates for observability.

* **Refactor**
  * Audio generation now runs via asynchronous background jobs rather than synchronous generation, with priority, retry and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->