### PR TITLE
fix(audio): prevent duplicate in-flight generation requests

### DIFF
--- a/libs/audio/services/audio-job.service.ts
+++ b/libs/audio/services/audio-job.service.ts
@@ -15,7 +15,7 @@ import {
 @Injectable()
 export class AudioJobService {
   private readonly logger = new Logger(AudioJobService.name);
-  private readonly enqueueLockTtlSeconds = 10;
+  private readonly enqueueLockTtlSeconds = 60;
 
   constructor(
     @Inject(AUDIO_GENERATION_QUEUE)

--- a/libs/audio/services/audio-job.service.ts
+++ b/libs/audio/services/audio-job.service.ts
@@ -2,6 +2,7 @@ import {
   AUDIO_GENERATION_QUEUE,
   GENERATE_AUDIO_JOB,
 } from '@libs/queue';
+import { RedisService } from '@libs/redis';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Job, Queue } from 'bullmq';
 import {
@@ -14,11 +15,74 @@ import {
 @Injectable()
 export class AudioJobService {
   private readonly logger = new Logger(AudioJobService.name);
+  private readonly enqueueLockTtlSeconds = 10;
 
   constructor(
     @Inject(AUDIO_GENERATION_QUEUE)
     private readonly audioQueue: Queue,
+    private readonly redisService: RedisService,
   ) { }
+
+  async hasPendingAudioJob(
+    sourceType: 'article' | 'transcription',
+    sourceId: string,
+  ): Promise<boolean> {
+    try {
+      const jobs = await this.audioQueue.getJobs([
+        'waiting',
+        'active',
+        'delayed',
+        'paused',
+      ]);
+
+      return jobs.some((job) => {
+        const data = job.data as GenerateAudioJobData;
+        return data.sourceType === sourceType && data.sourceId === sourceId;
+      });
+    } catch (error) {
+      this.logger.error({
+        operation: 'hasPendingAudioJob',
+        sourceType,
+        sourceId,
+        error: error instanceof Error ? error.message : String(error),
+        errorObject: error,
+      });
+      return false;
+    }
+  }
+
+  async enqueueAudioJobIfNotDuplicate(
+    data: GenerateAudioJobData,
+    options?: EnqueueOptions,
+  ): Promise<JobInfo | AudioJobStatus | null> {
+    const lockKey = `audio:enqueue-lock:${data.sourceType}:${data.sourceId}`;
+    const lockAcquired = await this.redisService.getClient().set(
+      lockKey,
+      '1',
+      'EX',
+      this.enqueueLockTtlSeconds,
+      'NX',
+    );
+
+    if (!lockAcquired) {
+      return null;
+    }
+
+    try {
+      const hasPendingJob = await this.hasPendingAudioJob(
+        data.sourceType,
+        data.sourceId,
+      );
+
+      if (hasPendingJob) {
+        return null;
+      }
+
+      return await this.enqueueAudioJob(data, options);
+    } finally {
+      await this.redisService.getClient().del(lockKey);
+    }
+  }
 
   /**
    * Enqueue an audio generation job

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -272,9 +272,7 @@ export class AiService implements OnModuleInit {
     const validVoices = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];
     const modelConfig = this.configService.getModelConfig();
     const selectedVoice =
-      voice && validVoices.includes(voice)
-        ? voice
-        : modelConfig.openaiTtsVoice;
+      voice && validVoices.includes(voice) ? voice : modelConfig.openaiTtsVoice;
 
     try {
       const response = await this.openaiTtsClient.audio.speech.create({
@@ -320,9 +318,7 @@ export class AiService implements OnModuleInit {
     ];
     const modelConfig = this.configService.getModelConfig();
     const selectedVoice =
-      voice && validVoices.includes(voice)
-        ? voice
-        : modelConfig.groqTtsVoice;
+      voice && validVoices.includes(voice) ? voice : modelConfig.groqTtsVoice;
 
     // Groq Orpheus model has a 200 character limit per request
     const maxCharsPerChunk = 200;
@@ -400,7 +396,11 @@ export class AiService implements OnModuleInit {
 
       // Add the chunk (including the period if we split on a sentence)
       let chunk = remainingText.substring(0, splitIndex + 1).trim();
-      if (!chunk.endsWith('.') && !chunk.endsWith('!') && !chunk.endsWith('?')) {
+      if (
+        !chunk.endsWith('.') &&
+        !chunk.endsWith('!') &&
+        !chunk.endsWith('?')
+      ) {
         chunk = remainingText.substring(0, splitIndex).trim();
       }
 

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -205,7 +205,7 @@ export class ArticlesController {
 
     if (existingAudio) {
       throw new ConflictException(
-        'Audio already exists for this article. Use GET /api/articles/:id?includeAudio=true to fetch the audio.',
+        'Audio already exists for this resource. Use the detail endpoint with includeAudio=true to fetch the audio.',
       );
     }
 
@@ -218,12 +218,18 @@ export class ArticlesController {
       );
     }
 
-    const jobInfo = await this.audioJobService.enqueueAudioJob({
+    const jobInfo = await this.audioJobService.enqueueAudioJobIfNotDuplicate({
       sourceType: 'article',
       sourceId: id,
       text,
       date: article.published_date,
     });
+
+    if (!jobInfo) {
+      throw new ConflictException(
+        'Audio generation is already in progress for this resource.',
+      );
+    }
 
     return {
       jobId: jobInfo.jobId,

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -61,7 +61,7 @@ describe('YoutubeTranscriptionsController', () => {
         mockTranscription,
       );
       mockAudioFilesService.getAudioFileBySource.mockResolvedValue(null);
-      mockAudioJobService.enqueueAudioJob.mockResolvedValue({
+      mockAudioJobService.enqueueAudioJobIfNotDuplicate.mockResolvedValue({
         jobId: 'job-123',
         status: 'queued',
       });
@@ -72,7 +72,7 @@ describe('YoutubeTranscriptionsController', () => {
         jobId: 'job-123',
         message: 'Audio generation job queued for transcription',
       });
-      expect(mockAudioJobService.enqueueAudioJob).toHaveBeenCalledWith({
+      expect(mockAudioJobService.enqueueAudioJobIfNotDuplicate).toHaveBeenCalledWith({
         sourceType: 'transcription',
         sourceId: transcriptionId,
         text: mockTranscription.transcriptionSummary,
@@ -89,14 +89,14 @@ describe('YoutubeTranscriptionsController', () => {
         transcriptionWithoutSummary,
       );
       mockAudioFilesService.getAudioFileBySource.mockResolvedValue(null);
-      mockAudioJobService.enqueueAudioJob.mockResolvedValue({
+      mockAudioJobService.enqueueAudioJobIfNotDuplicate.mockResolvedValue({
         jobId: 'job-456',
         status: 'queued',
       });
 
       await controller.generateAudio(transcriptionId);
 
-      expect(mockAudioJobService.enqueueAudioJob).toHaveBeenCalledWith({
+      expect(mockAudioJobService.enqueueAudioJobIfNotDuplicate).toHaveBeenCalledWith({
         sourceType: 'transcription',
         sourceId: transcriptionId,
         text: mockTranscription.transcriptionText,
@@ -113,7 +113,9 @@ describe('YoutubeTranscriptionsController', () => {
         controller.generateAudio('00000000-0000-0000-0000-000000000000'),
       ).rejects.toThrow(NotFoundException);
 
-      expect(mockAudioJobService.enqueueAudioJob).not.toHaveBeenCalled();
+      expect(
+        mockAudioJobService.enqueueAudioJobIfNotDuplicate,
+      ).not.toHaveBeenCalled();
     });
 
     it('should throw ConflictException when audio already exists', async () => {
@@ -130,11 +132,17 @@ describe('YoutubeTranscriptionsController', () => {
         created_at: new Date(),
       });
 
-      await expect(controller.generateAudio(transcriptionId)).rejects.toThrow(
-        ConflictException,
-      );
+      const result = controller.generateAudio(transcriptionId);
 
-      expect(mockAudioJobService.enqueueAudioJob).not.toHaveBeenCalled();
+      await expect(result).rejects.toThrow(ConflictException);
+      await expect(result).rejects.toMatchObject({
+        message:
+          'Audio already exists for this resource. Use the detail endpoint with includeAudio=true to fetch the audio.',
+      });
+
+      expect(
+        mockAudioJobService.enqueueAudioJobIfNotDuplicate,
+      ).not.toHaveBeenCalled();
     });
 
     it('should throw BadRequestException when transcription has no content', async () => {
@@ -152,7 +160,24 @@ describe('YoutubeTranscriptionsController', () => {
         BadRequestException,
       );
 
-      expect(mockAudioJobService.enqueueAudioJob).not.toHaveBeenCalled();
+      expect(
+        mockAudioJobService.enqueueAudioJobIfNotDuplicate,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should throw ConflictException when generation is already in progress', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
+        mockTranscription,
+      );
+      mockAudioFilesService.getAudioFileBySource.mockResolvedValue(null);
+      mockAudioJobService.enqueueAudioJobIfNotDuplicate.mockResolvedValue(null);
+
+      const result = controller.generateAudio(transcriptionId);
+
+      await expect(result).rejects.toThrow(ConflictException);
+      await expect(result).rejects.toMatchObject({
+        message: 'Audio generation is already in progress for this resource.',
+      });
     });
   });
 });

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -1,5 +1,9 @@
 import { AudioJobService } from '@libs/audio';
-import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { mock } from 'jest-mock-extended';
 import { AudioFilesService } from '../audio-files/audio-files.service';
 import { CreateYoutubeTranscriptionCommand } from './commands/create-youtube-transcription.command';
@@ -72,7 +76,9 @@ describe('YoutubeTranscriptionsController', () => {
         jobId: 'job-123',
         message: 'Audio generation job queued for transcription',
       });
-      expect(mockAudioJobService.enqueueAudioJobIfNotDuplicate).toHaveBeenCalledWith({
+      expect(
+        mockAudioJobService.enqueueAudioJobIfNotDuplicate,
+      ).toHaveBeenCalledWith({
         sourceType: 'transcription',
         sourceId: transcriptionId,
         text: mockTranscription.transcriptionSummary,
@@ -96,7 +102,9 @@ describe('YoutubeTranscriptionsController', () => {
 
       await controller.generateAudio(transcriptionId);
 
-      expect(mockAudioJobService.enqueueAudioJobIfNotDuplicate).toHaveBeenCalledWith({
+      expect(
+        mockAudioJobService.enqueueAudioJobIfNotDuplicate,
+      ).toHaveBeenCalledWith({
         sourceType: 'transcription',
         sourceId: transcriptionId,
         text: mockTranscription.transcriptionText,

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -77,7 +77,7 @@ export class YoutubeTranscriptionsController {
 
     if (existingAudio) {
       throw new ConflictException(
-        'Audio already exists for this transcription. Use GET /api/youtube/transcriptions/:id?includeAudio=true to fetch the audio.',
+        'Audio already exists for this resource. Use the detail endpoint with includeAudio=true to fetch the audio.',
       );
     }
 
@@ -90,12 +90,18 @@ export class YoutubeTranscriptionsController {
       );
     }
 
-    const jobInfo = await this.audioJobService.enqueueAudioJob({
+    const jobInfo = await this.audioJobService.enqueueAudioJobIfNotDuplicate({
       sourceType: 'transcription',
       sourceId: id,
       text,
       date: transcription.postedAt ? transcription.postedAt : new Date(),
     });
+
+    if (!jobInfo) {
+      throw new ConflictException(
+        'Audio generation is already in progress for this resource.',
+      );
+    }
 
     return {
       jobId: jobInfo.jobId,


### PR DESCRIPTION
## Summary

Prevents duplicate audio generation requests for the same article or transcription by:
- Adding `hasPendingAudioJob` and `enqueueAudioJobIfNotDuplicate` in `AudioJobService` with Redis lock
- Returning `409 Conflict` when generation is already in progress (article and transcription endpoints)
- Standardizing 409 error messages across both endpoints
- Adding test coverage for in-progress duplicate conflict

Closes https://linear.app/anas-org/issue/TASK-251/story-12-prevent-duplicate-generation-requests