### PR TITLE
feat(processor): isolate embedding failures and add email notifications

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -66,6 +66,10 @@ ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM=
 AUDIO_FAILURE_SUPPORT_EMAIL=
 AUDIO_FAILURE_SUPPORT_EMAIL_FROM=
 
+# Embedding Generation Failure
+EMBEDDING_FAILURE_NOTIFICATION_EMAIL=
+EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM=
+
 # Briefings Generation
 # Set to 'false' or '0' to disable briefings generation
 # Set to 'true' or '1' to enable (default: enabled if not set)

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -117,7 +117,7 @@ export class ArticlesService {
   async updateArticleProcessing(
     articleId: string,
     processedContent: string,
-    embedding: number[],
+    embedding?: number[] | null,
   ): Promise<void> {
     return new Promise((resolve, reject) => {
       const db = this.databaseService.getDbConnection();
@@ -129,7 +129,7 @@ export class ArticlesService {
       `);
 
       stmt.run(
-        [processedContent, JSON.stringify(embedding), articleId],
+        [processedContent, embedding ? JSON.stringify(embedding) : null, articleId],
         (err) => {
           if (err) {
             reject(err);

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -10,6 +10,11 @@ export type AudioFailureNotification = {
   from: string;
 };
 
+export type EmbeddingFailureNotification = {
+  to: string;
+  from: string;
+};
+
 export const VALID_CHAT_MODELS = {
   openai: 'gpt-4o-mini',
   deepseek: 'deepseek-chat',

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -117,6 +117,53 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('getEmbeddingFailureNotificationEmail', () => {
+    it('should return config when both to and from are set', () => {
+      process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL = 'embedding@example.com';
+      process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM = 'noreply@example.com';
+
+      const result = service.getEmbeddingFailureNotificationEmail();
+
+      expect(result).toEqual({ to: 'embedding@example.com', from: 'noreply@example.com' });
+
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL;
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM;
+    });
+
+    it('should fall back to ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM when EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM is not set', () => {
+      process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL = 'embedding@example.com';
+      process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM = 'article-from@example.com';
+
+      const result = service.getEmbeddingFailureNotificationEmail();
+
+      expect(result).toEqual({ to: 'embedding@example.com', from: 'article-from@example.com' });
+
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL;
+      delete process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM;
+    });
+
+    it('should return null when EMBEDDING_FAILURE_NOTIFICATION_EMAIL is not set', () => {
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL;
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM;
+
+      const result = service.getEmbeddingFailureNotificationEmail();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when from is not configured', () => {
+      process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL = 'embedding@example.com';
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM;
+      delete process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM;
+
+      const result = service.getEmbeddingFailureNotificationEmail();
+
+      expect(result).toBeNull();
+
+      delete process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL;
+    });
+  });
+
   describe('getPresignedUrlExpirySeconds', () => {
     it('should return 3600 when env var is not set', () => {
       delete process.env.PRESIGNED_URL_EXPIRY_SECONDS;

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -7,6 +7,7 @@ import {
   ArticleEmailsNotifications,
   AudioFailureNotification,
   Config,
+  EmbeddingFailureNotification,
   VALID_CHAT_MODELS,
   VALID_TTS_MODELS,
   ValidChatModel,
@@ -243,6 +244,24 @@ export class ConfigService {
     if (!from) {
       return null;
     }
+    return { to, from };
+  }
+
+  getEmbeddingFailureNotificationEmail(): EmbeddingFailureNotification | null {
+    const to = process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL?.trim() || '';
+    if (!to) {
+      return null;
+    }
+
+    const from =
+      process.env.EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM?.trim() ||
+      process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM?.trim() ||
+      '';
+
+    if (!from) {
+      return null;
+    }
+
     return { to, from };
   }
 

--- a/src/processor/processor.module.ts
+++ b/src/processor/processor.module.ts
@@ -1,4 +1,5 @@
 import { AudioModule } from '@libs/audio';
+import { EmailModule } from '@libs/email';
 import { forwardRef, Module } from '@nestjs/common';
 import { AiModule } from '../ai/ai.module';
 import { ArticlesModule } from '../articles/articles.module';
@@ -13,6 +14,7 @@ import { ProcessorService } from './processor.service';
     AiModule,
     ConfigModule,
     ProfilesModule,
+    EmailModule.forRoot(),
   ],
   providers: [ProcessorService],
   exports: [ProcessorService],

--- a/src/processor/processor.service.spec.ts
+++ b/src/processor/processor.service.spec.ts
@@ -1,0 +1,202 @@
+import { AudioJobService } from '@libs/audio';
+import { EmailService } from '@libs/email';
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { AiService } from '../ai/ai.service';
+import { DBArticle } from '../articles/article.entity';
+import { ArticlesService } from '../articles/articles.service';
+import { ConfigService } from '../config/config.service';
+import { ProfilesService } from '../profiles/profiles.service';
+import { FeedProfile } from '../shared/types/feed';
+import { ProcessorService } from './processor.service';
+
+describe('ProcessorService', () => {
+  let service: ProcessorService;
+  const mockArticlesService = mock<ArticlesService>();
+  const mockAiService = mock<AiService>();
+  const mockConfigService = mock<ConfigService>();
+  const mockProfilesService = mock<ProfilesService>();
+  const mockAudioJobService = mock<AudioJobService>();
+  const mockEmailService = mock<EmailService>();
+
+  const mockArticle: DBArticle = {
+    id: 'article-1',
+    url: 'https://example.com/article',
+    title: 'Test Article',
+    published_date: new Date('2024-01-01'),
+    feed_source: 'test-feed',
+    raw_content: 'Test content',
+    feed_profile: FeedProfile.DEFAULT,
+    created_at: new Date('2024-01-01'),
+  };
+
+  beforeEach(async () => {
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: ProcessorService,
+          useFactory: () =>
+            new ProcessorService(
+              mockArticlesService,
+              mockAiService,
+              mockConfigService,
+              mockProfilesService,
+              mockAudioJobService,
+              mockEmailService,
+            ),
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProcessorService>(ProcessorService);
+
+    mockProfilesService.getPromptsForProfile.mockReturnValue({
+      articleSummary: undefined,
+      impactRating: undefined,
+    });
+    mockConfigService.formatPrompt.mockImplementation((template) => template);
+    mockConfigService.getArticleSummaryPrompt.mockReturnValue('summary prompt');
+    mockArticlesService.getUnprocessedArticles.mockResolvedValue([mockArticle]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('processArticles - embedding failure isolation', () => {
+    it('should continue processing when embedding fails and save article without embedding', async () => {
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockRejectedValue(new Error('Embedding API error'));
+
+      const result = await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockAiService.callChat).toHaveBeenCalled();
+      expect(mockAiService.getEmbedding).toHaveBeenCalled();
+      expect(mockArticlesService.updateArticleProcessing).toHaveBeenCalledWith(
+        'article-1',
+        expect.stringContaining('Article summary'),
+        null,
+      );
+      expect(result.articlesProcessed).toBe(1);
+      expect(result.errors).toBe(1);
+    });
+
+    it('should send email notification when embedding fails and email config is set', async () => {
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockRejectedValue(new Error('Embedding API error'));
+      mockConfigService.getEmbeddingFailureNotificationEmail.mockReturnValue({
+        to: 'admin@example.com',
+        from: 'noreply@example.com',
+      });
+      mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockConfigService.getEmbeddingFailureNotificationEmail).toHaveBeenCalled();
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith({
+        from: 'noreply@example.com',
+        to: 'admin@example.com',
+        subject: 'Embedding Generation Failed',
+        text: expect.stringContaining('article-1'),
+      });
+    });
+
+    it('should log warning when embedding fails but email config is not set', async () => {
+      const loggerSpy = jest.spyOn(service['logger'], 'warn');
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockRejectedValue(new Error('Embedding API error'));
+      mockConfigService.getEmbeddingFailureNotificationEmail.mockReturnValue(null);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('EMBEDDING_FAILURE_NOTIFICATION_EMAIL'),
+      );
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should handle email send failure gracefully', async () => {
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockRejectedValue(new Error('Embedding API error'));
+      mockConfigService.getEmbeddingFailureNotificationEmail.mockReturnValue({
+        to: 'admin@example.com',
+        from: 'noreply@example.com',
+      });
+      mockEmailService.sendEmail.mockRejectedValue(new Error('Email send failed'));
+
+      const result = await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockArticlesService.updateArticleProcessing).toHaveBeenCalled();
+      expect(result.articlesProcessed).toBe(1);
+    });
+
+    it('should process multiple articles even if embedding fails for some', async () => {
+      const article2: DBArticle = {
+        ...mockArticle,
+        id: 'article-2',
+        title: 'Second Article',
+      };
+
+      mockArticlesService.getUnprocessedArticles.mockResolvedValue([mockArticle, article2]);
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding
+        .mockRejectedValueOnce(new Error('Embedding API error'))
+        .mockResolvedValueOnce([0.1, 0.2, 0.3]);
+
+      const result = await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockArticlesService.updateArticleProcessing).toHaveBeenCalledTimes(2);
+      expect(mockArticlesService.updateArticleProcessing).toHaveBeenNthCalledWith(
+        1,
+        'article-1',
+        expect.any(String),
+        null,
+      );
+      expect(mockArticlesService.updateArticleProcessing).toHaveBeenNthCalledWith(
+        2,
+        'article-2',
+        expect.any(String),
+        [0.1, 0.2, 0.3],
+      );
+      expect(result.articlesProcessed).toBe(2);
+      expect(result.errors).toBe(1);
+    });
+
+    it('should increment error count when embedding fails', async () => {
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockRejectedValue(new Error('Embedding API error'));
+
+      const result = await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(result.errors).toBe(1);
+    });
+
+    it('should handle null return from getEmbedding without throwing', async () => {
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue(null);
+      mockConfigService.getEmbeddingFailureNotificationEmail.mockReturnValue({
+        to: 'admin@example.com',
+        from: 'noreply@example.com',
+      });
+      mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+      const result = await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockAiService.getEmbedding).toHaveBeenCalled();
+      expect(mockArticlesService.updateArticleProcessing).toHaveBeenCalledWith(
+        'article-1',
+        expect.stringContaining('Article summary'),
+        null,
+      );
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith({
+        from: 'noreply@example.com',
+        to: 'admin@example.com',
+        subject: 'Embedding Generation Failed',
+        text: expect.stringContaining('Embedding returned null'),
+      });
+      expect(result.articlesProcessed).toBe(1);
+      expect(result.errors).toBe(1);
+    });
+  });
+});

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -1,4 +1,5 @@
 import { AudioJobService } from '@libs/audio';
+import { EmailService } from '@libs/email';
 import { Injectable, Logger } from '@nestjs/common';
 import { AiService } from '../ai/ai.service';
 import { ArticleCategory, DBArticle } from '../articles/article.entity';
@@ -18,7 +19,8 @@ export class ProcessorService {
     private readonly configService: ConfigService,
     private readonly profilesService: ProfilesService,
     private readonly audioJobService: AudioJobService,
-  ) {}
+    private readonly emailService: EmailService,
+  ) { }
 
   async processArticles(
     feedProfile: FeedProfile,
@@ -66,11 +68,11 @@ export class ProcessorService {
       try {
         const summaryPrompt = profilePrompts.articleSummary
           ? this.configService.formatPrompt(profilePrompts.articleSummary, {
-              article_content: article.raw_content.substring(0, 4000),
-            })
+            article_content: article.raw_content.substring(0, 4000),
+          })
           : this.configService.getArticleSummaryPrompt(
-              article.raw_content.substring(0, 4000),
-            );
+            article.raw_content.substring(0, 4000),
+          );
 
         const summary = await this.aiService.callChat(summaryPrompt);
 
@@ -84,12 +86,26 @@ export class ProcessorService {
 
         const finalSummary = `${summary}\n\nSource: [${article.title}](${article.url})`;
 
-        const embedding = await this.aiService.getEmbedding(finalSummary);
+        let embedding: number[] | null = null;
+        try {
+          embedding = await this.aiService.getEmbedding(finalSummary);
+        } catch (embeddingError) {
+          const errorMessage = embeddingError instanceof Error ? embeddingError.message : String(embeddingError);
+          this.logger.error(
+            `Embedding generation failed for article ${article.id} (${article.title}): ${errorMessage}`,
+          );
 
-        if (!embedding) {
-          console.log(`Skipping article ${article.id} due to embedding error.`);
           stats.errors++;
-          continue;
+          await this.notifyEmbeddingFailure(article, errorMessage);
+        }
+
+        if (!embedding && !stats.errors) {
+          this.logger.error(
+            `Embedding generation returned null for article ${article.id} (${article.title})`,
+          );
+
+          stats.errors++;
+          await this.notifyEmbeddingFailure(article, 'Embedding returned null');
         }
 
         await this.articlesService.updateArticleProcessing(
@@ -97,15 +113,16 @@ export class ProcessorService {
           finalSummary,
           embedding,
         );
+
         stats.articlesProcessed++;
         console.log(`Successfully processed article ID: ${article.id}`);
 
-        // Generate audio if flag is enabled
         if (generateAudio) {
           try {
             console.log(
               `Enqueuing audio generation for article ID: ${article.id}...`,
             );
+
             const jobInfo = await this.audioJobService.enqueueAudioJob({
               sourceType: 'article',
               sourceId: article.id,
@@ -114,6 +131,7 @@ export class ProcessorService {
                 ? new Date(article.published_date)
                 : new Date(),
             });
+
             console.log(`Audio generation job enqueued: ${jobInfo.jobId}`);
           } catch (audioError) {
             console.error(
@@ -136,6 +154,41 @@ export class ProcessorService {
     );
 
     return stats;
+  }
+
+  private async notifyEmbeddingFailure(article: DBArticle, errorMessage: string): Promise<void> {
+    const emailConfig = this.configService.getEmbeddingFailureNotificationEmail();
+
+    if (emailConfig) {
+      try {
+        await this.emailService.sendEmail({
+          from: emailConfig.from,
+          to: emailConfig.to,
+          subject: 'Embedding Generation Failed',
+          text: `Embedding generation failed for an article during processing.
+
+Details:
+- Article ID: ${article.id}
+- Article Title: ${article.title}
+- Article URL: ${article.url}
+- Error: ${errorMessage}
+- Timestamp: ${new Date().toISOString()}
+
+The article summary was successfully generated but embedding generation failed. The article processing will continue without embedding.`,
+        });
+
+        this.logger.log(`Embedding failure notification email sent to ${emailConfig.to} for article ${article.id}`);
+      } catch (emailError) {
+        this.logger.error(
+          `Failed to send embedding failure notification email for article ${article.id}:`,
+          emailError instanceof Error ? emailError.message : String(emailError),
+        );
+      }
+    } else {
+      this.logger.warn(
+        `Embedding generation failed for article ${article.id}, but EMBEDDING_FAILURE_NOTIFICATION_EMAIL (and EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM or ARTICLE_FAILURE_NOTIFICATION_EMAIL_FROM) is not configured.`,
+      );
+    }
   }
 
   async rateArticles(
@@ -186,8 +239,8 @@ export class ProcessorService {
       try {
         const ratingPrompt = profilePrompts.impactRating
           ? this.configService.formatPrompt(profilePrompts.impactRating, {
-              summary: article.processed_content,
-            })
+            summary: article.processed_content,
+          })
           : this.configService.getImpactRatingPrompt(article.processed_content);
 
         const ratingResponse = await this.aiService.callChat(ratingPrompt);


### PR DESCRIPTION
Implement graceful handling of embedding generation failures to prevent articles from being skipped when embedding fails. Articles are now saved without embeddings, and email notifications are sent for monitoring.

- Add EmailService integration and notifyEmbeddingFailure method
- Update updateArticleProcessing to accept null embeddings
- Add EMBEDDING_FAILURE_NOTIFICATION_EMAIL configuration support
- Add comprehensive tests for failure isolation scenarios