### PR TITLE
feat(audio): add support alerts and operational reliability for Epic 3

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -57,6 +57,10 @@ S3_ARTICLES_BUCKET_NAME=meridiano-api-articles-dev
 ARTICLE_FAILURE_NOTIFICATION_EMAIL=
 ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM=
 
+# Audio Generation Failure
+AUDIO_FAILURE_SUPPORT_EMAIL=
+AUDIO_FAILURE_SUPPORT_EMAIL_FROM=
+
 # Briefings Generation
 # Set to 'false' or '0' to disable briefings generation
 # Set to 'true' or '1' to enable (default: enabled if not set)

--- a/libs/queue/queue.service.spec.ts
+++ b/libs/queue/queue.service.spec.ts
@@ -1,12 +1,13 @@
 import { EmailService } from '@libs/email';
 import { RedisService } from '@libs/redis';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Queue } from 'bullmq';
+import { Job, Queue } from 'bullmq';
 import Redis from 'ioredis';
 import { mock, mockReset } from 'jest-mock-extended';
 import { ConfigService } from '../../src/config/config.service';
 import {
   ARTICLE_PROCESSING_QUEUE,
+  AUDIO_GENERATION_QUEUE,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from './constants/queue.constants';
@@ -19,6 +20,7 @@ describe('QueueService', () => {
   const mockArticleQueue = mock<Queue>();
   const mockMarkdownArticleQueue = mock<Queue>();
   const mockTranscriptionSummaryQueue = mock<Queue>();
+  const mockAudioQueue = mock<Queue>();
   const mockConfigService = mock<ConfigService>();
   const mockEmailService = mock<EmailService>();
   const mockRedisService = mock<RedisService>();
@@ -28,6 +30,7 @@ describe('QueueService', () => {
     mockReset(mockArticleQueue);
     mockReset(mockMarkdownArticleQueue);
     mockReset(mockTranscriptionSummaryQueue);
+    mockReset(mockAudioQueue);
     mockReset(mockConfigService);
     mockReset(mockEmailService);
     mockReset(mockRedisService);
@@ -49,6 +52,10 @@ describe('QueueService', () => {
         {
           provide: YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
           useValue: mockTranscriptionSummaryQueue,
+        },
+        {
+          provide: AUDIO_GENERATION_QUEUE,
+          useValue: mockAudioQueue,
         },
         {
           provide: ConfigService,
@@ -74,5 +81,96 @@ describe('QueueService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('handleAudioGenerationFailure', () => {
+    const handleAudioFailure = (jobId: string, failedReason: string) =>
+      (service as unknown as { handleAudioGenerationFailure: (j: string, r: string) => Promise<void> })
+        .handleAudioGenerationFailure(jobId, failedReason);
+
+    it('should send email when job exhausted retries and config is set', async () => {
+      const mockJob = {
+        id: 'job-123',
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+        data: { sourceType: 'transcription', sourceId: 'trans-id-1', text: 'x', date: new Date() },
+      } as unknown as Job;
+      mockAudioQueue.getJob.mockResolvedValue(mockJob);
+      mockConfigService.getAudioFailureNotificationEmail.mockReturnValue({
+        to: 'support@example.com',
+        from: 'noreply@example.com',
+      });
+      mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+      await handleAudioFailure('job-123', 'Test failure reason');
+
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'support@example.com',
+          from: 'noreply@example.com',
+          subject: 'Audio Generation Failed',
+          text: expect.stringContaining('job-123'),
+        }),
+      );
+      expect(mockEmailService.sendEmail.mock.calls[0][0].text).toContain('transcription');
+      expect(mockEmailService.sendEmail.mock.calls[0][0].text).toContain('trans-id-1');
+      expect(mockEmailService.sendEmail.mock.calls[0][0].text).toContain('Test failure reason');
+    });
+
+    it('should not send email when config is missing', async () => {
+      const mockJob = {
+        id: 'job-456',
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+        data: { sourceType: 'article', sourceId: 'art-id-1', text: 'x', date: new Date() },
+      } as unknown as Job;
+      mockAudioQueue.getJob.mockResolvedValue(mockJob);
+      mockConfigService.getAudioFailureNotificationEmail.mockReturnValue(null);
+
+      await handleAudioFailure('job-456', 'Some error');
+
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not send email when job has not exhausted retries', async () => {
+      const mockJob = {
+        id: 'job-789',
+        attemptsMade: 1,
+        opts: { attempts: 3 },
+        data: { sourceType: 'transcription', sourceId: 'trans-id-2', text: 'x', date: new Date() },
+      } as unknown as Job;
+      mockAudioQueue.getJob.mockResolvedValue(mockJob);
+      mockConfigService.getAudioFailureNotificationEmail.mockReturnValue({
+        to: 'support@example.com',
+        from: 'noreply@example.com',
+      });
+
+      await handleAudioFailure('job-789', 'Retryable error');
+
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when email send fails', async () => {
+      const mockJob = {
+        id: 'job-999',
+        attemptsMade: 3,
+        opts: { attempts: 3 },
+        data: { sourceType: 'article', sourceId: 'art-id-2', text: 'x', date: new Date() },
+      } as unknown as Job;
+      mockAudioQueue.getJob.mockResolvedValue(mockJob);
+      mockConfigService.getAudioFailureNotificationEmail.mockReturnValue({
+        to: 'support@example.com',
+        from: 'noreply@example.com',
+      });
+      mockEmailService.sendEmail.mockRejectedValue(new Error('Mailgun timeout'));
+
+      await expect(handleAudioFailure('job-999', 'Failure')).resolves.not.toThrow();
+    });
+
+    it('should not throw when job is not found', async () => {
+      mockAudioQueue.getJob.mockResolvedValue(undefined);
+
+      await expect(handleAudioFailure('missing-job', 'Error')).resolves.not.toThrow();
+    });
   });
 });

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -13,8 +13,8 @@ import {
   PROCESS_TRANSCRIPTION_SUMMARY_JOB,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from './constants/queue.constants';
-import type { GenerateAudioJobData } from './interfaces/audio-job.interface';
 import type { ProcessArticleJobData } from './interfaces/article-job.interface';
+import type { GenerateAudioJobData } from './interfaces/audio-job.interface';
 import type { ProcessMarkdownArticleJobData } from './interfaces/markdown-article-job.interface';
 import type { ProcessTranscriptionSummaryJobData } from './interfaces/youtube-transcription-job.interface';
 
@@ -101,8 +101,12 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       typeof data === 'object' &&
       'sourceType' in data &&
       'sourceId' in data &&
+      'text' in data &&
+      'date' in data &&
       typeof (data as { sourceType: unknown }).sourceType === 'string' &&
-      typeof (data as { sourceId: unknown }).sourceId === 'string'
+      typeof (data as { sourceId: unknown }).sourceId === 'string' &&
+      typeof (data as { text: unknown }).text === 'string' &&
+      (data as { date: unknown }).date instanceof Date
     );
   }
 

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -1,17 +1,19 @@
 import { EmailService } from '@libs/email';
 import { RedisService } from '@libs/redis';
-import { Inject, Injectable, NotFoundException, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { Queue, QueueEvents } from 'bullmq';
 import { ConfigService } from '../../src/config/config.service';
 import { FeedProfile } from '../../src/shared/types/feed';
 import {
   ARTICLE_PROCESSING_QUEUE,
+  AUDIO_GENERATION_QUEUE,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   PROCESS_ARTICLE_JOB,
   PROCESS_MARKDOWN_ARTICLE_JOB,
   PROCESS_TRANSCRIPTION_SUMMARY_JOB,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from './constants/queue.constants';
+import type { GenerateAudioJobData } from './interfaces/audio-job.interface';
 import type { ProcessArticleJobData } from './interfaces/article-job.interface';
 import type { ProcessMarkdownArticleJobData } from './interfaces/markdown-article-job.interface';
 import type { ProcessTranscriptionSummaryJobData } from './interfaces/youtube-transcription-job.interface';
@@ -35,7 +37,10 @@ export interface JobStatus {
 @Injectable()
 export class QueueService implements OnModuleInit, OnModuleDestroy {
   private markdownQueueEvents: QueueEvents;
-  private failureHandler: (({ jobId, failedReason }: { jobId: string; failedReason: string }) => void) | null = null;
+  private audioQueueEvents: QueueEvents;
+  private markdownFailureHandler: (({ jobId, failedReason }: { jobId: string; failedReason: string }) => void) | null = null;
+  private audioFailureHandler: (({ jobId, failedReason }: { jobId: string; failedReason: string }) => void) | null = null;
+  private readonly logger = new Logger(QueueService.name);
 
   constructor(
     @Inject(ARTICLE_PROCESSING_QUEUE)
@@ -44,6 +49,8 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     private readonly markdownArticleQueue: Queue,
     @Inject(YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE)
     private readonly transcriptionSummaryQueue: Queue,
+    @Inject(AUDIO_GENERATION_QUEUE)
+    private readonly audioQueue: Queue,
     private readonly configService: ConfigService,
     private readonly emailService: EmailService,
     private readonly redisService: RedisService,
@@ -51,25 +58,120 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     this.markdownQueueEvents = new QueueEvents(MARKDOWN_ARTICLE_PROCESSING_QUEUE, {
       connection: this.redisService.getClient(),
     });
+    this.audioQueueEvents = new QueueEvents(AUDIO_GENERATION_QUEUE, {
+      connection: this.redisService.getClient(),
+    });
   }
 
   onModuleInit() {
     this.setupMarkdownArticleFailureHandler();
+    this.setupAudioGenerationFailureHandler();
   }
 
   async onModuleDestroy() {
-    if (this.failureHandler) {
-      this.markdownQueueEvents.off('failed', this.failureHandler);
-      this.failureHandler = null;
+    if (this.markdownFailureHandler) {
+      this.markdownQueueEvents.off('failed', this.markdownFailureHandler);
+      this.markdownFailureHandler = null;
     }
     await this.markdownQueueEvents.close();
+    if (this.audioFailureHandler) {
+      this.audioQueueEvents.off('failed', this.audioFailureHandler);
+      this.audioFailureHandler = null;
+    }
+    await this.audioQueueEvents.close();
   }
 
   private setupMarkdownArticleFailureHandler() {
-    this.failureHandler = ({ jobId, failedReason }: { jobId: string; failedReason: string }) => {
+    this.markdownFailureHandler = ({ jobId, failedReason }: { jobId: string; failedReason: string }) => {
       void this.handleMarkdownArticleFailure(jobId, failedReason);
     };
-    this.markdownQueueEvents.on('failed', this.failureHandler);
+    this.markdownQueueEvents.on('failed', this.markdownFailureHandler);
+  }
+
+  private setupAudioGenerationFailureHandler() {
+    this.audioFailureHandler = ({ jobId, failedReason }: { jobId: string; failedReason: string }) => {
+      void this.handleAudioGenerationFailure(jobId, failedReason);
+    };
+    this.audioQueueEvents.on('failed', this.audioFailureHandler);
+  }
+
+  private isValidAudioJobData(data: unknown): data is GenerateAudioJobData {
+    return (
+      data !== null &&
+      typeof data === 'object' &&
+      'sourceType' in data &&
+      'sourceId' in data &&
+      typeof (data as { sourceType: unknown }).sourceType === 'string' &&
+      typeof (data as { sourceId: unknown }).sourceId === 'string'
+    );
+  }
+
+  private async handleAudioGenerationFailure(jobId: string, failedReason: string): Promise<void> {
+    try {
+      const job = await this.audioQueue.getJob(jobId);
+
+      if (!job) {
+        return;
+      }
+
+      const attemptsMade = job.attemptsMade;
+      const maxAttempts = job.opts.attempts ?? 3;
+
+      if (attemptsMade >= maxAttempts) {
+        const config = this.configService.getAudioFailureNotificationEmail();
+
+        if (!config) {
+          this.logger.warn(
+            `Audio job ${job.id} failed after ${maxAttempts} attempts, but AUDIO_FAILURE_SUPPORT_EMAIL (and AUDIO_FAILURE_SUPPORT_EMAIL_FROM or ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM) is not configured.`,
+          );
+          return;
+        }
+
+        const jobData = job.data;
+
+        if (!this.isValidAudioJobData(jobData)) {
+          this.logger.error(
+            `Audio job ${job.id} has invalid data structure. Expected GenerateAudioJobData but got:`,
+            jobData,
+          );
+          return;
+        }
+
+        const { sourceType, sourceId } = jobData;
+        const errorMessage = failedReason || 'Unknown error';
+        const timestamp = new Date().toISOString();
+
+        try {
+          await this.emailService.sendEmail({
+            from: config.from,
+            to: config.to,
+            subject: 'Audio Generation Failed',
+            text: `Audio generation job failed after ${maxAttempts} attempts.
+
+Details:
+- Job ID: ${job.id}
+- Source Type: ${sourceType}
+- Source ID: ${sourceId}
+- Error: ${errorMessage}
+- Timestamp: ${timestamp}
+
+Please investigate the issue.`,
+          });
+
+          this.logger.log(`Audio failure notification email sent to ${config.to} for job ${job.id}`);
+        } catch (emailError) {
+          this.logger.error(
+            `Failed to send audio failure notification email for job ${job.id}:`,
+            emailError instanceof Error ? emailError.message : String(emailError),
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error(
+        'Error in audio generation failure handler:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
   private isValidMarkdownArticleJobData(data: unknown): data is ProcessMarkdownArticleJobData {

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -5,6 +5,11 @@ export type ArticleEmailsNotifications = {
   failureNotificationEmailFrom: string;
 };
 
+export type AudioFailureNotification = {
+  to: string;
+  from: string;
+};
+
 export const VALID_CHAT_MODELS = {
   openai: 'gpt-4o-mini',
   deepseek: 'deepseek-chat',

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -70,6 +70,53 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('getAudioFailureNotificationEmail', () => {
+    it('should return config when both to and from are set', () => {
+      process.env.AUDIO_FAILURE_SUPPORT_EMAIL = 'support@example.com';
+      process.env.AUDIO_FAILURE_SUPPORT_EMAIL_FROM = 'noreply@example.com';
+
+      const result = service.getAudioFailureNotificationEmail();
+
+      expect(result).toEqual({ to: 'support@example.com', from: 'noreply@example.com' });
+
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL;
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL_FROM;
+    });
+
+    it('should fall back to ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM when AUDIO_FAILURE_SUPPORT_EMAIL_FROM is not set', () => {
+      process.env.AUDIO_FAILURE_SUPPORT_EMAIL = 'support@example.com';
+      process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM = 'article-from@example.com';
+
+      const result = service.getAudioFailureNotificationEmail();
+
+      expect(result).toEqual({ to: 'support@example.com', from: 'article-from@example.com' });
+
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL;
+      delete process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM;
+    });
+
+    it('should return null when AUDIO_FAILURE_SUPPORT_EMAIL is not set', () => {
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL;
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL_FROM;
+
+      const result = service.getAudioFailureNotificationEmail();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when from is not configured', () => {
+      process.env.AUDIO_FAILURE_SUPPORT_EMAIL = 'support@example.com';
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL_FROM;
+      delete process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM;
+
+      const result = service.getAudioFailureNotificationEmail();
+
+      expect(result).toBeNull();
+
+      delete process.env.AUDIO_FAILURE_SUPPORT_EMAIL;
+    });
+  });
+
   describe('getPresignedUrlExpirySeconds', () => {
     it('should return 3600 when env var is not set', () => {
       delete process.env.PRESIGNED_URL_EXPIRY_SECONDS;

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -5,6 +5,7 @@ import { FeedProfile } from '../shared/types/feed';
 import { YoutubeChannelsService } from '../youtube-channels/youtube-channels.service';
 import {
   ArticleEmailsNotifications,
+  AudioFailureNotification,
   Config,
   VALID_CHAT_MODELS,
   VALID_TTS_MODELS,
@@ -222,6 +223,21 @@ export class ConfigService {
       failureNotificationEmailFrom:
         process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM || '',
     };
+  }
+
+  getAudioFailureNotificationEmail(): AudioFailureNotification | null {
+    const to = process.env.AUDIO_FAILURE_SUPPORT_EMAIL?.trim() || '';
+    if (!to) {
+      return null;
+    }
+    const from =
+      process.env.AUDIO_FAILURE_SUPPORT_EMAIL_FROM?.trim() ||
+      process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM?.trim() ||
+      '';
+    if (!from) {
+      return null;
+    }
+    return { to, from };
   }
 
   isBriefingsGenerationEnabled(): boolean {

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -211,7 +211,7 @@ describe('YoutubeTranscriptionsController', () => {
   });
 
   describe('generateAudio', () => {
-    it('should return 202 with jobId and message when transcription exists with no audio', async () => {
+    it('should return 202 with jobId and message when transcription exists with no audio (initial or re-request after failure)', async () => {
       mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(
         mockTranscription,
       );

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -84,11 +84,6 @@ export class YoutubeTranscriptionsController {
       id,
     );
 
-    console.log('existingAudio', {
-      existingAudio,
-      id
-    });
-
     if (existingAudio) {
       throw new ConflictException(
         'Audio already exists for this resource. Use the detail endpoint with includeAudio=true to fetch the audio.',


### PR DESCRIPTION
## Summary

Implements Epic 3 stories for operational reliability and recovery (TASK-258, TASK-259, TASK-260).

### Story 3.1: Send Support Alerts on Audio Job Failures
- Add QueueEvents failure handler for `AUDIO_GENERATION_QUEUE`
- Send email to `AUDIO_FAILURE_SUPPORT_EMAIL` when audio jobs reach terminal failure
- Add `getAudioFailureNotificationEmail()` to ConfigService
- Document `AUDIO_FAILURE_SUPPORT_EMAIL` and `AUDIO_FAILURE_SUPPORT_EMAIL_FROM` in .env.sample
- Graceful handling when config is missing (log and skip, no crash)

### Story 3.2: Preserve User Recovery Through Re-Request Flow
- Remove debug `console.log` from transcription audio trigger
- Re-request flow verified: no audio = accept; `hasPendingAudioJob` excludes failed jobs
- Updated test name to document re-request-after-failure scenario

### Story 3.3: Meet Operational Visibility Timing Expectations
- Add unit tests for `handleAudioGenerationFailure`:
  - Sends email when retries exhausted and config set
  - Skips when config missing or retries not exhausted
  - Does not throw on email failure or missing job
- Design meets NFR4 (within 3 minutes): retry window ~14s, immediate email on terminal failure

### Environment Variables
- `AUDIO_FAILURE_SUPPORT_EMAIL` (required for notifications)
- `AUDIO_FAILURE_SUPPORT_EMAIL_FROM` (optional, falls back to `ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM`)

Closes TASK-258
Closes TASK-259
Closes TASK-260