### PR TITLE
feat(ai): integrate OpenAI chat functionality and update configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,8 +3,13 @@ NODE_ENV=development # or production
 # AI Keys
 DEEPSEEK_API_KEY=
 EMBEDDING_API_KEY=
-# Required for text-to-speech audio generation
+# Required for text-to-speech audio generation and OpenAI chat
 OPENAI_API_KEY=
+
+# AI Provider Configuration
+# Set which chat model provider to use: 'deepseek' or 'gpt-4o-mini'
+# Default: 'deepseek'
+ENABLED_CHAT_MODEL=deepseek
 
 # Ports (for nginx)
 HTTP_PORT=80

--- a/.env.sample
+++ b/.env.sample
@@ -7,7 +7,7 @@ EMBEDDING_API_KEY=
 OPENAI_API_KEY=
 
 # AI Provider Configuration
-# Set which chat model provider to use: 'deepseek' or 'gpt-4o-mini'
+# Set which chat model provider to use: 'deepseek' or 'openai'
 # Default: 'deepseek'
 ENABLED_CHAT_MODEL=deepseek
 

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -85,11 +85,12 @@ export class AiService implements OnModuleInit {
 
     try {
       const modelName = model || this.configService.getModelConfig().deepseekChatModel;
+      const config = this.configService.getModelConfig();
       const response = await this.deepseekClient.chat.completions.create({
         model: modelName,
         messages,
-        max_tokens: 2048,
-        temperature: 0.7,
+        max_tokens: config.maxTokens,
+        temperature: config.temperature,
       });
 
       return response.choices[0]?.message?.content?.trim() || null;
@@ -121,11 +122,12 @@ export class AiService implements OnModuleInit {
 
     try {
       const modelName = model || this.configService.getModelConfig().openaiChatModel;
+      const config = this.configService.getModelConfig();
       const response = await this.openaiChatClient.chat.completions.create({
         model: modelName,
         messages,
-        max_tokens: 2048,
-        temperature: 0.7,
+        max_tokens: config.maxTokens,
+        temperature: config.temperature,
       });
 
       return response.choices[0]?.message?.content?.trim() || null;

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { BadRequestException, Injectable, OnModuleInit } from '@nestjs/common';
 import OpenAI from 'openai';
 import { ConfigService } from '../config/config.service';
 import { ChatMessage } from '../shared/types/ai';
@@ -22,11 +22,11 @@ export class AiService implements OnModuleInit {
     const openaiApiKey = process.env.OPENAI_API_KEY;
 
     if (!deepseekApiKey) {
-      throw new Error('DEEPSEEK_API_KEY not found in environment variables');
+      throw new BadRequestException('DEEPSEEK_API_KEY not found in environment variables');
     }
 
     if (!embeddingApiKey) {
-      throw new Error('EMBEDDING_API_KEY not found in environment variables');
+      throw new BadRequestException('EMBEDDING_API_KEY not found in environment variables');
     }
 
     this.deepseekClient = new OpenAI({
@@ -53,7 +53,7 @@ export class AiService implements OnModuleInit {
       console.log('OpenAI TTS and Chat clients initialized successfully');
     } else if (enabledChatModel === 'openai') {
       // Fail fast if OpenAI chat model is enabled but API key is missing
-      throw new Error(
+      throw new BadRequestException(
         'Configuration error: ENABLED_CHAT_MODEL is set to "openai" but OPENAI_API_KEY is not defined. ' +
         'Please set the OPENAI_API_KEY environment variable or change ENABLED_CHAT_MODEL to "deepseek".'
       );
@@ -70,7 +70,7 @@ export class AiService implements OnModuleInit {
     systemPrompt?: string,
   ): Promise<string | null> {
     if (!this.deepseekClient) {
-      throw new Error(
+      throw new BadRequestException(
         'Deepseek client not initialized. Call initializeClients() first.',
       );
     }
@@ -106,7 +106,7 @@ export class AiService implements OnModuleInit {
     systemPrompt?: string,
   ): Promise<string | null> {
     if (!this.openaiChatClient) {
-      throw new Error(
+      throw new BadRequestException(
         'OpenAI chat client not initialized. OPENAI_API_KEY may be missing.',
       );
     }
@@ -154,7 +154,7 @@ export class AiService implements OnModuleInit {
 
   async getEmbedding(text: string, model?: string): Promise<number[] | null> {
     if (!this.embeddingClient) {
-      throw new Error(
+      throw new BadRequestException(
         'Embedding client not initialized. Call initializeClients() first.',
       );
     }
@@ -183,7 +183,7 @@ export class AiService implements OnModuleInit {
     model?: string,
   ): Promise<(number[] | null)[]> {
     if (!this.embeddingClient) {
-      throw new Error(
+      throw new BadRequestException(
         'Embedding client not initialized. Call initializeClients() first.',
       );
     }

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -8,6 +8,7 @@ export class AiService implements OnModuleInit {
   private deepseekClient: OpenAI | null = null;
   private embeddingClient: OpenAI | null = null;
   private openaiTtsClient: OpenAI | null = null;
+  private openaiChatClient: OpenAI | null = null;
 
   constructor(private readonly configService: ConfigService) { }
 
@@ -42,9 +43,14 @@ export class AiService implements OnModuleInit {
       this.openaiTtsClient = new OpenAI({
         apiKey: openaiApiKey,
       });
-      console.log('OpenAI TTS client initialized successfully');
+
+      this.openaiChatClient = new OpenAI({
+        apiKey: openaiApiKey,
+      });
+
+      console.log('OpenAI TTS and Chat clients initialized successfully');
     } else {
-      console.warn('OPENAI_API_KEY not found in environment variables. TTS functionality will not be available.');
+      console.warn('OPENAI_API_KEY not found in environment variables. TTS and OpenAI chat functionality will not be available.');
     }
 
     console.log('API clients initialized successfully');
@@ -70,8 +76,7 @@ export class AiService implements OnModuleInit {
     messages.push({ role: 'user', content: prompt });
 
     try {
-      const modelName =
-        model || this.configService.getModelConfig().deepseekChatModel;
+      const modelName = model || this.configService.getModelConfig().deepseekChatModel;
       const response = await this.deepseekClient.chat.completions.create({
         model: modelName,
         messages,
@@ -87,6 +92,58 @@ export class AiService implements OnModuleInit {
     }
   }
 
+  async callOpenAIChat(
+    prompt: string,
+    model?: string,
+    systemPrompt?: string,
+  ): Promise<string | null> {
+    if (!this.openaiChatClient) {
+      throw new Error(
+        'OpenAI chat client not initialized. OPENAI_API_KEY may be missing.',
+      );
+    }
+
+    const messages: ChatMessage[] = [];
+
+    if (systemPrompt) {
+      messages.push({ role: 'system', content: systemPrompt });
+    }
+
+    messages.push({ role: 'user', content: prompt });
+
+    try {
+      const modelName = model || this.configService.getModelConfig().openaiChatModel;
+      const response = await this.openaiChatClient.chat.completions.create({
+        model: modelName,
+        messages,
+        max_tokens: 2048,
+        temperature: 0.7,
+      });
+
+      return response.choices[0]?.message?.content?.trim() || null;
+    } catch (error) {
+      console.error('Error calling OpenAI Chat API:', error);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      return null;
+    }
+  }
+
+  async callChat(
+    prompt: string,
+    model?: string,
+    systemPrompt?: string,
+  ): Promise<string | null> {
+    const enabledProvider = this.configService.getEnabledChatModel();
+
+    switch (enabledProvider) {
+      case 'openai':
+        return this.callOpenAIChat(prompt, model, systemPrompt);
+      case 'deepseek':
+      default:
+        return this.callDeepseekChat(prompt, model, systemPrompt);
+    }
+  }
+
   async getEmbedding(text: string, model?: string): Promise<number[] | null> {
     if (!this.embeddingClient) {
       throw new Error(
@@ -94,13 +151,8 @@ export class AiService implements OnModuleInit {
       );
     }
 
-    // console.log(
-    //   `INFO: Getting embedding for text snippet: '${text.substring(0, 50)}...'`,
-    // );
-
     try {
-      const modelName =
-        model || this.configService.getModelConfig().embeddingModel;
+      const modelName = model || this.configService.getModelConfig().embeddingModel;
       const response = await this.embeddingClient.embeddings.create({
         model: modelName,
         input: [text],
@@ -130,8 +182,7 @@ export class AiService implements OnModuleInit {
 
     const results: (number[] | null)[] = [];
     const batchSize = 10;
-    const modelName =
-      model || this.configService.getModelConfig().embeddingModel;
+    const modelName = model || this.configService.getModelConfig().embeddingModel;
 
     for (let i = 0; i < texts.length; i += batchSize) {
       const batch = texts.slice(i, i + batchSize);
@@ -179,6 +230,7 @@ export class AiService implements OnModuleInit {
       'nova',
       'shimmer',
     ];
+
     const selectedVoice = voice && validVoices.includes(voice) ? voice : 'alloy';
 
     try {
@@ -210,6 +262,7 @@ export class AiService implements OnModuleInit {
       const testPrompt = 'Respond with "OK" if you can read this.';
       const response = await this.callDeepseekChat(testPrompt);
       deepseekWorking = response !== null;
+
       if (!deepseekWorking) {
         errors.push('Deepseek API returned null response');
       }
@@ -221,6 +274,7 @@ export class AiService implements OnModuleInit {
       const testText = 'This is a test for embedding API connectivity.';
       const embedding = await this.getEmbedding(testText);
       embeddingWorking = embedding !== null && embedding.length > 0;
+
       if (!embeddingWorking) {
         errors.push('Embedding API returned null or empty embedding');
       }

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -39,6 +39,8 @@ export class AiService implements OnModuleInit {
       baseURL: 'https://api.together.xyz/v1',
     });
 
+    const enabledChatModel = this.configService.getEnabledChatModel();
+
     if (openaiApiKey) {
       this.openaiTtsClient = new OpenAI({
         apiKey: openaiApiKey,
@@ -49,6 +51,12 @@ export class AiService implements OnModuleInit {
       });
 
       console.log('OpenAI TTS and Chat clients initialized successfully');
+    } else if (enabledChatModel === 'openai') {
+      // Fail fast if OpenAI chat model is enabled but API key is missing
+      throw new Error(
+        'Configuration error: ENABLED_CHAT_MODEL is set to "openai" but OPENAI_API_KEY is not defined. ' +
+        'Please set the OPENAI_API_KEY environment variable or change ENABLED_CHAT_MODEL to "deepseek".'
+      );
     } else {
       console.warn('OPENAI_API_KEY not found in environment variables. TTS and OpenAI chat functionality will not be available.');
     }

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -30,6 +30,8 @@ export type Config = {
     openaiChatModel: string;
     embeddingModel: string;
     enabledChatModel: ValidChatModel;
+    maxTokens: number;
+    temperature: number;
   };
   app: {
     defaultFeedProfile: FeedProfile;

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -5,6 +5,9 @@ export type ArticleEmailsNotifications = {
   failureNotificationEmailFrom: string;
 };
 
+export const VALID_CHAT_MODELS = { openai: 'gpt-4o-mini', deepseek: 'deepseek-chat' } as const;
+export type ValidChatModel = keyof typeof VALID_CHAT_MODELS;
+
 export type Config = {
   prompts: {
     articleSummary: string;
@@ -24,7 +27,9 @@ export type Config = {
   };
   models: {
     deepseekChatModel: string;
+    openaiChatModel: string;
     embeddingModel: string;
+    enabledChatModel: ValidChatModel;
   };
   app: {
     defaultFeedProfile: FeedProfile;

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -68,4 +68,39 @@ describe('ConfigService', () => {
       delete process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM;
     });
   });
+
+  describe('getEnabledChatModel', () => {
+    it('should return environment variable value when ENABLED_CHAT_MODEL is set', () => {
+      process.env.ENABLED_CHAT_MODEL = 'deepseek';
+
+      const result = service.getEnabledChatModel();
+
+      expect(result).toBe('deepseek');
+
+      delete process.env.ENABLED_CHAT_MODEL;
+    });
+
+    it('should return config value when ENABLED_CHAT_MODEL env var is not set', () => {
+      delete process.env.ENABLED_CHAT_MODEL;
+
+      const result = service.getEnabledChatModel();
+
+      expect(result).toBe('deepseek');
+    });
+
+    it('should throw error when neither env var nor config value is available', () => {
+      delete process.env.ENABLED_CHAT_MODEL;
+
+      // Temporarily override the config value to be empty
+      const originalValue = (service as unknown as { CONFIGS: { models: { enabledChatModel: string } } }).CONFIGS.models.enabledChatModel;
+      (service as unknown as { CONFIGS: { models: { enabledChatModel: string } } }).CONFIGS.models.enabledChatModel = '';
+
+      expect(() => service.getEnabledChatModel()).toThrow(
+        'No enabled chat model found in environment variables or config file',
+      );
+
+      // Restore original value
+      (service as unknown as { CONFIGS: { models: { enabledChatModel: string } } }).CONFIGS.models.enabledChatModel = originalValue;
+    });
+  });
 });

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock } from 'jest-mock-extended';
 import { YoutubeChannelsService } from '../youtube-channels/youtube-channels.service';
@@ -96,7 +97,7 @@ describe('ConfigService', () => {
       (service as unknown as { CONFIGS: { models: { enabledChatModel: string } } }).CONFIGS.models.enabledChatModel = '';
 
       expect(() => service.getEnabledChatModel()).toThrow(
-        'No enabled chat model found in environment variables or config file',
+        new BadRequestException('No enabled chat model found in environment variables or config file'),
       );
 
       // Restore original value

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { BriefingOptions } from '../briefing/briefing.entity';
 import { ImpactRating, PromptVariables } from '../shared/types/ai';
 import { FeedProfile } from '../shared/types/feed';
@@ -153,10 +153,8 @@ export class ConfigService {
   }
 
   async getYoutubeChannelsConfig() {
-    // Delegate to YoutubeChannelsService for backward compatibility
     const channels = await this.youtubeChannelsService.getAllChannels();
 
-    // Convert to old format for backward compatibility
     const channelsObj: Record<string, {
       name: string;
       url: string;
@@ -219,6 +217,6 @@ export class ConfigService {
       return this.CONFIGS.models.enabledChatModel;
     }
 
-    throw new Error('No enabled chat model found in environment variables or config file');
+    throw new BadRequestException('No enabled chat model found in environment variables or config file');
   }
 }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -3,7 +3,7 @@ import { BriefingOptions } from '../briefing/briefing.entity';
 import { ImpactRating, PromptVariables } from '../shared/types/ai';
 import { FeedProfile } from '../shared/types/feed';
 import { YoutubeChannelsService } from '../youtube-channels/youtube-channels.service';
-import { ArticleEmailsNotifications, Config } from './config.entity';
+import { ArticleEmailsNotifications, Config, VALID_CHAT_MODELS, ValidChatModel } from './config.entity';
 import {
   articleSummaryPrompt,
   briefSynthesisPrompt,
@@ -40,7 +40,9 @@ export class ConfigService {
 
     models: {
       deepseekChatModel: 'deepseek-chat',
+      openaiChatModel: 'gpt-4o-mini',
       embeddingModel: 'Alibaba-NLP/gte-modernbert-base',
+      enabledChatModel: 'deepseek',
     },
 
     app: {
@@ -195,5 +197,26 @@ export class ConfigService {
   isBriefingsGenerationEnabled(): boolean {
     const value = process.env.ENABLE_BRIEFINGS_GENERATION;
     return value === 'true' || value === '1' || value === undefined;
+  }
+
+  getEnabledChatModel(): ValidChatModel {
+    const envValue = process.env.ENABLED_CHAT_MODEL;
+    if (envValue) {
+
+      const validModels = Object.keys(VALID_CHAT_MODELS);
+      if (!validModels.includes(envValue)) {
+        throw new Error(
+          `Invalid ENABLED_CHAT_MODEL value: '${envValue}'. Must be one of: ${validModels.join(', ')}.`,
+        );
+      }
+
+      return envValue as ValidChatModel;
+    }
+
+    if (this.CONFIGS.models.enabledChatModel) {
+      return this.CONFIGS.models.enabledChatModel;
+    }
+
+    throw new Error('No enabled chat model found in environment variables or config file');
   }
 }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -43,6 +43,8 @@ export class ConfigService {
       openaiChatModel: 'gpt-4o-mini',
       embeddingModel: 'Alibaba-NLP/gte-modernbert-base',
       enabledChatModel: 'deepseek',
+      maxTokens: 2048,
+      temperature: 0.7,
     },
 
     app: {

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -72,7 +72,7 @@ export class ProcessorService {
             article.raw_content.substring(0, 4000),
           );
 
-        const summary = await this.aiService.callDeepseekChat(summaryPrompt);
+        const summary = await this.aiService.callChat(summaryPrompt);
 
         if (!summary) {
           console.log(
@@ -184,7 +184,7 @@ export class ProcessorService {
           : this.configService.getImpactRatingPrompt(article.processed_content);
 
         const ratingResponse =
-          await this.aiService.callDeepseekChat(ratingPrompt);
+          await this.aiService.callChat(ratingPrompt);
 
         if (ratingResponse) {
           try {
@@ -289,7 +289,7 @@ export class ProcessorService {
           );
 
         const categoryResponse =
-          await this.aiService.callDeepseekChat(categoryPrompt);
+          await this.aiService.callChat(categoryPrompt);
 
         if (categoryResponse) {
           try {


### PR DESCRIPTION
## PR Description

This PR integrates OpenAI chat functionality into the AI service and updates the configuration system to support multiple chat model providers.

### Summary of Changes

**AI Service Enhancements:**
- Added `openaiChatClient` to the AI service alongside existing Deepseek and embedding clients
- Implemented `callOpenAIChat()` method for direct OpenAI chat API interactions
- Added `callChat()` method that provides a unified interface to switch between OpenAI and Deepseek providers based on configuration
- OpenAI chat client is conditionally initialized when `OPENAI_API_KEY` environment variable is present

**Configuration Updates:**
- Added `openaiChatModel` configuration option (defaults to 'gpt-4o-mini')
- Added `enabledChatModel` configuration to control which provider is active
- Introduced `VALID_CHAT_MODELS` constant and `ValidChatModel` type for type-safe provider selection
- Added `getEnabledChatModel()` method to retrieve the configured chat provider from environment variables or config

### Motivation
This change enables the application to leverage OpenAI's chat capabilities while maintaining backward compatibility with the existing Deepseek integration. The configurable provider system allows for easy switching between AI providers based on deployment needs or feature requirements.

### Configuration
To use OpenAI chat functionality, set the following environment variable:
- `OPENAI_API_KEY` - Your OpenAI API key
- `ENABLED_CHAT_MODEL` - Set to 'openai' to use OpenAI (defaults to 'deepseek')

### Breaking Changes
None. The default chat provider remains Deepseek, ensuring backward compatibility for existing deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI chat provider option alongside existing chat provider, plus system-prompt support.

* **Configuration**
  * New ENABLED_CHAT_MODEL option and sample env updated; new model settings (openai model, maxTokens, temperature) with validation and clearer error reporting when misconfigured or API key missing.

* **Tests**
  * Added tests for enabled-chat-model resolution and fallback behavior.

* **Behavior**
  * Chat calls now route through the selected provider at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->