### PR TITLE
feat(audio): return frontend-compatible submission feedback message

### DIFF
--- a/libs/audio/constants/audio.constants.ts
+++ b/libs/audio/constants/audio.constants.ts
@@ -1,0 +1,2 @@
+export const AUDIO_GENERATION_SUCCESS_MESSAGE =
+  'Audio is being generated. Please refresh the page soon.';

--- a/libs/audio/index.ts
+++ b/libs/audio/index.ts
@@ -1,3 +1,4 @@
+export { AUDIO_GENERATION_SUCCESS_MESSAGE } from './constants/audio.constants';
 export { AudioModule } from './audio.module';
 export type {
   AudioJobStatus,

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -1,4 +1,4 @@
-import { AudioJobService } from '@libs/audio';
+import { AudioJobService, AUDIO_GENERATION_SUCCESS_MESSAGE } from '@libs/audio';
 import { QueueService } from '@libs/queue';
 import { S3Service } from '@libs/s3';
 import {
@@ -233,7 +233,7 @@ export class ArticlesController {
 
     return {
       jobId: jobInfo.jobId,
-      message: 'Audio generation job queued for article',
+      message: AUDIO_GENERATION_SUCCESS_MESSAGE,
     };
   }
 

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -1,4 +1,4 @@
-import { AudioJobService } from '@libs/audio';
+import { AUDIO_GENERATION_SUCCESS_MESSAGE, AudioJobService } from '@libs/audio';
 import {
   BadRequestException,
   ConflictException,
@@ -74,7 +74,7 @@ describe('YoutubeTranscriptionsController', () => {
 
       expect(result).toEqual({
         jobId: 'job-123',
-        message: 'Audio generation job queued for transcription',
+        message: AUDIO_GENERATION_SUCCESS_MESSAGE,
       });
       expect(
         mockAudioJobService.enqueueAudioJobIfNotDuplicate,

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -11,7 +11,7 @@ import {
   ParseUUIDPipe,
   Post,
 } from '@nestjs/common';
-import { AudioJobService } from '@libs/audio';
+import { AudioJobService, AUDIO_GENERATION_SUCCESS_MESSAGE } from '@libs/audio';
 import { AudioFilesService } from '../audio-files/audio-files.service';
 import { CreateYoutubeTranscriptionCommand } from './commands/create-youtube-transcription.command';
 import { DeleteYoutubeTranscriptionCommand } from './commands/delete-youtube-transcription.command';
@@ -105,7 +105,7 @@ export class YoutubeTranscriptionsController {
 
     return {
       jobId: jobInfo.jobId,
-      message: 'Audio generation job queued for transcription',
+      message: AUDIO_GENERATION_SUCCESS_MESSAGE,
     };
   }
 


### PR DESCRIPTION
Standardize success message across article and transcription audio generation endpoints to match PRD FR5: 'Audio is being generated. Please refresh the page soon.'

Add AUDIO_GENERATION_SUCCESS_MESSAGE constant in libs/audio for consistency.

Closes https://linear.app/anas-org/issue/TASK-254