### PR TITLE
feat(youtube-transcriptions): add audio generation endpoint for transcriptions

### DIFF
--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -1,6 +1,10 @@
+import { AudioJobService } from '@libs/audio';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { mock } from 'jest-mock-extended';
+import { AudioFilesService } from '../audio-files/audio-files.service';
 import { CreateYoutubeTranscriptionCommand } from './commands/create-youtube-transcription.command';
 import { DeleteYoutubeTranscriptionCommand } from './commands/delete-youtube-transcription.command';
+import { YoutubeTranscription } from './entities/youtube-transcription.entity';
 import { GetYoutubeTranscriptionByIdQuery } from './queries/get-youtube-transcription-by-id.query';
 import { ListAllYoutubeTranscriptionsQuery } from './queries/list-all-youtube-transcriptions.query';
 import { YoutubeTranscriptionsService } from './services/youtube-transcriptions.service';
@@ -9,8 +13,25 @@ import { YoutubeTranscriptionsController } from './youtube-transcriptions.contro
 describe('YoutubeTranscriptionsController', () => {
   let controller: YoutubeTranscriptionsController;
   const mockYoutubeTranscriptionsService = mock<YoutubeTranscriptionsService>();
+  const mockAudioJobService = mock<AudioJobService>();
+  const mockAudioFilesService = mock<AudioFilesService>();
+
+  const transcriptionId = '11111111-1111-1111-1111-111111111111';
+  const mockTranscription: YoutubeTranscription = {
+    id: transcriptionId,
+    channelId: 'channel-1',
+    channelName: 'Test Channel',
+    videoTitle: 'Test Video',
+    videoUrl: 'https://youtube.com/watch?v=abc',
+    processedAt: new Date('2024-01-01'),
+    transcriptionText: 'Full transcription text for TTS',
+    transcriptionSummary: 'Summary for TTS',
+    postedAt: new Date('2024-01-01'),
+  };
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
     const mockListAllYoutubeTranscriptionsQuery =
       new ListAllYoutubeTranscriptionsQuery(mockYoutubeTranscriptionsService);
     const mockGetYoutubeTranscriptionByIdQuery =
@@ -25,10 +46,113 @@ describe('YoutubeTranscriptionsController', () => {
       mockGetYoutubeTranscriptionByIdQuery,
       mockDeleteYoutubeTranscriptionCommand,
       mockCreateYoutubeTranscriptionCommand,
+      mockAudioJobService,
+      mockAudioFilesService,
     );
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('generateAudio', () => {
+    it('should return 202 with jobId and message when transcription exists with no audio', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
+        mockTranscription,
+      );
+      mockAudioFilesService.getAudioFileBySource.mockResolvedValue(null);
+      mockAudioJobService.enqueueAudioJob.mockResolvedValue({
+        jobId: 'job-123',
+        status: 'queued',
+      });
+
+      const result = await controller.generateAudio(transcriptionId);
+
+      expect(result).toEqual({
+        jobId: 'job-123',
+        message: 'Audio generation job queued for transcription',
+      });
+      expect(mockAudioJobService.enqueueAudioJob).toHaveBeenCalledWith({
+        sourceType: 'transcription',
+        sourceId: transcriptionId,
+        text: mockTranscription.transcriptionSummary,
+        date: mockTranscription.postedAt,
+      });
+    });
+
+    it('should use transcriptionText when transcriptionSummary is empty', async () => {
+      const transcriptionWithoutSummary = {
+        ...mockTranscription,
+        transcriptionSummary: undefined,
+      };
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
+        transcriptionWithoutSummary,
+      );
+      mockAudioFilesService.getAudioFileBySource.mockResolvedValue(null);
+      mockAudioJobService.enqueueAudioJob.mockResolvedValue({
+        jobId: 'job-456',
+        status: 'queued',
+      });
+
+      await controller.generateAudio(transcriptionId);
+
+      expect(mockAudioJobService.enqueueAudioJob).toHaveBeenCalledWith({
+        sourceType: 'transcription',
+        sourceId: transcriptionId,
+        text: mockTranscription.transcriptionText,
+        date: mockTranscription.postedAt,
+      });
+    });
+
+    it('should throw NotFoundException when transcription does not exist', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
+        null,
+      );
+
+      await expect(
+        controller.generateAudio('00000000-0000-0000-0000-000000000000'),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockAudioJobService.enqueueAudioJob).not.toHaveBeenCalled();
+    });
+
+    it('should throw ConflictException when audio already exists', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
+        mockTranscription,
+      );
+      mockAudioFilesService.getAudioFileBySource.mockResolvedValue({
+        id: 'audio-1',
+        source_type: 'transcription',
+        source_id: transcriptionId,
+        s3_bucket: 'bucket',
+        s3_key: 'key',
+        file_size_bytes: 1000,
+        created_at: new Date(),
+      });
+
+      await expect(controller.generateAudio(transcriptionId)).rejects.toThrow(
+        ConflictException,
+      );
+
+      expect(mockAudioJobService.enqueueAudioJob).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when transcription has no content', async () => {
+      const emptyTranscription = {
+        ...mockTranscription,
+        transcriptionText: '',
+        transcriptionSummary: '',
+      };
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
+        emptyTranscription,
+      );
+      mockAudioFilesService.getAudioFileBySource.mockResolvedValue(null);
+
+      await expect(controller.generateAudio(transcriptionId)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockAudioJobService.enqueueAudioJob).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -1,13 +1,18 @@
 import {
+  BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Delete,
   Get,
+  HttpCode,
   NotFoundException,
   Param,
   ParseUUIDPipe,
   Post,
 } from '@nestjs/common';
+import { AudioJobService } from '@libs/audio';
+import { AudioFilesService } from '../audio-files/audio-files.service';
 import { CreateYoutubeTranscriptionCommand } from './commands/create-youtube-transcription.command';
 import { DeleteYoutubeTranscriptionCommand } from './commands/delete-youtube-transcription.command';
 import { CreateYoutubeTranscriptionDto } from './dto/create-youtube-transcription.dto';
@@ -21,6 +26,8 @@ export class YoutubeTranscriptionsController {
     private readonly getYoutubeTranscriptionByIdQuery: GetYoutubeTranscriptionByIdQuery,
     private readonly deleteYoutubeTranscriptionCommand: DeleteYoutubeTranscriptionCommand,
     private readonly createYoutubeTranscriptionCommand: CreateYoutubeTranscriptionCommand,
+    private readonly audioJobService: AudioJobService,
+    private readonly audioFilesService: AudioFilesService,
   ) {}
 
   @Get('transcriptions')
@@ -51,6 +58,49 @@ export class YoutubeTranscriptionsController {
   async delete(@Param('id', ParseUUIDPipe) id: string) {
     const data = await this.deleteYoutubeTranscriptionCommand.execute(id);
     return data;
+  }
+
+  @Post('transcriptions/:id/audio')
+  @HttpCode(202)
+  async generateAudio(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.getYoutubeTranscriptionByIdQuery.execute(id);
+
+    if (!data || !data.transcription) {
+      throw new NotFoundException('YouTube transcription not found');
+    }
+
+    const transcription = data.transcription;
+    const existingAudio = await this.audioFilesService.getAudioFileBySource(
+      'transcription',
+      id,
+    );
+
+    if (existingAudio) {
+      throw new ConflictException(
+        'Audio already exists for this transcription. Use GET /api/youtube/transcriptions/:id?includeAudio=true to fetch the audio.',
+      );
+    }
+
+    const text =
+      transcription.transcriptionSummary || transcription.transcriptionText;
+
+    if (!text || text.trim().length === 0) {
+      throw new BadRequestException(
+        'Transcription has no content available for audio generation',
+      );
+    }
+
+    const jobInfo = await this.audioJobService.enqueueAudioJob({
+      sourceType: 'transcription',
+      sourceId: id,
+      text,
+      date: transcription.postedAt ? transcription.postedAt : new Date(),
+    });
+
+    return {
+      jobId: jobInfo.jobId,
+      message: 'Audio generation job queued for transcription',
+    };
   }
 
   // @Public()

--- a/src/youtube-transcriptions/youtube-transcriptions.module.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.module.ts
@@ -1,5 +1,6 @@
 import { AudioModule } from '@libs/audio';
 import { DatabaseModule } from '@libs/database';
+import { AudioFilesModule } from '../audio-files/audio-files.module';
 import { QueueModule } from '@libs/queue';
 import { RedisModule } from '@libs/redis';
 import { Module, forwardRef } from '@nestjs/common';
@@ -29,6 +30,7 @@ import { ProcessTranscriptionFilesUseCase } from './usecases/process-transcripti
 @Module({
   imports: [
     DatabaseModule,
+    AudioFilesModule,
     AiModule,
     ConfigModule,
     YoutubeChannelsModule,


### PR DESCRIPTION
Add POST /transcriptions/:id/audio endpoint that queues audio generation jobs for YouTube transcriptions. Includes validation for existing audio, empty content, and missing transcriptions. Also adds corresponding unit tests.

Closes https://linear.app/anas-org/issue/TASK-253