### PR TITLE
feat: add groq text for speach

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,11 +5,18 @@ DEEPSEEK_API_KEY=
 EMBEDDING_API_KEY=
 # Required for text-to-speech audio generation and OpenAI chat
 OPENAI_API_KEY=
+# Required for Groq TTS (Orpheus model)
+GROQ_API_KEY=
 
 # AI Provider Configuration
 # Set which chat model provider to use: 'deepseek' or 'openai'
 # Default: 'deepseek'
 ENABLED_CHAT_MODEL=deepseek
+
+# TTS Provider Configuration
+# Set which TTS provider to use: 'openai' or 'groq'
+# Default: 'openai'
+ENABLED_TTS_MODEL=openai
 
 # Ports (for nginx)
 HTTP_PORT=80

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "commander": "12.1.0",
     "dotenv": "17.2.3",
     "form-data": "4.0.1",
+    "groq-sdk": "^0.37.0",
     "ioredis": "5.8.2",
     "jsdom": "23.0.0",
     "mailgun.js": "11.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       form-data:
         specifier: 4.0.1
         version: 4.0.1
+      groq-sdk:
+        specifier: ^0.37.0
+        version: 0.37.0
       ioredis:
         specifier: 5.8.2
         version: 5.8.2
@@ -2683,6 +2686,9 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  groq-sdk@0.37.0:
+    resolution: {integrity: sha512-lT72pcT8b/X5XrzdKf+rWVzUGW1OQSKESmL8fFN5cTbsf02gq6oFam4SVeNtzELt9cYE2Pt3pdGgSImuTbHFDg==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -7782,6 +7788,18 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  groq-sdk@0.37.0:
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   has-flag@4.0.0: {}
 

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, OnModuleInit } from '@nestjs/common';
 import OpenAI from 'openai';
+import Groq from 'groq-sdk';
 import { ConfigService } from '../config/config.service';
 import { ChatMessage } from '../shared/types/ai';
 
@@ -9,6 +10,7 @@ export class AiService implements OnModuleInit {
   private embeddingClient: OpenAI | null = null;
   private openaiTtsClient: OpenAI | null = null;
   private openaiChatClient: OpenAI | null = null;
+  private groqClient: Groq | null = null;
 
   constructor(private readonly configService: ConfigService) {}
 
@@ -20,6 +22,7 @@ export class AiService implements OnModuleInit {
     const deepseekApiKey = process.env.DEEPSEEK_API_KEY;
     const embeddingApiKey = process.env.EMBEDDING_API_KEY;
     const openaiApiKey = process.env.OPENAI_API_KEY;
+    const groqApiKey = process.env.GROQ_API_KEY;
 
     if (!deepseekApiKey) {
       throw new BadRequestException(
@@ -64,6 +67,18 @@ export class AiService implements OnModuleInit {
     } else {
       console.warn(
         'OPENAI_API_KEY not found in environment variables. TTS and OpenAI chat functionality will not be available.',
+      );
+    }
+
+    // Initialize Groq client for TTS
+    if (groqApiKey) {
+      this.groqClient = new Groq({
+        apiKey: groqApiKey,
+      });
+      console.log('Groq TTS client initialized successfully');
+    } else {
+      console.warn(
+        'GROQ_API_KEY not found in environment variables. Groq TTS functionality will not be available.',
       );
     }
 
@@ -232,6 +247,21 @@ export class AiService implements OnModuleInit {
   }
 
   async generateAudio(text: string, voice?: string): Promise<Buffer | null> {
+    const enabledTtsModel = this.configService.getEnabledTtsModel();
+
+    switch (enabledTtsModel) {
+      case 'groq':
+        return this.generateGroqAudio(text, voice);
+      case 'openai':
+      default:
+        return this.generateOpenAiAudio(text, voice);
+    }
+  }
+
+  async generateOpenAiAudio(
+    text: string,
+    voice?: string,
+  ): Promise<Buffer | null> {
     if (!this.openaiTtsClient) {
       console.error(
         'OpenAI TTS client not initialized. OPENAI_API_KEY may be missing.',
@@ -240,9 +270,11 @@ export class AiService implements OnModuleInit {
     }
 
     const validVoices = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];
-
+    const modelConfig = this.configService.getModelConfig();
     const selectedVoice =
-      voice && validVoices.includes(voice) ? voice : 'alloy';
+      voice && validVoices.includes(voice)
+        ? voice
+        : modelConfig.openaiTtsVoice;
 
     try {
       const response = await this.openaiTtsClient.audio.speech.create({
@@ -264,6 +296,127 @@ export class AiService implements OnModuleInit {
       console.error('Error generating audio with OpenAI TTS:', error);
       return null;
     }
+  }
+
+  async generateGroqAudio(
+    text: string,
+    voice?: string,
+  ): Promise<Buffer | null> {
+    if (!this.groqClient) {
+      console.error(
+        'Groq client not initialized. GROQ_API_KEY may be missing.',
+      );
+      return null;
+    }
+
+    // Groq Orpheus model supports these voices: autumn, diana, hannah, austin, daniel, troy
+    const validVoices = [
+      'autumn',
+      'diana',
+      'hannah',
+      'austin',
+      'daniel',
+      'troy',
+    ];
+    const modelConfig = this.configService.getModelConfig();
+    const selectedVoice =
+      voice && validVoices.includes(voice)
+        ? voice
+        : modelConfig.groqTtsVoice;
+
+    // Groq Orpheus model has a 200 character limit per request
+    const maxCharsPerChunk = 200;
+
+    try {
+      // Split text into chunks of maxCharsPerChunk
+      const chunks = this.splitTextIntoChunks(text, maxCharsPerChunk);
+      console.log(
+        `Splitting text into ${chunks.length} chunks for Groq TTS (limit: ${maxCharsPerChunk} chars per chunk)`,
+      );
+
+      // Generate audio for each chunk and collect buffers
+      const audioBuffers: Buffer[] = [];
+
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        try {
+          const response = await this.groqClient.audio.speech.create({
+            model: 'canopylabs/orpheus-v1-english',
+            voice: selectedVoice,
+            input: chunk,
+            response_format: 'wav',
+          });
+
+          const arrayBuffer = await response.arrayBuffer();
+          audioBuffers.push(Buffer.from(arrayBuffer));
+
+          // Small delay between chunks to avoid rate limiting
+          if (i < chunks.length - 1) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+          }
+        } catch (chunkError) {
+          console.error(
+            `Error generating audio for chunk ${i + 1}/${chunks.length}:`,
+            chunkError,
+          );
+          return null;
+        }
+      }
+
+      // Concatenate all audio buffers
+      const combinedBuffer = Buffer.concat(audioBuffers);
+      return combinedBuffer;
+    } catch (error) {
+      console.error('Error generating audio with Groq Orpheus TTS:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Splits text into chunks of specified maximum size.
+   * Tries to split at sentence boundaries when possible.
+   */
+  private splitTextIntoChunks(text: string, maxChunkSize: number): string[] {
+    if (text.length <= maxChunkSize) {
+      return [text];
+    }
+
+    const chunks: string[] = [];
+    let remainingText = text;
+
+    while (remainingText.length > maxChunkSize) {
+      // Find the last sentence boundary within the chunk size
+      let splitIndex = remainingText.lastIndexOf('. ', maxChunkSize);
+
+      // If no sentence boundary found, try other punctuation
+      if (splitIndex === -1 || splitIndex < maxChunkSize * 0.5) {
+        splitIndex = remainingText.lastIndexOf(' ', maxChunkSize);
+      }
+
+      // If still no good split point, force split at maxChunkSize
+      if (splitIndex === -1 || splitIndex < maxChunkSize * 0.5) {
+        splitIndex = maxChunkSize;
+      }
+
+      // Add the chunk (including the period if we split on a sentence)
+      let chunk = remainingText.substring(0, splitIndex + 1).trim();
+      if (!chunk.endsWith('.') && !chunk.endsWith('!') && !chunk.endsWith('?')) {
+        chunk = remainingText.substring(0, splitIndex).trim();
+      }
+
+      if (chunk.length > 0) {
+        chunks.push(chunk);
+      }
+
+      remainingText = remainingText.substring(chunk.length).trim();
+    }
+
+    // Add remaining text as the last chunk
+    if (remainingText.length > 0) {
+      chunks.push(remainingText);
+    }
+
+    return chunks;
   }
 
   async testApiConnectivity(): Promise<{

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -11,6 +11,12 @@ export const VALID_CHAT_MODELS = {
 } as const;
 export type ValidChatModel = keyof typeof VALID_CHAT_MODELS;
 
+export const VALID_TTS_MODELS = {
+  openai: 'tts-1',
+  groq: 'canopylabs/orpheus-v1-english',
+} as const;
+export type ValidTtsModel = keyof typeof VALID_TTS_MODELS;
+
 export type Config = {
   prompts: {
     articleSummary: string;
@@ -33,6 +39,9 @@ export type Config = {
     openaiChatModel: string;
     embeddingModel: string;
     enabledChatModel: ValidChatModel;
+    enabledTtsModel: ValidTtsModel;
+    openaiTtsVoice: string;
+    groqTtsVoice: string;
     maxTokens: number;
     temperature: number;
   };

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -7,7 +7,9 @@ import {
   ArticleEmailsNotifications,
   Config,
   VALID_CHAT_MODELS,
+  VALID_TTS_MODELS,
   ValidChatModel,
+  ValidTtsModel,
 } from './config.entity';
 import {
   articleSummaryPrompt,
@@ -50,6 +52,9 @@ export class ConfigService {
       openaiChatModel: 'gpt-4o-mini',
       embeddingModel: 'Alibaba-NLP/gte-modernbert-base',
       enabledChatModel: 'deepseek',
+      enabledTtsModel: 'openai',
+      openaiTtsVoice: 'alloy',
+      groqTtsVoice: 'hannah',
       maxTokens: 2048,
       temperature: 0.7,
     },
@@ -231,6 +236,28 @@ export class ConfigService {
 
     throw new BadRequestException(
       'No enabled chat model found in environment variables or config file',
+    );
+  }
+
+  getEnabledTtsModel(): ValidTtsModel {
+    const envValue = process.env.ENABLED_TTS_MODEL;
+    if (envValue) {
+      const validModels = Object.keys(VALID_TTS_MODELS);
+      if (!validModels.includes(envValue)) {
+        throw new Error(
+          `Invalid ENABLED_TTS_MODEL value: '${envValue}'. Must be one of: ${validModels.join(', ')}.`,
+        );
+      }
+
+      return envValue as ValidTtsModel;
+    }
+
+    if (this.CONFIGS.models.enabledTtsModel) {
+      return this.CONFIGS.models.enabledTtsModel;
+    }
+
+    throw new BadRequestException(
+      'No enabled TTS model found in environment variables or config file',
     );
   }
 }


### PR DESCRIPTION
## Changes Made

### 1. Added Groq SDK Dependency
- Installed `groq-sdk` package via pnpm

### 2. Updated Environment Configuration ([`.env.sample`](.env.sample))
Added new environment variables:
- `GROQ_API_KEY` - API key for Groq TTS
- `ENABLED_TTS_MODEL` - Set to `'openai'` or `'groq'`

### 3. Updated Config Entity ([`src/config/config.entity.ts`](src/config/config.entity.ts:14))
- Added `VALID_TTS_MODELS` constant with model mappings
- Added `ValidTtsModel` type and TTS config fields

### 4. Updated Config Service ([`src/config/config.service.ts`](src/config/config.service.ts:237))
- Added `getEnabledTtsModel()` method

### 5. Updated AI Service ([`src/ai/ai.service.ts`](src/ai/ai.service.ts))
- Added `generateOpenAiAudio()` method (refactored from original)
- Added [`generateGroqAudio()`](src/ai/ai.service.ts:304) method with 200-character limit handling
- Added [`splitTextIntoChunks()`](src/ai/ai.service.ts:392) private method for intelligent text chunking
- Modified [`generateAudio()`](src/ai/ai.service.ts:249) to route to the appropriate provider

## 200 Character Limit Handling

The `generateGroqAudio()` method now:
1. Splits text into chunks of max 200 characters using sentence boundaries when possible
2. Generates audio for each chunk individually
3. Concatenates all WAV audio buffers into a single audio file
4. Adds small delays between API calls to avoid rate limiting

## Usage

```bash
# Set environment variable
ENABLED_TTS_MODEL=groq
GROQ_API_KEY=your_groq_api_key
```

## Supported Voices

| Provider | Voices |
|----------|--------|
| OpenAI | alloy, echo, fable, onyx, nova, shimmer |
| Groq | autumn, diana, hannah, austin, daniel, troy |

## Output Format
- OpenAI: MP3
- Groq Orpheus: WAV (concatenated from chunks)