### PR TITLE
feat(auth): keep audio generation endpoints authentication-gated

### DIFF
--- a/src/articles/articles.controller.spec.ts
+++ b/src/articles/articles.controller.spec.ts
@@ -1,0 +1,13 @@
+import { IS_PUBLIC_KEY } from '@libs/auth';
+import { ArticlesController } from './articles.controller';
+
+describe('ArticlesController', () => {
+  it('should not have @Public() on generateAudio endpoint', () => {
+    const isPublic = Reflect.getMetadata(
+      IS_PUBLIC_KEY,
+      ArticlesController.prototype,
+      'generateAudio',
+    );
+    expect(isPublic).toBeUndefined();
+  });
+});

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -1,4 +1,5 @@
 import { AUDIO_GENERATION_SUCCESS_MESSAGE, AudioJobService } from '@libs/audio';
+import { IS_PUBLIC_KEY } from '@libs/auth';
 import {
   BadRequestException,
   ConflictException,
@@ -57,6 +58,15 @@ describe('YoutubeTranscriptionsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should not have @Public() on generateAudio endpoint', () => {
+    const isPublic = Reflect.getMetadata(
+      IS_PUBLIC_KEY,
+      YoutubeTranscriptionsController.prototype,
+      'generateAudio',
+    );
+    expect(isPublic).toBeUndefined();
   });
 
   describe('generateAudio', () => {

--- a/test/audio-generation-auth.e2e-spec.ts
+++ b/test/audio-generation-auth.e2e-spec.ts
@@ -1,0 +1,59 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+
+const ARTICLE_ID = '11111111-1111-1111-1111-111111111111';
+const TRANSCRIPTION_ID = '22222222-2222-2222-2222-222222222222';
+
+describe('Audio generation endpoints authentication (e2e)', () => {
+  let app: INestApplication<App>;
+  let moduleFixture: TestingModule;
+
+  beforeAll(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    if (app) {
+      await app.close();
+    }
+  });
+
+  describe('POST /api/articles/:id/audio', () => {
+    it('should return 401 when request has no Authorization header', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/articles/${ARTICLE_ID}/audio`)
+        .expect(401);
+    });
+
+    it('should return 401 when request has invalid Authorization header', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/articles/${ARTICLE_ID}/audio`)
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401);
+    });
+  });
+
+  describe('POST /api/youtube/transcriptions/:id/audio', () => {
+    it('should return 401 when request has no Authorization header', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/youtube/transcriptions/${TRANSCRIPTION_ID}/audio`)
+        .expect(401);
+    });
+
+    it('should return 401 when request has invalid Authorization header', async () => {
+      await request(app.getHttpServer())
+        .post(`/api/youtube/transcriptions/${TRANSCRIPTION_ID}/audio`)
+        .set('Authorization', 'Bearer invalid-token')
+        .expect(401);
+    });
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -28,6 +28,7 @@
     "^youtubei\\.js$": "<rootDir>/../src/__mocks__/youtubei.js.ts",
     "^youtube-transcript-plus$": "<rootDir>/../src/__mocks__/youtube-transcript-plus.ts",
     "^marked$": "<rootDir>/../node_modules/marked/lib/marked.umd.js",
-    "^@libs/(.*)$": "<rootDir>/../libs/$1"
+    "^@libs/(.*)$": "<rootDir>/../libs/$1",
+    "^youtubei\\.js/web$": "<rootDir>/../src/__mocks__/youtubei.js.ts"
   }
 }


### PR DESCRIPTION
- Add e2e tests for 401 on unauthenticated requests to article and transcription audio generation endpoints
- Add unit tests asserting generateAudio endpoints lack @Public() decorator
- Fix jest-e2e moduleNameMapper for youtubei.js/web to enable app e2e


Closes TASK-252