### PR TITLE
feat(articles): add external article submission endpoint for Telegram integration

### DIFF
--- a/.cursor/commands/bmad-portable-prompt.md
+++ b/.cursor/commands/bmad-portable-prompt.md
@@ -1,0 +1,8 @@
+I need a portable prompt for command /<command-name>.
+
+Please:
+1) resolve all referenced files,
+2) inline everything into ONE consolidated prompt,
+3) keep all hard constraints/rules/menus,
+4) do not summarize unless I ask,
+5) save only the final prompt in a single markdown code block in a file called portable-prompt-<command-name>.md.

--- a/.env.sample
+++ b/.env.sample
@@ -74,3 +74,11 @@ EMBEDDING_FAILURE_NOTIFICATION_EMAIL_FROM=
 # Set to 'false' or '0' to disable briefings generation
 # Set to 'true' or '1' to enable (default: enabled if not set)
 ENABLE_BRIEFINGS_GENERATION=true
+
+# External Article Submission (Telegram Bot Integration)
+# Comma-separated list of valid tokens for external API access
+# Example: EXTERNAL_API_TOKENS=token1,token2,token3
+EXTERNAL_API_TOKENS=
+
+# Enable/disable Telegram integration feature (default: true)
+TELEGRAM_INTEGRATION_ENABLED=true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,24 @@ services:
     networks:
       - meridian-network
 
+  # Node-RED for Telegram Bot Integration
+  nodered:
+    image: nodered/node-red:latest
+    container_name: meridiano-nodered-prod
+    restart: unless-stopped
+    ports:
+      - "1880:1880"
+    volumes:
+      - nodered_data:/data
+    environment:
+      - MERIDIANO_API_URL=http://meridian-backend:3005
+      # Telegram Bot token should be set via Node-RED credentials (not env var for security)
+      # EXTERNAL_API_TOKEN is configured in Node-RED flow settings
+    networks:
+      - meridian-network
+    depends_on:
+      - meridian-backend
+
   meridian-backend:
     build:
       context: .
@@ -44,6 +62,11 @@ services:
       MAILGUN_API_KEY: ${MAILGUN_API_KEY}
       MAILGUN_DOMAIN: ${MAILGUN_DOMAIN}
       CORS_ORIGINS: http://89.116.214.113
+      # External Article Submission (Telegram Bot Integration)
+      # Comma-separated list of valid tokens - SET IN PRODUCTION ENVIRONMENT
+      EXTERNAL_API_TOKENS: ${EXTERNAL_API_TOKENS:-}
+      # Disable Telegram integration initially in production (enable after testing)
+      TELEGRAM_INTEGRATION_ENABLED: ${TELEGRAM_INTEGRATION_ENABLED:-false}
     networks:
       - meridian-network
       - goal-tracker-network
@@ -79,6 +102,8 @@ services:
 volumes:
   redis_data:
     name: meridiano-redis-data-prod
+  nodered_data:
+    name: meridiano-nodered-data-prod
 
 networks:
   meridian-network:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,78 @@
+version: '3.8'
+
+# Staging environment configuration for Meridiano
+# This file extends the base docker-compose.yml with staging-specific settings
+
+services:
+  redis:
+    container_name: meridiano-redis-staging
+    environment:
+      # Staging-specific Redis config
+    networks:
+      - meridiano-network
+
+  # Node-RED for Telegram Bot Integration (Staging)
+  nodered:
+    image: nodered/node-red:latest
+    container_name: meridiano-nodered-staging
+    restart: unless-stopped
+    ports:
+      - "1880:1880"
+    volumes:
+      - nodered_staging_data:/data
+    environment:
+      - MERIDIANO_API_URL=http://api:3000
+      # Telegram Bot token should be set via Node-RED credentials (not env var for security)
+      # EXTERNAL_API_TOKEN is configured in Node-RED flow settings
+    networks:
+      - meridiano-network
+    depends_on:
+      - api
+
+  api:
+    container_name: meridian-backend-staging
+    environment:
+      NODE_ENV: staging
+      PORT: 3005
+      # Staging database config (override with staging-specific values)
+      DATABASE_HOST: ${DATABASE_HOST}
+      DATABASE_PORT: 5432
+      DATABASE_USER: ${DATABASE_USER}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      DATABASE_NAME: ${DATABASE_NAME:-meridian_staging}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      # AI API Keys
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY}
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY}
+      # Mailgun API Keys
+      MAILGUN_API_KEY: ${MAILGUN_API_KEY}
+      MAILGUN_DOMAIN: ${MAILGUN_DOMAIN}
+      # CORS - staging frontend URL
+      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000}
+      # External Article Submission (Telegram Bot Integration)
+      # Comma-separated list of valid tokens for staging
+      EXTERNAL_API_TOKENS: ${EXTERNAL_API_TOKENS:-}
+      # Enable Telegram integration in staging for testing
+      TELEGRAM_INTEGRATION_ENABLED: ${TELEGRAM_INTEGRATION_ENABLED:-true}
+    networks:
+      - meridiano-network
+
+  meridian-frontend:
+    container_name: meridian-frontend-staging
+    environment:
+      NODE_ENV: staging
+      PORT: 3006
+      NEXT_PUBLIC_API_BASE_URL: http://localhost:3005/meridian-api
+    networks:
+      - meridiano-network
+
+volumes:
+  nodered_staging_data:
+    name: meridiano-nodered-data-staging
+
+networks:
+  meridiano-network:
+    name: meridiano-network
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,11 +49,34 @@ services:
     networks:
       - meridiano-network
 
+  # Node-RED for Telegram Bot Integration
+  nodered:
+    image: nodered/node-red:latest
+    container_name: meridiano-nodered-${COMPOSE_PROFILE:-local}
+    restart: unless-stopped
+    profiles:
+      - local
+      - staging
+      - production
+    ports:
+      - "1880:1880"
+    volumes:
+      - nodered_data:/data
+    environment:
+      - MERIDIANO_API_URL=http://api:3000
+      # Note: Set EXTERNAL_API_TOKEN via Node-RED flow settings or secrets
+    networks:
+      - meridiano-network
+    depends_on:
+      - api
+
 volumes:
   postgres_data:
     name: meridiano-postgres-data-${COMPOSE_PROFILE:-local}
   redis_data:
     name: meridiano-redis-data-${COMPOSE_PROFILE:-local}
+  nodered_data:
+    name: meridiano-nodered-data-${COMPOSE_PROFILE:-local}
 
 networks:
   meridiano-network:

--- a/docs/nodered/SETUP.md
+++ b/docs/nodered/SETUP.md
@@ -1,0 +1,196 @@
+# Telegram Article Submission - Node-RED Flow Setup
+
+This document provides instructions for setting up the Node-RED flow for the Telegram Article Submission feature.
+
+## Prerequisites
+
+1. **Node-RED** installed (locally or on Raspberry Pi)
+2. **Telegram Bot** created via [BotFather](https://t.me/BotFather)
+3. **Meridiano API** running with the external endpoint configured
+
+## Installation
+
+### 1. Install Node-RED
+
+```bash
+# Install Node-RED globally (use pnpm; npm -g also works for global installs)
+pnpm add -g node-red
+
+# Or use Docker
+docker run -it -p 1880:1880 -v node_red_data:/data --name my-nodered nodered/node-red:latest
+```
+
+### 2. Install Telegram Nodes
+
+In Node-RED, go to **Manage Palette** → **Install** and search for:
+- `node-red-contrib-telegrambot` - For Telegram bot integration
+
+### 3. Import the Flow
+
+1. Open Node-RED (http://localhost:1880)
+2. Click the menu (☰) → **Import** → **Clipboard**
+3. Copy the contents of [`telegram-article-submission-flow.json`](telegram-article-submission-flow.json)
+4. Paste into the import dialog and click **Import**
+
+> **Important:** The flow JSON does not include credentials. You must configure them after importing (see next section).
+
+### 4. Configure Telegram Bot Credentials
+
+1. Double-click the **Telegram Bot** node
+2. Click the edit button (pencil icon) next to Bot
+3. Enter your Telegram Bot API Token (from BotFather)
+4. Click **Add**
+
+### 5. Configure Environment Variables
+
+Set the following values in Node-RED flow settings:
+
+1. Click the **Menu** → **Settings** → **Flow Settings**
+2. Add the following environment variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `MERIDIANO_API_URL` | Meridiano API base URL | `http://localhost:3000` |
+| `EXTERNAL_API_TOKEN` | External API token (from Meridiano env) | `tok_your_token_here` |
+
+Or set them in the `Prepare API Request` function node directly.
+
+## Telegram Bot Setup
+
+### Creating the Bot
+
+1. Open Telegram and start a chat with [BotFather](https://t.me/BotFather)
+2. Send `/newbot` command
+3. Follow the prompts to create your bot
+4. Copy the bot API token
+
+### Configuring Bot Commands
+
+Send the following commands to BotFather:
+
+```
+/setcommands
+```
+
+Then enter:
+
+```
+start - Get started with the bot
+help - Get help on how to use the bot
+```
+
+## Testing the Integration
+
+### Test Message Format
+
+Send the following message to your Telegram bot:
+
+```
+URL: https://addyosmani.com/blog/self-improving-agents/
+Feed: technology
+```
+
+### Expected Response
+
+On success:
+```
+✅ Article submitted successfully!
+
+Article submitted successfully and queued for processing
+
+🆔 Job ID: 550e8400-e29b-41d4-a716-446655440000
+📄 Article ID: article-uuid-here
+
+⏳ Your article is being processed and will be available soon.
+```
+
+On error (invalid URL):
+```
+❌ The URL you provided doesn't seem valid. Please check and try again.
+```
+
+## Node-RED Flow Overview
+
+```
+┌─────────────────┐     ┌──────────────────┐
+│  Telegram Bot   │────▶│   Parse Message   │
+│   (Receiver)    │     │   (Option B)      │
+└─────────────────┘     └────────┬─────────┘
+                                  │
+                    ┌─────────────┴─────────────┐
+                    │                           │
+                    ▼                           ▼
+          ┌──────────────────┐      ┌─────────────────────┐
+          │  Validation      │      │    API Request      │
+          │  Error Response  │      │  (Meridiano API)    │
+          └──────────────────┘      └──────────┬──────────┘
+                                                │
+                                   ┌────────────┴────────────┐
+                                   │                         │
+                                   ▼                         ▼
+                         ┌──────────────────┐    ┌──────────────────┐
+                         │  Success Handler │    │   Error Handler  │
+                         └────────┬─────────┘    └────────┬─────────┘
+                                  │                       │
+                                  └───────────┬───────────┘
+                                              │
+                                              ▼
+                                    ┌──────────────────┐
+                                    │  Telegram Bot    │
+                                    │    (Sender)      │
+                                    └──────────────────┘
+```
+
+## Troubleshooting
+
+### Bot not responding
+
+1. Check that the bot token is correct in the Telegram Receiver node
+2. Verify the bot is started (send `/start` to the bot)
+
+### API requests failing
+
+1. Verify `MERIDIANO_API_URL` is correct
+2. Check that `EXTERNAL_API_TOKEN` is valid
+3. Ensure Meridiano API is running
+
+### Rate limiting
+
+- The API allows 10 requests per minute per token
+- If you hit the limit, wait 60 seconds before retrying
+
+## Security Considerations
+
+1. **Never commit tokens or credentials** to version control
+2. The flow JSON intentionally excludes credentials - always configure them through the Node-RED UI after importing
+3. Use environment variables for sensitive data
+4. Consider setting up a webhook with a secret token for production
+5. The Telegram bot token should be stored in Node-RED credentials
+
+## Docker Compose Setup (Optional)
+
+For running Node-RED alongside Meridiano:
+
+```yaml
+version: '3.8'
+services:
+  nodered:
+    image: nodered/node-red:latest
+    ports:
+      - "1880:1880"
+    volumes:
+      - nodered-data:/data
+    environment:
+      - MERIDIANO_API_URL=http://api:3000
+      # Note: Tokens should be set via Node-RED UI or secrets management
+
+volumes:
+  nodered-data:
+```
+
+## Support
+
+For issues related to:
+- **Meridiano API**: Check the API logs
+- **Node-RED flow**: Check Node-RED debug panel
+- **Telegram Bot**: Check BotFather bot settings

--- a/docs/nodered/message-parser.test.js
+++ b/docs/nodered/message-parser.test.js
@@ -1,0 +1,482 @@
+/**
+ * Node-RED Message Parsing Tests
+ * 
+ * Tests for the Telegram message parsing function in the Node-RED flow.
+ * This tests the "Parse Message (Option B)" function node.
+ * 
+ * Run with: node docs/nodered/message-parser.test.js
+ */
+
+const VALID_FEEDS = ['default', 'technology', 'politics', 'business', 'health', 'science', 'brasil', 'teclas'];
+
+// Extract the parsing logic from the Node-RED flow
+function parseMessage(messageText, chatId = '123456789', messageId = '456', username = 'testuser') {
+  // Store chat info for later
+  const msg = {
+    chatId: chatId,
+    messageId: messageId,
+    username: username
+  };
+
+  // If it's a command, ignore it
+  if (messageText && messageText.startsWith('/')) {
+    msg.payload = {
+      isCommand: true,
+      command: messageText.split(' ')[0]
+    };
+    return { msg, isValid: false, isCommand: true };
+  }
+
+  const lines = (messageText || '').split('\n');
+
+  // Initialize variables
+  let url = null;
+  let feedProfile = null;
+  let note = null;
+  const errors = [];
+
+  // Parse each line for key-value pairs
+  lines.forEach(line => {
+    const trimmedLine = line.trim();
+
+    // Match URL: label (case-insensitive)
+    const urlMatch = trimmedLine.match(/^URL:\s*(.+)$/i);
+    if (urlMatch) {
+      url = urlMatch[1].trim();
+    }
+
+    // Match Feed: label (case-insensitive)
+    const feedMatch = trimmedLine.match(/^Feed:\s*(.+)$/i);
+    if (feedMatch) {
+      feedProfile = feedMatch[1].trim().toLowerCase();
+    }
+
+    // Match Note: label (optional, case-insensitive)
+    const noteMatch = trimmedLine.match(/^Note:\s*(.+)$/i);
+    if (noteMatch) {
+      note = noteMatch[1].trim();
+    }
+  });
+
+  // Validation
+  if (!url) {
+    errors.push("❌ URL is required. Please include a URL: line.");
+  }
+
+  if (!feedProfile) {
+    errors.push("❌ Feed profile is required. Please include a Feed: line.");
+  }
+
+  // URL format validation
+  if (url && !url.match(/^https?:\/\/.+/i)) {
+    errors.push("❌ The URL doesn't appear to be valid. Please check and try again.");
+  }
+
+  // Feed profile validation
+  if (feedProfile && !VALID_FEEDS.includes(feedProfile)) {
+    errors.push(`❌ Feed '${feedProfile}' doesn't exist. Available feeds: ${VALID_FEEDS.join(', ')}`);
+  }
+
+  // Set payload for next node
+  if (errors.length > 0) {
+    msg.payload = {
+      url: url,
+      feedProfile: feedProfile,
+      note: note,
+      errors: errors,
+      isValid: false
+    };
+    return { msg, isValid: false, errors };
+  }
+
+  msg.payload = {
+    url: url,
+    feedProfile: feedProfile,
+    note: note,
+    errors: null,
+    isValid: true,
+    metadata: {
+      chatId: chatId.toString(),
+      messageId: messageId.toString(),
+      username: username || undefined
+    }
+  };
+
+  return { msg, isValid: true };
+}
+
+// Test utilities
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ❌ ${name}`);
+    console.log(`     ${error.message}`);
+    failed++;
+  }
+}
+
+function assertEqual(actual, expected, message = '') {
+  if (actual !== expected) {
+    throw new Error(`${message}\n       Expected: ${expected}\n       Actual: ${actual}`);
+  }
+}
+
+function assertTrue(actual, message = '') {
+  if (actual !== true) {
+    throw new Error(`${message}\n       Expected: true\n       Actual: ${actual}`);
+  }
+}
+
+function assertFalse(actual, message = '') {
+  if (actual !== false) {
+    throw new Error(`${message}\n       Expected: false\n       Actual: ${actual}`);
+  }
+}
+
+function assertContains(array, item, message = '') {
+  if (!array.includes(item)) {
+    throw new Error(`${message}\n       Expected array to contain: ${item}\n       Array: ${array.join(', ')}`);
+  }
+}
+
+console.log('\n========================================');
+console.log('Node-RED Message Parser Tests');
+console.log('========================================\n');
+
+// ==========================================
+// VALID MESSAGE FORMATS
+// ==========================================
+console.log('📝 Valid Message Formats:');
+
+test('Valid Format 1 - Basic URL and Feed', () => {
+  const result = parseMessage(
+    'URL: https://addyosmani.com/blog/self-improving-agents/\nFeed: technology'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://addyosmani.com/blog/self-improving-agents/');
+  assertEqual(result.msg.payload.feedProfile, 'technology');
+  assertEqual(result.msg.payload.note, null);
+});
+
+test('Valid Format 2 - With extra whitespace', () => {
+  const result = parseMessage(
+    'URL:   https://example.com/article\nFeed:   technology'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com/article');
+  assertEqual(result.msg.payload.feedProfile, 'technology');
+});
+
+test('Valid Format 3 - Reverse order (Feed before URL)', () => {
+  const result = parseMessage(
+    'Feed: technology\nURL: https://example.com/design-article'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com/design-article');
+  assertEqual(result.msg.payload.feedProfile, 'technology');
+});
+
+test('Valid Format 4 - With optional description (Note field)', () => {
+  const result = parseMessage(
+    'URL: https://example.com/article\nFeed: technology\nNote: Great article about AI agents'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com/article');
+  assertEqual(result.msg.payload.feedProfile, 'technology');
+  assertEqual(result.msg.payload.note, 'Great article about AI agents');
+});
+
+test('Valid Format 5 - Mixed case labels (url:, feed:)', () => {
+  const result = parseMessage(
+    'url: https://example.com/article\nfeed: technology'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com/article');
+  assertEqual(result.msg.payload.feedProfile, 'technology');
+});
+
+test('Valid Format 6 - Mixed case labels (Url:, Feed:)', () => {
+  const result = parseMessage(
+    'Url: https://example.com/article\nFeed: business'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.feedProfile, 'business');
+});
+
+test('Valid Format 7 - Feed with uppercase stored as lowercase', () => {
+  const result = parseMessage(
+    'URL: https://example.com/article\nFeed: TECHNOLOGY'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.feedProfile, 'technology'); // Should be lowercase
+});
+
+test('Valid Format 8 - Feed with mixed case', () => {
+  const result = parseMessage(
+    'URL: https://example.com/article\nFeed: TeChNoLoGy'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.feedProfile, 'technology'); // Should be normalized to lowercase
+});
+
+test('Valid Format 9 - All valid feeds', () => {
+  VALID_FEEDS.forEach(feed => {
+    const result = parseMessage(`URL: https://example.com/article\nFeed: ${feed}`);
+    assertTrue(result.isValid, `Feed "${feed}" should be valid`);
+  });
+});
+
+test('Valid Format 10 - URL with query parameters', () => {
+  const result = parseMessage(
+    'URL: https://example.com/article?ref=twitter&utm_source=social\nFeed: technology'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com/article?ref=twitter&utm_source=social');
+});
+
+test('Valid Format 11 - URL with port number', () => {
+  const result = parseMessage(
+    'URL: https://example.com:8080/article\nFeed: technology'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com:8080/article');
+});
+
+test('Valid Format 12 - URL with path and hash', () => {
+  const result = parseMessage(
+    'URL: https://example.com/path/to/article#section\nFeed: technology'
+  );
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com/path/to/article#section');
+});
+
+// ==========================================
+// INVALID MESSAGE FORMATS
+// ==========================================
+console.log('\n📝 Invalid Message Formats:');
+
+test('Invalid Format 1 - Missing URL', () => {
+  const result = parseMessage('Feed: technology');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ URL is required. Please include a URL: line.");
+});
+
+test('Invalid Format 2 - Missing Feed', () => {
+  const result = parseMessage('URL: https://example.com/article');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ Feed profile is required. Please include a Feed: line.");
+});
+
+test('Invalid Format 3 - Missing both URL and Feed', () => {
+  const result = parseMessage('Note: Some note');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ URL is required. Please include a URL: line.");
+  assertContains(result.errors, "❌ Feed profile is required. Please include a Feed: line.");
+});
+
+test('Invalid Format 4 - Invalid URL (not a valid URL)', () => {
+  const result = parseMessage('URL: not-a-valid-url\nFeed: technology');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ The URL doesn't appear to be valid. Please check and try again.");
+});
+
+test('Invalid Format 5 - Invalid URL (just domain)', () => {
+  const result = parseMessage('URL: example.com\nFeed: technology');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ The URL doesn't appear to be valid. Please check and try again.");
+});
+
+test('Invalid Format 6 - Invalid URL (http without slashes)', () => {
+  const result = parseMessage('URL: http:example.com\nFeed: technology');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ The URL doesn't appear to be valid. Please check and try again.");
+});
+
+test('Invalid Format 7 - Non-existent feed', () => {
+  const result = parseMessage('URL: https://example.com/article\nFeed: nonexistent-feed');
+  assertFalse(result.isValid);
+  // Check that the error message contains the feed name and valid feeds list
+  const errorMessage = result.errors.find(e => e.includes('nonexistent-feed'));
+  assertTrue(errorMessage !== undefined, 'Should have error about invalid feed');
+  assertTrue(errorMessage.includes('default, technology, politics, business, health, science, brasil, teclas'), 'Should list valid feeds');
+});
+
+test('Invalid Format 8 - Empty message', () => {
+  const result = parseMessage('');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ URL is required. Please include a URL: line.");
+  assertContains(result.errors, "❌ Feed profile is required. Please include a Feed: line.");
+});
+
+test('Invalid Format 9 - Whitespace only message', () => {
+  const result = parseMessage('   \n\n   ');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ URL is required. Please include a URL: line.");
+  assertContains(result.errors, "❌ Feed profile is required. Please include a Feed: line.");
+});
+
+test('Invalid Format 10 - Invalid URL + missing Feed', () => {
+  const result = parseMessage('URL: invalid-url');
+  assertFalse(result.isValid);
+  assertContains(result.errors, "❌ Feed profile is required. Please include a Feed: line.");
+});
+
+test('Invalid Format 11 - Invalid URL + invalid Feed', () => {
+  const result = parseMessage('URL: not-a-url\nFeed: invalid');
+  assertFalse(result.isValid);
+  // Should have both URL and feed errors
+  const hasUrlError = result.errors.some(e => e.includes("URL doesn't appear to be valid"));
+  const hasFeedError = result.errors.some(e => e.includes("Feed 'invalid' doesn't exist"));
+  assertTrue(hasUrlError, 'Should have URL validation error');
+  assertTrue(hasFeedError, 'Should have feed validation error');
+});
+
+// ==========================================
+// PARSING RULES
+// ==========================================
+console.log('\n📝 Parsing Rules:');
+
+test('Rule 1 - Case Insensitivity (URL: lowercase)', () => {
+  const result = parseMessage('url: https://example.com\nfeed: technology');
+  assertTrue(result.isValid);
+});
+
+test('Rule 2 - Case Insensitivity (URL: uppercase)', () => {
+  const result = parseMessage('URL: https://example.com\nFEED: technology');
+  assertTrue(result.isValid);
+});
+
+test('Rule 3 - Case Insensitivity (mixed)', () => {
+  const result = parseMessage('Url: https://example.com\nFeed: technology');
+  assertTrue(result.isValid);
+});
+
+test('Rule 4 - Whitespace Tolerance (spaces after colon)', () => {
+  const result = parseMessage('URL:   https://example.com\nFeed:   technology');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com');
+});
+
+test('Rule 5 - Whitespace Tolerance (tabs after colon)', () => {
+  const result = parseMessage('URL:\thttps://example.com\nFeed:\ttechnology');
+  assertTrue(result.isValid);
+});
+
+test('Rule 6 - Whitespace Tolerance (trailing whitespace)', () => {
+  const result = parseMessage('URL: https://example.com   \nFeed: technology   ');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com');
+});
+
+test('Rule 7 - Line Order (URL first)', () => {
+  const result = parseMessage('URL: https://example.com\nFeed: technology');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com');
+});
+
+test('Rule 8 - Line Order (Feed first)', () => {
+  const result = parseMessage('Feed: technology\nURL: https://example.com');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.url, 'https://example.com');
+});
+
+test('Rule 9 - Line Order (Note first)', () => {
+  const result = parseMessage('Note: My note\nURL: https://example.com\nFeed: technology');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.note, 'My note');
+});
+
+test('Rule 10 - Optional Note field (not present)', () => {
+  const result = parseMessage('URL: https://example.com\nFeed: technology');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.note, null);
+});
+
+test('Rule 11 - Optional Note field (present)', () => {
+  const result = parseMessage('URL: https://example.com\nFeed: technology\nNote: This is a note');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.note, 'This is a note');
+});
+
+test('Rule 12 - HTTP URL (valid)', () => {
+  const result = parseMessage('URL: http://example.com/article\nFeed: technology');
+  assertTrue(result.isValid);
+});
+
+test('Rule 13 - HTTPS URL (valid)', () => {
+  const result = parseMessage('URL: https://example.com/article\nFeed: technology');
+  assertTrue(result.isValid);
+});
+
+test('Rule 14 - Feed validation (all valid feeds)', () => {
+  const allFeeds = ['default', 'technology', 'politics', 'business', 'health', 'science', 'brasil', 'teclas'];
+  allFeeds.forEach(feed => {
+    const result = parseMessage(`URL: https://example.com\nFeed: ${feed}`);
+    assertTrue(result.isValid, `Feed "${feed}" should be valid`);
+  });
+});
+
+// ==========================================
+// METADATA TESTS
+// ==========================================
+console.log('\n📝 Metadata Tests:');
+
+test('Metadata - Includes chatId', () => {
+  const result = parseMessage('URL: https://example.com\nFeed: technology', '123456');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.metadata.chatId, '123456');
+});
+
+test('Metadata - Includes messageId', () => {
+  const result = parseMessage('URL: https://example.com\nFeed: technology', '123456', '789');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.metadata.messageId, '789');
+});
+
+test('Metadata - Includes username when provided', () => {
+  const result = parseMessage('URL: https://example.com\nFeed: technology', '123456', '789', 'testuser');
+  assertTrue(result.isValid);
+  assertEqual(result.msg.payload.metadata.username, 'testuser');
+});
+
+// ==========================================
+// COMMAND HANDLING
+// ==========================================
+console.log('\n📝 Command Handling:');
+
+test('Command - /start is detected', () => {
+  const result = parseMessage('/start', '123456');
+  assertTrue(result.isCommand);
+  assertEqual(result.msg.payload.command, '/start');
+});
+
+test('Command - /help is detected', () => {
+  const result = parseMessage('/help', '123456');
+  assertTrue(result.isCommand);
+  assertEqual(result.msg.payload.command, '/help');
+});
+
+test('Command - /submit is detected', () => {
+  const result = parseMessage('/submit https://example.com technology', '123456');
+  assertTrue(result.isCommand);
+  assertEqual(result.msg.payload.command, '/submit');
+});
+
+// ==========================================
+// SUMMARY
+// ==========================================
+console.log('\n========================================');
+console.log(`Test Results: ${passed} passed, ${failed} failed`);
+console.log('========================================\n');
+
+if (failed > 0) {
+  process.exit(1);
+}
+
+console.log('All tests passed! ✅\n');

--- a/docs/nodered/telegram-article-submission-flow.json
+++ b/docs/nodered/telegram-article-submission-flow.json
@@ -1,0 +1,179 @@
+{
+  "id": "telegram-article-submission-flow",
+  "label": "Telegram Article Submission",
+  "nodes": [
+    {
+      "id": "telegram-receiver",
+      "type": "telegram receiver",
+      "z": "telegram-article-submission-flow",
+      "name": "Telegram Bot",
+      "bot": "telegram-bot-config",
+      "saveDataDir": "",
+      "filterCommands": false,
+      "x": 100,
+      "y": 200,
+      "wires": [
+        ["message-parser"]
+      ]
+    },
+    {
+      "id": "message-parser",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Parse Message (Option B)",
+      "func": "// Message parsing function for Option B (Structured Format)\n// Format:\n// URL: https://example.com/article\n// Feed: technology\n// Note: Optional description\n\nconst messageText = msg.payload.content || msg.payload.message.text;\nconst chatId = msg.payload.chatId || msg.payload.message.chat.id;\nconst messageId = msg.payload.messageId || msg.payload.message.message_id;\nconst username = msg.payload.from?.username || msg.payload.message?.from?.username;\n\n// Store chat info for later\nmsg.chatId = chatId;\nmsg.messageId = messageId;\nmsg.username = username;\n\n// If it's a command, ignore it\nif (msg.payload.content && msg.payload.content.startsWith('/')) {\n  msg.payload = {\n    isCommand: true,\n    command: msg.payload.content.split(' ')[0]\n  };\n  return [null, msg];\n}\n\nconst lines = (messageText || '').split('\\n');\n\n// Initialize variables\nlet url = null;\nlet feedProfile = null;\nlet note = null;\nconst errors = [];\n\n// Parse each line for key-value pairs\nlines.forEach(line => {\n  const trimmedLine = line.trim();\n\n  // Match URL: label (case-insensitive)\n  const urlMatch = trimmedLine.match(/^URL:\\s*(.+)$/i);\n  if (urlMatch) {\n    url = urlMatch[1].trim();\n  }\n\n  // Match Feed: label (case-insensitive)\n  const feedMatch = trimmedLine.match(/^Feed:\\s*(.+)$/i);\n  if (feedMatch) {\n    feedProfile = feedMatch[1].trim().toLowerCase();\n  }\n\n  // Match Note: label (optional, case-insensitive)\n  const noteMatch = trimmedLine.match(/^Note:\\s*(.+)$/i);\n  if (noteMatch) {\n    note = noteMatch[1].trim();\n  }\n});\n\n// Validation\nif (!url) {\n  errors.push(\"❌ URL is required. Please include a URL: line.\");\n}\n\nif (!feedProfile) {\n  errors.push(\"❌ Feed profile is required. Please include a Feed: line.\");\n}\n\n// URL format validation\nif (url && !url.match(/^https?:\\/\\/.+/i)) {\n  errors.push(\"❌ The URL doesn't appear to be valid. Please check and try again.\");\n}\n\n// Feed profile validation\nconst validFeeds = ['default', 'technology', 'politics', 'business', 'health', 'science', 'brasil', 'teclas'];\nif (feedProfile && !validFeeds.includes(feedProfile)) {\n  errors.push(`❌ Feed '${feedProfile}' doesn't exist. Available feeds: ${validFeeds.join(', ')}`);\n}\n\n// Set payload for next node\nif (errors.length > 0) {\n  msg.payload = {\n    url: url,\n    feedProfile: feedProfile,\n    note: note,\n    errors: errors,\n    isValid: false\n  };\n  return [null, msg];\n}\n\nmsg.payload = {\n  url: url,\n  feedProfile: feedProfile,\n  note: note,\n  errors: null,\n  isValid: true,\n  metadata: {\n    chatId: chatId.toString(),\n    messageId: messageId.toString(),\n    username: username || undefined\n  }\n};\n\nreturn [msg, null];\n",
+      "outputs": 2,
+      "x": 280,
+      "y": 200,
+      "wires": [
+        ["api-request"], ["validation-error"]
+      ]
+    },
+    {
+      "id": "validation-error",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Format Validation Error",
+      "func": "// Format validation errors for Telegram\nconst errors = msg.payload.errors || [];\nlet errorMessage = \"❌ Submission failed:\\n\\n\";\n\nerrors.forEach(err => {\n  errorMessage += err + \"\\n\";\n});\n\nerrorMessage += \"\\n📝 Use this format:\\nURL: https://example.com\\nFeed: technology\";\n\nmsg.payload = {\n  chatId: msg.chatId,\n  type: \"message\",\n  content: errorMessage\n};\n\nreturn msg;",
+      "x": 500,
+      "y": 320,
+      "wires": [
+        ["telegram-sender"]
+      ]
+    },
+    {
+      "id": "api-request",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Prepare API Request",
+      "func": "// Prepare the API request payload\nconst payload = msg.payload;\n\nmsg.url = flow.get('MERIDIANO_API_URL') || 'http://localhost:3000/api/articles/external';\nmsg.method = 'POST';\nmsg.headers = {\n  'Content-Type': 'application/json',\n  'X-External-Token': flow.get('EXTERNAL_API_TOKEN') || process.env.EXTERNAL_API_TOKEN\n};\n\nmsg.payload = {\n  url: payload.url,\n  feedProfile: payload.feedProfile,\n  source: 'telegram',\n  metadata: payload.metadata\n};\n\n// If there's a note, add it to metadata\nif (payload.note) {\n  msg.payload.metadata.note = payload.note;\n}\n\nreturn msg;",
+      "x": 500,
+      "y": 200,
+      "wires": [
+        ["http-request"]
+      ]
+    },
+    {
+      "id": "http-request",
+      "type": "http request",
+      "z": "telegram-article-submission-flow",
+      "name": "Submit to Meridiano API",
+      "method": "POST",
+      "ret": "obj",
+      "paytoqs": "ignore",
+      "url": "",
+      "tls": "",
+      "persist": false,
+      "proxy": "",
+      "insecureHTTPParser": false,
+      "authType": "none",
+      "senderr": true,
+      "x": 720,
+      "y": 200,
+      "wires": [
+        ["api-response-handler"]
+      ]
+    },
+    {
+      "id": "api-response-handler",
+      "type": "switch",
+      "z": "telegram-article-submission-flow",
+      "name": "Check Response Status",
+      "property": "statusCode",
+      "propertyType": "msg",
+      "rules": [
+        {
+          "t": "eq",
+          "v": "201",
+          "vt": "str"
+        },
+        {
+          "t": "eq",
+          "v": "200",
+          "vt": "str"
+        },
+        {
+          "t": "else"
+        }
+      ],
+      "checkall": "false",
+      "repair": false,
+      "x": 920,
+      "y": 200,
+      "wires": [
+        ["success-handler"], ["success-handler"], ["error-handler"]
+      ]
+    },
+    {
+      "id": "success-handler",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Format Success Response",
+      "func": "// Format success message for Telegram\nconst response = msg.payload;\n\nlet successMessage = \"✅ Article submitted successfully!\\n\\n\";\n\nif (response.message) {\n  successMessage += response.message + \"\\n\\n\";\n}\n\nif (response.jobId) {\n  successMessage += `🆔 Job ID: \\`${response.jobId}\\`\\n`;\n}\n\nif (response.articleId) {\n  successMessage += `📄 Article ID: \\`${response.articleId}\\`\\n`;\n}\n\nsuccessMessage += \"\\n⏳ Your article is being processed and will be available soon.\";\n\nmsg.payload = {\n  chatId: msg.chatId,\n  type: \"message\",\n  content: successMessage\n};\n\nreturn msg;",
+      "x": 1120,
+      "y": 160,
+      "wires": [
+        ["telegram-sender"]
+      ]
+    },
+    {
+      "id": "error-handler",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Format Error Response",
+      "func": "// Format error message for Telegram based on error code\nconst response = msg.payload;\nconst statusCode = msg.statusCode;\n\n// Error message formatting based on error codes\nconst errorMessages = {\n  INVALID_URL: \"❌ The URL you provided doesn't seem valid. Please check and try again.\",\n  INVALID_FEED_PROFILE: \"❌ Invalid feed profile. Use one of: default, technology, politics, business, health, science, brasil, teclas\",\n  UNAUTHORIZED: \"⚠️ Authentication error. Please contact support.\",\n  RATE_LIMIT_EXCEEDED: \"⏳ You're submitting too fast. Please wait a minute before trying again.\",\n  ARTICLE_EXISTS: \"ℹ️ This article has already been submitted before.\",\n  SCRAPE_FAILED: \"❌ Couldn't access the article. Is the URL correct and accessible?\",\n  INTERNAL_ERROR: \"🔥 Something went wrong on our end. Please try again later.\"\n};\n\n// Try to extract error code from response\nlet errorCode = 'INTERNAL_ERROR';\nlet errorMessage = 'An error occurred. Please try again later.';\n\nif (response && response.error && response.error.code) {\n  errorCode = response.error.code;\n  errorMessage = errorMessages[errorCode] || response.error.message || errorMessages.INTERNAL_ERROR;\n} else if (statusCode === 401) {\n  errorCode = 'UNAUTHORIZED';\n  errorMessage = errorMessages.UNAUTHORIZED;\n} else if (statusCode === 429) {\n  errorCode = 'RATE_LIMIT_EXCEEDED';\n  errorMessage = errorMessages.RATE_LIMIT_EXCEEDED;\n} else if (statusCode === 409) {\n  errorCode = 'ARTICLE_EXISTS';\n  errorMessage = errorMessages.ARTICLE_EXISTS;\n} else if (statusCode === 502 || statusCode === 503) {\n  errorCode = 'SCRAPE_FAILED';\n  errorMessage = errorMessages.SCRAPE_FAILED;\n}\n\nmsg.payload = {\n  chatId: msg.chatId,\n  type: \"message\",\n  content: errorMessage\n};\n\nreturn msg;",
+      "x": 1120,
+      "y": 260,
+      "wires": [
+        ["telegram-sender"]
+      ]
+    },
+    {
+      "id": "telegram-sender",
+      "type": "telegram sender",
+      "z": "telegram-article-submission-flow",
+      "name": "Send Reply",
+      "bot": "telegram-bot-config",
+      "x": 1320,
+      "y": 200,
+      "wires": [
+        []
+      ]
+    },
+    {
+      "id": "help-command",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Help Command Handler",
+      "func": "// Handle /help command\nconst helpMessage = `📚 *Article Submission Bot Help*\\n\\n` +\n  `Send me an article to add it to your feed. Use this format:\\n\\n` +\n  `\\`\\`\\`\\n` +\n  `URL: https://example.com/article\\n` +\n  `Feed: technology\\n` +\n  `Note: Optional description\\n` +\n  `\\`\\`\\`\\n\\n` +\n  `*Available Feeds:*\\n` +\n  `• default\\n` +\n  `• technology\\n` +\n  `• politics\\n` +\n  `• business\\n` +\n  `• health\\n` +\n  `• science\\n` +\n  `• brasil\\n` +\n  `• teclas\\n\\n` +\n  `*Example:*\\n` +\n  `\\`\\`\\`\\n` +\n  `URL: https://addyosmani.com/blog/self-improving-agents/\\n` +\n  `Feed: technology\\n` +\n  `\\`\\`\\``;\n\nmsg.payload = {\n  chatId: msg.chatId,\n  type: \"message\",\n  content: helpMessage\n};\n\nreturn msg;",
+      "x": 280,
+      "y": 80,
+      "wires": [
+        ["telegram-sender"]
+      ]
+    },
+    {
+      "id": "start-command",
+      "type": "function",
+      "z": "telegram-article-submission-flow",
+      "name": "Start Command Handler",
+      "func": "// Handle /start command\nconst startMessage = `👋 *Welcome to Meridiano Article Bot!*\\n\\n` +\n  `I can help you submit articles for processing.\\n\\n` +\n  `*How to use:*\\n` +\n  `1. Send me a URL with a feed profile\\n` +\n  `2. I'll submit it for processing\\n` +\n  `3. You'll get notified when it's ready\\n\\n` +\n  `Type /help for more information.`;\n\nmsg.payload = {\n  chatId: msg.chatId,\n  type: \"message\",\n  content: startMessage\n};\n\nreturn msg;",
+      "x": 280,
+      "y": 40,
+      "wires": [
+        ["telegram-sender"]
+      ]
+    },
+    {
+      "id": "telegram-bot-config",
+      "type": "telegram bot credentials",
+      "botname": "Meridiano Article Bot",
+      "usertoken": "",
+      "chatId": "",
+      "split": false,
+      "x": 100,
+      "y": 40,
+      "wires": []
+    }
+  ]
+}

--- a/docs/plans/Prompt Versioning and Audit System-glm4.7.md
+++ b/docs/plans/Prompt Versioning and Audit System-glm4.7.md
@@ -1,0 +1,158 @@
+# Prompt Versioning and Audit System
+## Problem Statement
+The Meridiano system uses AI prompts throughout its pipeline (article summarization, transcription analysis, briefing synthesis, etc.), but currently lacks:
+* Ability to track which version of a prompt was used for any given processing job
+* Historical record of prompt changes over time
+* Auditing capability to review inputs/outputs for specific AI interactions
+* Reproducibility when debugging AI-related issues or testing prompt changes
+## Current State
+**Existing Infrastructure:**
+* Prompts stored in `src/config/prompts/` as TypeScript constants (e.g., `articleSummaryPrompt`, `transcriptionSummaryPrompt`)
+* `AiService` in `src/ai/ai.service.ts` handles AI calls to DeepSeek, OpenAI, Groq
+* Prompts use simple string interpolation with `PromptVariables` interface
+* TypeORM database already configured with PostgreSQL
+* BullMQ queues for background processing
+* Multiple prompt templates: article-summary, brief-synthesis, transcription-analysis, cluster-analysis, impact-rating, etc.
+**Current Prompt Usage Pattern:**
+```typescript
+// Current inline prompt usage
+const response = await this.aiService.callChat(
+  articleSummaryPrompt.replace('{article_content}', article.raw_content),
+  'deepseek',
+);
+```
+## Proposed Solution
+### 1. Database Schema for Prompt Versioning
+Create new entities to track prompts and their usage:
+**`prompt_version` table:**
+* `id` (UUID, primary key)
+* `name` (text) - e.g., "article-summary-v1"
+* `template` (text) - the prompt template with placeholders
+* `version` (integer) - numeric version (1, 2, 3...)
+* `is_active` (boolean) - whether this version is currently in use
+* `description` (text, nullable) - notes about what changed
+* `created_at`, `updated_at`
+**`prompt_execution` table:**
+* `id` (UUID, primary key)
+* `prompt_version_id` (UUID, foreign key)
+* `input_variables` (jsonb) - the actual variables used
+* `prompt_text` (text) - the fully rendered prompt sent to AI
+* `ai_provider` (text) - e.g., "deepseek", "openai"
+* `ai_model` (text) - e.g., "deepseek-chat"
+* `output` (text, nullable) - AI response
+* `status` (text) - "success", "error", "timeout"
+* `error_message` (text, nullable)
+* `duration_ms` (integer)
+* `tokens_used` (integer, nullable)
+* `cost_estimate_usd` (float, nullable)
+* `reference_id` (text, nullable) - link to article/transcription ID
+* `reference_type` (text) - "article", "transcription", "briefing"
+* `created_at`
+**`prompt_tags` table:**
+* `id` (UUID, primary key)
+* `name` (text, unique) - e.g., "summarization", "classification"
+* `prompt_version_id` (UUID, foreign key)
+### 2. Prompt Registry Service
+Create a `src/prompts/prompt-registry.service.ts` that:
+* Loads initial prompt versions from files into database on first run
+* Provides methods to `registerPrompt(name, template, description)`
+* Supports versioning by detecting hash changes in templates
+* `getActivePrompt(name)` - returns the currently active prompt version
+* `updatePrompt(name, template, description)` - creates new version, deactivates old
+* `listHistory(name)` - returns all versions of a prompt
+### 3. Audit Service
+Create `src/audit/ai-audit.service.ts` that:
+* `logExecution(promptName, variables, aiConfig)` - called before AI call
+* `recordSuccess(output, metadata)` - update after successful response
+* `recordError(error)` - update on failure
+* `getExecutions(referenceId, referenceType)` - retrieve by external reference
+* `getExecutionsByPrompt(promptName)` - audit trail for specific prompt
+* `analyzePromptUsage(promptName)` - stats on success rates, costs, etc.
+### 4. AiService Integration
+Refactor `src/ai/ai.service.ts` to:
+* Accept `PromptExecutionContext` object instead of raw prompt string
+* Automatically create audit record before/after AI calls
+* Extract metadata (token usage, duration) from API responses
+* Handle errors gracefully, ensuring audit record is always created
+**Before:**
+```typescript
+const response = await this.aiService.callChat(
+  articleSummaryPrompt.replace('{article_content}', article.raw_content),
+  'deepseek',
+);
+```
+**After:**
+```typescript
+const response = await this.aiService.callChat(
+  { promptName: 'article-summary', variables: { article_content: article.raw_content } },
+  { provider: 'deepseek' },
+  { referenceId: article.id, referenceType: 'article' },
+);
+```
+### 5. Migration and APIs
+**Database Migration:**
+* Create tables for prompt versioning and audit tracking
+* Seed initial prompts from existing templates
+**New Endpoints:**
+* `GET /api/prompts` - List all prompts with active versions
+* `GET /api/prompts/:name` - Get prompt history and versions
+* `POST /api/prompts` - Create new prompt version
+* `GET /api/ai-audit` - List audit records with filters
+* `GET /api/ai-audit/:id` - Get full audit record with input/output
+* `GET /api/ai-audit/ref/:referenceId` - Get audits by reference (article/transcription)
+### 6. CLI and Scripts
+**New commands:**
+* `pnpm run prompts:seed` - Load prompts from files to database
+* `pnpm run prompts:export` - Export database prompts to files
+* `pnpm run prompts:diff` - Compare versions of a prompt
+* `pnpm run audit:report` - Generate usage report (cost, success rates, avg response time)
+## Implementation Steps
+### Phase 1: Core Infrastructure
+1. Create database entities and migrations
+2. Implement PromptRegistryService with initial seeding
+3. Implement AiAuditService with logging/tracking
+4. Refactor AiService to integrate with new services
+### Phase 2: Integration
+5. Update article processors to use new API
+6. Update transcription processors to use new API
+7. Update briefing generation to use new API
+8. Update cluster analysis to use new API
+### Phase 3: Visibility
+9. Create REST API endpoints for prompt management
+10. Create REST API endpoints for audit queries
+11. Build CLI tools for prompt management
+12. Add admin UI for viewing prompt executions (optional)
+### Phase 4: Analysis
+13. Implement cost tracking (token usage × model pricing)
+14.Implement success/failure rate analytics
+15. Implement A/B testing capability (multiple active versions)
+16. Build comparison tools for prompt differences
+## Technical Considerations
+**Performance:**
+* Audit records can grow large - implement pruning strategy (keep 90 days)
+* Batch inserts for audit records in high-volume scenarios
+* Consider read replica for audit queries
+**Backwards Compatibility:**
+* Keep old string-based API for existing code
+* Provide migration path for each processor
+* Gradual rollout per module to minimize disruption
+**Security:**
+* Admin-only access to prompt management endpoints
+* Sanitize sensitive data before storing in audit (PII redaction)
+* Manage secrets/API keys at service level, not prompt level
+**Extensibility:**
+* Support for A/B testing prompts (multiple active versions)
+* Tag-based organization for prompts
+* Export/import prompt versions for transfer between environments
+## Success Metrics
+* All AI interactions tracked in audit table
+* 100% reproducibility for any past processing job
+* Ability to identify which prompt version caused issues
+* Visibility into AI costs and usage patterns
+* Easy rollback capability for prompt changes
+## Future Enhancements
+* Automatic prompt optimization based on success metrics
+* Integration with feature flags for gradual rollouts
+* Prompt performance dashboards
+* Historical price tracking for token cost estimation
+* CI/CD integration for prompt version testing

--- a/docs/plans/Prompt Versioning and Audit System-sonnet-4.6.md
+++ b/docs/plans/Prompt Versioning and Audit System-sonnet-4.6.md
@@ -1,0 +1,158 @@
+# Prompt Versioning and Audit System
+## Problem Statement
+The Meridiano system uses AI prompts throughout its pipeline (article summarization, transcription analysis, briefing synthesis, etc.), but currently lacks:
+* Ability to track which version of a prompt was used for any given processing job
+* Historical record of prompt changes over time
+* Auditing capability to review inputs/outputs for specific AI interactions
+* Reproducibility when debugging AI-related issues or testing prompt changes
+## Current State
+**Existing Infrastructure:**
+* Prompts stored in `src/config/prompts/` as TypeScript constants (e.g., `articleSummaryPrompt`, `transcriptionSummaryPrompt`)
+* `AiService` in `src/ai/ai.service.ts` handles AI calls to DeepSeek, OpenAI, Groq
+* Prompts use simple string interpolation with `PromptVariables` interface
+* TypeORM database already configured with PostgreSQL
+* BullMQ queues for background processing
+* Multiple prompt templates: article-summary, brief-synthesis, transcription-analysis, cluster-analysis, impact-rating, etc.
+**Current Prompt Usage Pattern:**
+```typescript
+// Current inline prompt usage
+const response = await this.aiService.callChat(
+  articleSummaryPrompt.replace('{article_content}', article.raw_content),
+  'deepseek',
+);
+```
+## Proposed Solution
+### 1. Database Schema for Prompt Versioning
+Create new entities to track prompts and their usage:
+**`prompt_version` table:**
+* `id` (UUID, primary key)
+* `name` (text) - e.g., "article-summary-v1"
+* `template` (text) - the prompt template with placeholders
+* `version` (integer) - numeric version (1, 2, 3...)
+* `is_active` (boolean) - whether this version is currently in use
+* `description` (text, nullable) - notes about what changed
+* `created_at`, `updated_at`
+**`prompt_execution` table:**
+* `id` (UUID, primary key)
+* `prompt_version_id` (UUID, foreign key)
+* `input_variables` (jsonb) - the actual variables used
+* `prompt_text` (text) - the fully rendered prompt sent to AI
+* `ai_provider` (text) - e.g., "deepseek", "openai"
+* `ai_model` (text) - e.g., "deepseek-chat"
+* `output` (text, nullable) - AI response
+* `status` (text) - "success", "error", "timeout"
+* `error_message` (text, nullable)
+* `duration_ms` (integer)
+* `tokens_used` (integer, nullable)
+* `cost_estimate_usd` (float, nullable)
+* `reference_id` (text, nullable) - link to article/transcription ID
+* `reference_type` (text) - "article", "transcription", "briefing"
+* `created_at`
+**`prompt_tags` table:**
+* `id` (UUID, primary key)
+* `name` (text, unique) - e.g., "summarization", "classification"
+* `prompt_version_id` (UUID, foreign key)
+### 2. Prompt Registry Service
+Create a `src/prompts/prompt-registry.service.ts` that:
+* Loads initial prompt versions from files into database on first run
+* Provides methods to `registerPrompt(name, template, description)`
+* Supports versioning by detecting hash changes in templates
+* `getActivePrompt(name)` - returns the currently active prompt version
+* `updatePrompt(name, template, description)` - creates new version, deactivates old
+* `listHistory(name)` - returns all versions of a prompt
+### 3. Audit Service
+Create `src/audit/ai-audit.service.ts` that:
+* `logExecution(promptName, variables, aiConfig)` - called before AI call
+* `recordSuccess(output, metadata)` - update after successful response
+* `recordError(error)` - update on failure
+* `getExecutions(referenceId, referenceType)` - retrieve by external reference
+* `getExecutionsByPrompt(promptName)` - audit trail for specific prompt
+* `analyzePromptUsage(promptName)` - stats on success rates, costs, etc.
+### 4. AiService Integration
+Refactor `src/ai/ai.service.ts` to:
+* Accept `PromptExecutionContext` object instead of raw prompt string
+* Automatically create audit record before/after AI calls
+* Extract metadata (token usage, duration) from API responses
+* Handle errors gracefully, ensuring audit record is always created
+**Before:**
+```typescript
+const response = await this.aiService.callChat(
+  articleSummaryPrompt.replace('{article_content}', article.raw_content),
+  'deepseek',
+);
+```
+**After:**
+```typescript
+const response = await this.aiService.callChat(
+  { promptName: 'article-summary', variables: { article_content: article.raw_content } },
+  { provider: 'deepseek' },
+  { referenceId: article.id, referenceType: 'article' },
+);
+```
+### 5. Migration and APIs
+**Database Migration:**
+* Create tables for prompt versioning and audit tracking
+* Seed initial prompts from existing templates
+**New Endpoints:**
+* `GET /api/prompts` - List all prompts with active versions
+* `GET /api/prompts/:name` - Get prompt history and versions
+* `POST /api/prompts` - Create new prompt version
+* `GET /api/ai-audit` - List audit records with filters
+* `GET /api/ai-audit/:id` - Get full audit record with input/output
+* `GET /api/ai-audit/ref/:referenceId` - Get audits by reference (article/transcription)
+### 6. CLI and Scripts
+**New commands:**
+* `pnpm run prompts:seed` - Load prompts from files to database
+* `pnpm run prompts:export` - Export database prompts to files
+* `pnpm run prompts:diff` - Compare versions of a prompt
+* `pnpm run audit:report` - Generate usage report (cost, success rates, avg response time)
+## Implementation Steps
+### Phase 1: Core Infrastructure
+1. Create database entities and migrations
+2. Implement PromptRegistryService with initial seeding
+3. Implement AiAuditService with logging/tracking
+4. Refactor AiService to integrate with new services
+### Phase 2: Integration
+5. Update article processors to use new API
+6. Update transcription processors to use new API
+7. Update briefing generation to use new API
+8. Update cluster analysis to use new API
+### Phase 3: Visibility
+9. Create REST API endpoints for prompt management
+10. Create REST API endpoints for audit queries
+11. Build CLI tools for prompt management
+12. Add admin UI for viewing prompt executions (optional)
+### Phase 4: Analysis
+13. Implement cost tracking (token usage × model pricing)
+14.Implement success/failure rate analytics
+15. Implement A/B testing capability (multiple active versions)
+16. Build comparison tools for prompt differences
+## Technical Considerations
+**Performance:**
+* Audit records can grow large - implement pruning strategy (keep 90 days)
+* Batch inserts for audit records in high-volume scenarios
+* Consider read replica for audit queries
+**Backwards Compatibility:**
+* Keep old string-based API for existing code
+* Provide migration path for each processor
+* Gradual rollout per module to minimize disruption
+**Security:**
+* Admin-only access to prompt management endpoints
+* Sanitize sensitive data before storing in audit (PII redaction)
+* Manage secrets/API keys at service level, not prompt level
+**Extensibility:**
+* Support for A/B testing prompts (multiple active versions)
+* Tag-based organization for prompts
+* Export/import prompt versions for transfer between environments
+## Success Metrics
+* All AI interactions tracked in audit table
+* 100% reproducibility for any past processing job
+* Ability to identify which prompt version caused issues
+* Visibility into AI costs and usage patterns
+* Easy rollback capability for prompt changes
+## Future Enhancements
+* Automatic prompt optimization based on success metrics
+* Integration with feature flags for gradual rollouts
+* Prompt performance dashboards
+* Historical price tracking for token cost estimation
+* CI/CD integration for prompt version testing

--- a/docs/plans/telegram_article_submission_deployment.md
+++ b/docs/plans/telegram_article_submission_deployment.md
@@ -1,0 +1,333 @@
+# Telegram Article Submission - Deployment Guide
+
+## Overview
+
+This document outlines the deployment steps for Phase 5 of the Telegram Article Submission feature.
+
+## Prerequisites
+
+Before deploying, ensure you have:
+1. A Telegram Bot created via BotFather
+2. The Node-RED flow imported (see [`docs/nodered/telegram-article-submission-flow.json`](docs/nodered/telegram-article-submission-flow.json))
+3. External API tokens generated for authentication
+4. Access to your deployment environment
+
+---
+
+## Environment Configuration
+
+### Required Environment Variables
+
+| Variable | Description | Example |
+| -------- | ----------- | -------- |
+| `EXTERNAL_API_TOKENS` | Comma-separated list of valid tokens | `tok_prod_abc123,tok_prod_xyz789` |
+| `TELEGRAM_INTEGRATION_ENABLED` | Enable/disable feature | `true` or `false` |
+| `TELEGRAM_BOT_TOKEN` | Telegram Bot API token (set in Node-RED) | Generated via BotFather |
+
+### Setting Environment Variables
+
+#### For Docker Compose
+
+Add to your environment or `.env` file:
+
+```bash
+# .env file
+EXTERNAL_API_TOKENS=tok_prod_your_token_here
+TELEGRAM_INTEGRATION_ENABLED=true
+```
+
+---
+
+## Staging Deployment
+
+### Step 1: Configure Staging Environment
+
+1. Set up staging-specific environment variables:
+
+```bash
+# staging.env
+COMPOSE_PROFILE=staging
+DATABASE_HOST=your-staging-db-host
+DATABASE_USER=staging_user
+DATABASE_PASSWORD=staging_password
+DATABASE_NAME=meridian_staging
+REDIS_PASSWORD=staging_redis_password
+
+# Telegram-specific
+EXTERNAL_API_TOKENS=tok_stg_test_token
+TELEGRAM_INTEGRATION_ENABLED=true
+```
+
+### Step 2: Deploy Staging Stack
+
+```bash
+# Start staging services
+docker-compose -f docker-compose.yml --profile staging up -d
+
+# Or use the staging-specific compose file
+docker-compose -f docker-compose.staging.yml up -d
+```
+
+### Step 3: Configure Node-RED (Staging)
+
+1. Access Node-RED at `http://localhost:1880`
+2. Import the flow from [`docs/nodered/telegram-article-submission-flow.json`](docs/nodered/telegram-article-submission-flow.json)
+3. Configure the Telegram credentials:
+   - Bot Token: Your test bot token from BotFather
+4. Set the API URL to your staging API endpoint
+5. Deploy the flow
+
+### Step 4: Set Webhook (Optional - for production-like testing)
+
+If you want to test with webhooks in staging:
+
+```bash
+# Set webhook (replace with your staging URL)
+curl -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
+  -d "url=https://your-staging-domain.com/webhook"
+```
+
+### Step 5: Test the Integration
+
+Send a test message to your Telegram bot:
+
+```
+URL: https://example.com/article
+Feed: technology
+```
+
+Expected response:
+```
+✅ Article submitted successfully!
+📝 Title: Example Article
+📊 Status: Queed for processing
+🆔 Job ID: <job-uuid>
+```
+
+---
+
+## Production Deployment
+
+### Step 1: Generate Production Token
+
+Generate a secure token for production use:
+
+```bash
+# Generate a secure random token
+openssl rand -hex 32
+```
+
+### Step 2: Configure Production Environment
+
+```bash
+# production.env
+COMPOSE_PROFILE=production
+DATABASE_HOST=your-prod-db-host
+DATABASE_USER=prod_user
+DATABASE_PASSWORD=prod_password
+DATABASE_NAME=meridian
+REDIS_PASSWORD=prod_redis_password
+
+# Telegram-specific - Initially DISABLED
+EXTERNAL_API_TOKENS=tok_prod_your_secure_token
+TELEGRAM_INTEGRATION_ENABLED=false
+```
+
+### Step 3: Deploy Production Stack
+
+```bash
+# Build and start production services
+docker-compose -f docker-compose.prod.yml up -d --build
+```
+
+### Step 4: Run Database Migrations
+
+Ensure the Telegram submissions table is created:
+
+```bash
+# Run migrations
+docker exec -it meridian-backend pnpm run migrations:run
+
+# Or use the migration script
+docker exec -it meridian-backend node dist/scripts/run-migrations.js
+```
+
+### Step 5: Configure Node-RED (Production)
+
+1. Access Node-RED at `http://localhost:1880` (or configure a reverse proxy)
+2. Import the flow from [`docs/nodered/telegram-article-submission-flow.json`](docs/nodered/telegram-article-submission-flow.json)
+3. Configure the production Telegram bot credentials
+4. Set the API URL to your production API endpoint
+5. **Important**: Configure the external API token in Node-RED
+6. Deploy the flow
+
+### Step 6: Verify Production Deployment
+
+```bash
+# Check API health
+curl http://localhost:3005/api/health
+
+# Test external endpoint (should fail without token)
+curl -X POST http://localhost:3005/api/articles/external \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","feedProfile":"technology"}'
+
+# Test with valid token
+curl -X POST http://localhost:3005/api/articles/external \
+  -H "Content-Type: application/json" \
+  -H "X-External-Token: tok_prod_your_secure_token" \
+  -d '{"url":"https://example.com","feedProfile":"technology"}'
+```
+
+---
+
+## Enabling the Feature in Production
+
+After thorough testing in staging and verifying production deployment:
+
+### Step 1: Update Environment Variable
+
+```bash
+# Option 1: Update .env file and restart
+TELEGRAM_INTEGRATION_ENABLED=true
+docker-compose -f docker-compose.prod.yml restart meridian-backend
+
+# Option 2: Update at runtime (if supported)
+docker exec -e TELEGRAM_INTEGRATION_ENABLED=true meridian-backend ...
+```
+
+### Step 2: Verify Feature is Enabled
+
+```bash
+# Check that the endpoint is accessible
+curl -X POST http://localhost:3005/api/articles/external \
+  -H "X-External-Token: tok_prod_your_token" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","feedProfile":"technology"}'
+```
+
+Expected response:
+```json
+{
+  "success": true,
+  "jobId": "550e8400-e29b-41d4-a716-446655440000",
+  "message": "Article submitted successfully and queued for processing"
+}
+```
+
+### Step 3: Set Telegram Webhook (Production)
+
+```bash
+curl -X POST "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
+  -d "url=https://your-production-domain.com/nodered-webhook"
+```
+
+---
+
+## Rollback Procedures
+
+### Immediate Rollback
+
+If issues are detected:
+
+```bash
+# Disable the feature flag
+TELEGRAM_INTEGRATION_ENABLED=false
+docker-compose -f docker-compose.prod.yml restart meridian-backend
+```
+
+### Token Revocation
+
+If a token is compromised:
+
+```bash
+# Remove the compromised token from EXTERNAL_API_TOKENS
+# Generate a new token
+openssl rand -hex 32
+
+# Update environment and restart
+docker-compose -f docker-compose.prod.yml restart meridian-backend
+```
+
+---
+
+## Monitoring
+
+### Key Metrics to Monitor
+
+| Metric | Description | Alert Threshold |
+|--------|-------------|-----------------|
+| `external_api.requests` | Total external API requests | > 1000/min |
+| `external_api.errors` | Error rate | > 5% |
+| `external_api.latency` | Response time (p95) | > 2s |
+| `telegram.submissions` | Successful submissions | Track daily |
+
+### Logs
+
+Check logs for the external article submission:
+
+```bash
+# View API logs
+docker logs meridian-backend | grep -i "external"
+
+# View Node-RED logs
+docker logs meridiano-nodered-prod
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+1. **401 Unauthorized**
+   - Verify token is set in `EXTERNAL_API_TOKENS`
+   - Check token matches exactly (no extra spaces)
+
+2. **429 Rate Limited**
+   - Default: 10 requests per minute per token
+   - Wait and retry
+
+3. **502 Bad Gateway**
+   - Check Node-RED can reach the API
+   - Verify `MERIDIANO_API_URL` is correct
+
+4. **Node-RED Flow Not Working**
+   - Check Telegram bot token in Node-RED credentials
+   - Verify flow is deployed
+   - Check Node-RED logs
+
+---
+
+## Security Checklist
+
+- [ ] `EXTERNAL_API_TOKENS` set in production environment
+- [ ] `TELEGRAM_INTEGRATION_ENABLED` set to `false` initially
+- [ ] Telegram bot token stored in Node-RED credentials (not env vars)
+- [ ] API endpoint behind authentication/VPN if possible
+- [ ] Rate limiting enabled and tested
+- [ ] Logs monitored for suspicious activity
+- [ ] Token rotation policy established (every 90 days)
+
+---
+
+## Files Modified/Created
+
+| File | Description |
+|------|-------------|
+| `docker-compose.prod.yml` | Updated with Node-RED and Telegram env vars |
+| `docker-compose.staging.yml` | New staging configuration |
+| `docs/plans/telegram_article_submission_deployment.md` | This deployment guide |
+
+---
+
+## Next Steps
+
+After Phase 5 deployment is complete:
+
+1. Monitor metrics and logs
+2. Gather user feedback
+3. Plan Phase 2 improvements:
+   - Multi-user support with Telegram user mapping
+   - Support for submitting with notes/tags
+   - Bot usage analytics

--- a/docs/plans/telegram_article_submission_feature.tdd.md
+++ b/docs/plans/telegram_article_submission_feature.tdd.md
@@ -1,0 +1,1103 @@
+# TDD - Telegram Bot Integration for Article Submission
+
+| Field        | Value                                      |
+| ------------ | ------------------------------------------ |
+| Tech Lead    | Ana Helena                                 |
+| Epic/Ticket  | https://linear.app/anas-org/issue/TASK-140 |
+| Status       | Complete                                          |
+| Created      | 2026-03-03                                 |
+| Last Updated | 2026-03-05 (Phase 4 Complete - Testing Complete) |
+
+---
+
+## 1. Executive Summary
+
+This document outlines the technical design for integrating a Telegram Bot with the Meridiano NestJS application to enable article submission via Telegram messages. The integration will use Node-RED as an intermediary middleware to process Telegram messages and forward them to a new secure API endpoint in the Meridiano backend.
+
+The solution provides a convenient way for users to submit articles for processing directly from their mobile devices through Telegram, leveraging the existing article scraping and processing infrastructure.
+
+---
+
+## 2. Context
+
+### Background
+
+Meridiano is a NestJS-based content aggregation and processing platform that currently supports article submission through a REST API endpoint (`POST /api/articles`). The platform scrapes articles from provided URLs, processes them using AI for summarization and categorization, and stores them for later retrieval.
+
+The existing flow requires users to interact with the API directly or through a frontend interface. This integration aims to provide an alternative, more convenient submission channel through Telegram.
+
+### Domain
+
+This feature falls under the **Content Ingestion** domain, specifically expanding the input channels for the article processing pipeline. It touches on:
+
+- External messaging platform integration (Telegram)
+- Middleware orchestration (Node-RED)
+- API security and authentication
+- Asynchronous job processing (BullMQ)
+
+### Stakeholders
+
+- **End Users**: Content curators who want to submit articles via mobile
+- **Development Team**: Responsible for implementation and maintenance
+- **Operations Team**: Responsible for Node-RED and Telegram Bot management
+
+---
+
+## 3. Problem Statement & Motivation
+
+### Problems We're Solving
+
+- **Manual API interaction is inconvenient**: Users must use API clients or custom scripts to submit articles, creating friction in the content curation workflow
+- **Mobile-unfriendly submission process**: The current API-first approach doesn't work well on mobile devices
+- **No real-time feedback on mobile**: Users don't have an easy way to receive immediate confirmation or error messages when submitting articles
+
+### Why Now?
+
+- Telegram is widely used by the target audience for content sharing
+- The existing article processing infrastructure is mature and can handle additional input sources
+- Low implementation cost with high user experience improvement
+
+### Impact of NOT Solving
+
+- Continued friction in content submission workflow
+- Missed opportunities for rapid content curation on mobile
+- Potential user attrition due to inconvenient submission process
+
+---
+
+## 4. Goals and Non-Goals
+
+### Goals
+
+1. Enable article submission via Telegram bot messages
+2. Support URL and feed profile extraction from Telegram messages
+3. Provide immediate feedback to users on submission success/failure
+4. Maintain security through token-based API authentication
+5. Leverage existing article processing infrastructure
+
+### Non-Goals
+
+1. **Bot Management UI**: Creating a web interface to manage bot settings
+2. **Multi-bot Support**: Supporting multiple Telegram bots simultaneously
+3. **Rich Media Processing**: Handling images, videos, or documents from Telegram
+4. **User Authentication**: Telegram user mapping to Meridiano users (out of scope for V1)
+5. **Conversation Flows**: Complex multi-step interactions with the bot
+6. **Analytics Dashboard**: Tracking bot usage metrics (can be added in V2)
+
+### Future Considerations (V2+)
+
+- Multi-user support with Telegram user-to-Meridiano account mapping
+- Support for submitting articles with attached notes or tags
+- Bulk submission via forwarded messages
+- Bot usage analytics and reporting
+
+---
+
+## 5. Technical Solution
+
+### Architecture Overview
+
+The solution consists of three main components:
+
+1. **Telegram Bot**: Receives messages from users and sends responses
+2. **Node-RED Middleware**: Processes incoming messages, extracts data, and forwards to API
+3. **Meridiano API**: New secure endpoint that integrates with existing article processing pipeline
+
+```mermaid
+flowchart LR
+    subgraph User["User Device"]
+        TG["Telegram App"]
+    end
+
+    subgraph TelegramCloud["Telegram Cloud"]
+        BotAPI["Telegram Bot API"]
+    end
+
+    subgraph Middleware["Middleware Layer"]
+        NodeRED["Node-RED Flow"]
+    end
+
+    subgraph Meridiano["Meridiano Platform"]
+        API["POST /api/articles/external"]
+        Scraper["ScraperService"]
+        Queue["BullMQ Queue"]
+        Processor["Article Processor"]
+        DB[("PostgreSQL")]
+    end
+
+    TG -->|"1. Send message with URL + profile"| BotAPI
+    BotAPI -->|"2. Webhook/HTTP POST"| NodeRED
+    NodeRED -->|"3. POST with token header"| API
+    API -->|"4. Scrape article"| Scraper
+    API -->|"5. Queue for processing"| Queue
+    Queue -->|"6. Process article"| Processor
+    Processor -->|"7. Store result"| DB
+    API -->|"8. Return status"| NodeRED
+    NodeRED -->|"9. Success/Error message"| BotAPI
+    BotAPI -->|"10. Reply to user"| TG
+```
+
+### Infrastructure Requirements
+
+#### 5.8 Hosting Configuration (Raspberry Pi)
+
+Node-RED will run on the **same Raspberry Pi** that hosts the Meridiano API and frontend. This co-location provides several advantages:
+
+```mermaid
+flowchart LR
+    subgraph RaspberryPi["Raspberry Pi (Single Host)"]
+        NodeRED["Node-RED"]
+        API["Meridiano API"]
+        Frontend["Frontend"]
+        Postgres[(PostgreSQL)]
+        Redis[(Redis)]
+    end
+
+    subgraph TelegramCloud["Telegram Cloud"]
+        BotAPI["Telegram Bot API"]
+    end
+
+    BotAPI <-->|"Webhook/Polling"| NodeRED
+    NodeRED -->|"localhost:3000"| API
+    API --> Postgres
+    API --> Redis
+```
+
+**Networking Benefits:**
+
+| Aspect            | Configuration                               | Benefit                              |
+| ----------------- | ------------------------------------------- | ------------------------------------ |
+| API Communication | `localhost:3000` or Docker internal network | No external HTTPS required           |
+| Latency           | < 1ms internal                              | Faster message processing            |
+| Security          | Internal network only                       | Reduced attack surface               |
+| Webhook Options   | Polling or local reverse proxy              | No external HTTPS certificate needed |
+
+**Recommended: Long Polling**
+
+Since Node-RED runs alongside the API, we can use **long polling** instead of webhooks:
+
+```
+Telegram Bot API <--[HTTPS]--> Node-RED (polling)
+                                    |
+                                    | localhost/Docker network
+                                    v
+                              Meridiano API
+```
+
+**Why Polling over Webhooks:**
+
+| Method       | Setup Complexity                  | Reliability | Best For                  |
+| ------------ | --------------------------------- | ----------- | ------------------------- |
+| Long Polling | ⭐ Simple                          | High        | Local/Raspberry Pi setups |
+| Webhook      | ⭐⭐⭐ Complex (needs HTTPS, domain) | High        | Cloud deployments         |
+
+**Docker Network Configuration (if using Docker Compose):**
+
+```yaml
+# docker-compose.yml additions
+services:
+  nodered:
+    image: nodered/node-red:latest
+    networks:
+      - meridiano-network
+    environment:
+      - MERIDIANO_API_URL=http://api:3000
+
+  api:
+    # existing API configuration
+    networks:
+      - meridiano-network
+
+networks:
+  meridiano-network:
+    driver: bridge
+```
+
+**Security Notes:**
+
+- Node-RED dashboard should be bound to `localhost` or protected by authentication
+- No external ports needed for Node-RED if using polling
+- Telegram Bot token stored in Node-RED credentials file (not environment variables)
+
+---
+
+### Component Details
+
+#### 5.2 Telegram Bot Configuration
+
+**Bot Setup Requirements**:
+
+- Create a new bot via BotFather
+- Configure webhook URL pointing to Node-RED instance
+- Set bot commands and description
+
+#### 5.2.1 Message Format Options
+
+The following message format options have been identified. **Option B (Structured Format) has been selected for implementation.**
+
+**Option A: Simple Format** (Not Selected)
+
+Single line with URL and feed profile separated by space.
+
+```
+https://addyosmani.com/blog/self-improving-agents/ technology
+```
+
+| Pros                                       | Cons                                         |
+| ------------------------------------------ | -------------------------------------------- |
+| ✅ Fastest to type on mobile                | ❌ Profile can be ambiguous if URL has spaces |
+| ✅ Easy to remember                         | ❌ No clear visual separation                 |
+| ✅ Minimal parsing complexity               | ❌ Harder to add optional fields later        |
+| ✅ Works well with URL sharing from browser |                                              |
+
+---
+
+**Option B: Structured Format** ✅ **SELECTED / IMPLEMENTED**
+
+Multi-line with explicit labels.
+
+```
+URL: https://addyosmani.com/blog/self-improving-agents/
+Feed: technology
+```
+
+| Pros                              | Cons                                       |
+| --------------------------------- | ------------------------------------------ |
+| ✅ Self-documenting and clear      | ❌ Requires more typing                     |
+| ✅ Easy to extend with more fields | ❌ Multi-line input can be tricky on mobile |
+| ✅ URL and profile are unambiguous | ❌ Slightly more complex parsing            |
+| ✅ Better for future automation    |                                            |
+
+---
+
+**Option C: Command-Style Format** (Not Selected)
+
+Using bot commands with arguments.
+
+```
+/submit https://addyosmani.com/blog/self-improving-agents/ technology
+```
+
+| Pros                                          | Cons                                   |
+| --------------------------------------------- | -------------------------------------- |
+| ✅ Clear intent via /submit command            | ❌ Requires users to remember command   |
+| ✅ Can provide command hints in bot            | ❌ Slightly longer to type              |
+| ✅ Extensible with flags/args                  | ❌ Telegram auto-complete may interfere |
+| ✅ Can have separate commands (/help, /status) |                                        |
+
+---
+
+**Decision**: ✅ **Option B (Structured Format) implemented.**
+
+#### 5.2.2 Message Format Examples
+
+This section provides concrete examples of valid and invalid message formats for the **Option B (Structured Format)** implementation.
+
+##### Valid Message Formats
+
+**Valid Format 1 - Basic:**
+```
+URL: https://addyosmani.com/blog/self-improving-agents/
+Feed: technology
+```
+
+**Valid Format 2 - With extra whitespace:**
+```
+URL:   https://example.com/article
+Feed:   productivity
+```
+*Note: Extra spaces after the colon and at line endings are trimmed during parsing.*
+
+**Valid Format 3 - Reverse order:**
+```
+Feed: design
+URL: https://example.com/design-article
+```
+*Note: The order of lines does not matter; the parser extracts by label.*
+
+**Valid Format 4 - With optional description:**
+```
+URL: https://example.com/article
+Feed: technology
+Note: Great article about AI agents
+```
+*Note: The `Note:` field is optional and can be used to add a description or context.*
+
+---
+
+##### Invalid Message Formats
+
+**Invalid Format 1 - Missing URL:**
+```
+Feed: technology
+```
+**Error:** "❌ URL is required. Please include a URL: line."
+
+---
+
+**Invalid Format 2 - Missing Feed:**
+```
+URL: https://example.com/article
+```
+**Error:** "❌ Feed profile is required. Please include a Feed: line."
+
+---
+
+**Invalid Format 3 - Invalid URL:**
+```
+URL: not-a-valid-url
+Feed: technology
+```
+**Error:** "❌ The URL doesn't appear to be valid. Please check and try again."
+
+---
+
+**Invalid Format 4 - Non-existent feed:**
+```
+URL: https://example.com/article
+Feed: nonexistent-feed
+```
+**Error:** "❌ Feed 'nonexistent-feed' doesn't exist. Available feeds: technology, productivity, design, ..."
+
+---
+
+##### Parsing Rules Summary
+
+| Rule                     | Description                                               |
+| ------------------------ | --------------------------------------------------------- |
+| **Case Insensitivity**   | Labels (`URL:`, `Feed:`, `Note:`) are case-insensitive    |
+| **Whitespace Tolerance** | Extra spaces after colons and at line endings are trimmed |
+| **Line Order**           | Lines can appear in any order                             |
+| **Required Fields**      | `URL:` and `Feed:` are mandatory                          |
+| **Optional Fields**      | `Note:` is optional and ignored if not present            |
+| **URL Validation**       | Must be a valid HTTP/HTTPS URL format                     |
+| **Feed Validation**      | Must match an existing feed profile name                  |
+
+#### 5.3 Node-RED Flow Design
+
+**Input Node**: HTTP In or Telegram Receiver node
+
+**Processing Nodes**:
+
+1. **Message Parser**: Extract URL and feed profile from message text
+2. **URL Validator**: Validate URL format
+3. **Profile Validator**: Validate against allowed feed profiles
+4. **HTTP Request**: POST to Meridiano API with authentication token
+5. **Response Handler**: Format success/error messages for Telegram
+
+**Output Node**: Telegram Sender or HTTP Response
+
+**Example Node-RED Flow Logic (Structured Format - Option B)**:
+
+```javascript
+// Message parsing function node for Option B (Structured Format)
+const messageText = msg.payload.message.text;
+const lines = messageText.split('\n');
+
+// Initialize variables
+let url = null;
+let feedProfile = null;
+let note = null;
+const errors = [];
+
+// Parse each line for key-value pairs
+lines.forEach(line => {
+  const trimmedLine = line.trim();
+
+  // Match URL: label (case-insensitive)
+  const urlMatch = trimmedLine.match(/^URL:\s*(.+)$/i);
+  if (urlMatch) {
+    url = urlMatch[1].trim();
+  }
+
+  // Match Feed: label (case-insensitive)
+  const feedMatch = trimmedLine.match(/^Feed:\s*(.+)$/i);
+  if (feedMatch) {
+    feedProfile = feedMatch[1].trim();
+  }
+
+  // Match Note: label (optional, case-insensitive)
+  const noteMatch = trimmedLine.match(/^Note:\s*(.+)$/i);
+  if (noteMatch) {
+    note = noteMatch[1].trim();
+  }
+});
+
+// Validation
+if (!url) {
+  errors.push("❌ URL is required. Please include a URL: line.");
+}
+
+if (!feedProfile) {
+  errors.push("❌ Feed profile is required. Please include a Feed: line.");
+}
+
+// URL format validation
+if (url && !url.match(/^https?:\/\/.+/)) {
+  errors.push("❌ The URL doesn't appear to be valid. Please check and try again.");
+}
+
+// Set payload for next node
+msg.payload = {
+  url: url,
+  feedProfile: feedProfile,
+  note: note,
+  errors: errors.length > 0 ? errors : null
+};
+
+return msg;
+```
+
+**Key Parsing Requirements for Option B:**
+
+| Requirement         | Implementation                                 |
+| ------------------- | ---------------------------------------------- |
+| Label Matching      | Case-insensitive regex: `/^URL:\s*(.+)$/i`     |
+| Whitespace Handling | `.trim()` on both label value and entire line  |
+| Line Order          | Process all lines with separate regex patterns |
+| Required Fields     | `URL:` and `Feed:` must be present             |
+| Optional Fields     | `Note:` is extracted if present                |
+| Validation          | URL must start with `http://` or `https://`    |
+
+#### 5.4 Meridiano API Design
+
+**New Endpoint**: `POST /api/articles/external`
+
+| Attribute     | Value                                |
+| ------------- | ------------------------------------ |
+| Method        | POST                                 |
+| Path          | `/api/articles/external`             |
+| Content-Type  | `application/json`                   |
+| Authorization | `X-External-Token` header (required) |
+| Rate Limit    | 10 requests per minute per token     |
+
+**Request Body Schema**:
+
+```json
+{
+  "url": "https://addyosmani.com/blog/self-improving-agents/",
+  "feedProfile": "technology",
+  "source": "telegram",
+  "metadata": {
+    "chatId": "123456789",
+    "messageId": "456",
+    "username": "@userhandle"
+  }
+}
+```
+
+**Request Validation**:
+
+- `url`: Required, valid URL format
+- `feedProfile`: Required, must be valid FeedProfile enum value
+- `source`: Optional, default "external"
+- `metadata`: Optional, object for tracking source information
+
+**Response Schema - Success (201 Created)**:
+
+```json
+{
+  "success": true,
+  "jobId": "550e8400-e29b-41d4-a716-446655440000",
+  "articleId": "article-uuid-here",
+  "message": "Article submitted successfully and queued for processing"
+}
+```
+
+**Response Schema - Error (400 Bad Request)**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "INVALID_URL",
+    "message": "The provided URL is not valid or accessible"
+  }
+}
+```
+
+**Response Schema - Error (401 Unauthorized)**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Invalid or missing authentication token"
+  }
+}
+```
+
+**Response Schema - Error (429 Too Many Requests)**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "Rate limit exceeded. Please try again later.",
+    "retryAfter": 60
+  }
+}
+```
+
+**Response Schema - Error (409 Conflict)**:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ARTICLE_EXISTS",
+    "message": "Article already exists in the database"
+  }
+}
+```
+
+#### 5.5 Authentication Strategy
+
+**Token-Based Authentication**:
+
+- Pre-shared token stored in environment variables
+- Token passed via `X-External-Token` header
+- Tokens are long-lived but rotatable
+- Separate tokens for different environments (dev/staging/prod)
+
+**Token Validation**:
+
+```typescript
+// High-level validation logic
+const validateToken = (token: string): boolean => {
+  const validTokens = process.env.EXTERNAL_API_TOKENS?.split(',') || [];
+  return validTokens.includes(token);
+};
+```
+
+**Rate Limiting**:
+
+- Per-token rate limiting: 10 requests per minute
+- Global rate limiting: 100 requests per minute across all tokens
+- Redis-backed rate limit storage
+
+#### 5.6 Data Flow
+
+**Success Flow**:
+
+1. User sends message to Telegram bot with URL and feed profile
+2. Telegram forwards message to configured webhook (Node-RED)
+3. Node-RED parses the message and extracts URL and feed profile
+4. Node-RED sends POST request to `/api/articles/external` with auth token
+5. Meridiano API validates token and rate limits
+6. API calls `ScraperService.scrapeSingleArticle()` to fetch article content
+7. API calls `QueueService.addArticleProcessingJob()` to queue for processing
+8. API returns success response with jobId to Node-RED
+9. Node-RED formats success message and sends back to Telegram
+10. Telegram displays success message to user
+
+**Error Flow**:
+
+1. Steps 1-4 same as success flow
+2. If validation fails or processing error occurs:
+   - API returns error response with specific error code
+   - Node-RED formats error message based on error code
+   - Node-RED sends error message back to Telegram chat
+   - User receives immediate feedback about the failure
+
+### 5.7 Database Changes
+
+#### Telegram Submissions Table (New for Analytics)
+
+A new table will be created to store Telegram submission metadata for analytics purposes.
+
+```sql
+CREATE TABLE telegram_submissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  article_id UUID REFERENCES articles(id) ON DELETE SET NULL,
+  chat_id VARCHAR(255) NOT NULL,
+  username VARCHAR(255),
+  message_id VARCHAR(255) NOT NULL,
+  message_text TEXT,
+  feed_profile VARCHAR(50) NOT NULL,
+  url TEXT NOT NULL,
+  submission_status VARCHAR(50) NOT NULL DEFAULT 'pending',
+  -- submission_status: pending, success, failed, duplicate
+  error_message TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for analytics queries
+CREATE INDEX idx_telegram_submissions_chat_id ON telegram_submissions(chat_id);
+CREATE INDEX idx_telegram_submissions_created_at ON telegram_submissions(created_at);
+CREATE INDEX idx_telegram_submissions_username ON telegram_submissions(username);
+```
+
+**Stored Fields:**
+
+| Field         | Description                       | GDPR/Privacy Consideration             |
+| ------------- | --------------------------------- | -------------------------------------- |
+| `chatId`      | Telegram chat ID (numeric string) | Pseudonymous identifier                |
+| `username`    | Telegram username (if public)     | Personal data - consider anonymization |
+| `messageId`   | Telegram message ID               | Technical identifier                   |
+| `messageText` | Full message content              | May contain personal data              |
+| `timestamp`   | Submission time                   | Automatic                              |
+
+**Privacy Considerations:**
+
+- Usernames are optional public data on Telegram
+- Consider implementing data retention policy (e.g., anonymize after 90 days)
+- Provide mechanism for users to request data deletion (GDPR Article 17)
+- Store minimal data necessary for analytics
+
+---
+
+**Optional Enhancement** (for articles table):
+
+- Add `source` column to articles table to track submission source
+- Add `external_metadata` JSONB column for storing Telegram-specific data
+
+---
+
+### 5.1 Node-RED Flow Configuration
+
+The Node-RED flow handles the Telegram bot integration. For detailed setup instructions, see:
+
+- **Flow JSON**: [`docs/nodered/telegram-article-submission-flow.json`](docs/nodered/telegram-article-submission-flow.json:1)
+- **Setup Guide**: [`docs/nodered/SETUP.md`](docs/nodered/SETUP.md:1)
+
+#### Node-RED Flow Components
+
+| Node | Function |
+|------|----------|
+| Telegram Receiver | Receives messages from Telegram bot |
+| Parse Message | Extracts URL, feed profile, and note from message |
+| Validation Error | Formats validation error responses |
+| API Request | Prepares request to Meridiano API |
+| Submit to API | Sends POST request to `/api/articles/external` |
+| Success Handler | Formats success response for Telegram |
+| Error Handler | Formats error response for Telegram |
+| Telegram Sender | Sends response back to user |
+
+#### Docker Compose Node-RED Service
+
+The Node-RED service has been added to `docker-compose.yml` for easy deployment:
+
+```yaml
+nodered:
+  image: nodered/node-red:latest
+  ports:
+    - "1880:1880"
+  environment:
+    - MERIDIANO_API_URL=http://api:3000
+```
+
+---
+
+## 5. Implementation Status
+
+| Component                   | Status       | File Reference                                    |
+| --------------------------- | ------------ | ------------------------------------------------- |
+| External API Endpoint       | ✅ Complete  | [`src/articles/external-articles.controller.ts`](src/articles/external-articles.controller.ts:1) |
+| Token Authentication Guard  | ✅ Complete  | [`src/articles/guards/external-token.guard.ts`](src/articles/guards/external-token.guard.ts:1) |
+| Rate Limiting               | ✅ Complete  | Uses `@libs/auth/rate-limit` module              |
+| Telegram Submission Service | ✅ Complete  | [`src/articles/services/telegram-submission.service.ts`](src/articles/services/telegram-submission.service.ts:1) |
+| Database Migration          | ✅ Complete  | [`src/database/migrations/1741047600000-CreateTelegramSubmissionsTable.ts`](src/database/migrations/1741047600000-CreateTelegramSubmissionsTable.ts:1) |
+| Request DTO                 | ✅ Complete  | [`src/articles/dto/external-create-article.dto.ts`](src/articles/dto/external-create-article.dto.ts:1) |
+| Response DTO                | ✅ Complete  | [`src/articles/dto/external-article-response.dto.ts`](src/articles/dto/external-article-response.dto.ts:1) |
+| Unit Tests                  | ✅ Complete  | [`src/articles/external-articles.controller.spec.ts`](src/articles/external-articles.controller.spec.ts:1) |
+| Node-RED Flow               | ✅ Complete  | [`docs/nodered/telegram-article-submission-flow.json`](docs/nodered/telegram-article-submission-flow.json:1) |
+| Node-RED Message Parser Tests | ✅ Complete  | [`docs/nodered/message-parser.test.js`](docs/nodered/message-parser.test.js:1) |
+| Telegram Bot Setup          | ⏳ Pending   | Requires BotFather configuration                |
+
+#### Implemented Features
+
+- **Token-based Authentication**: Uses `X-External-Token` header, tokens configured via `EXTERNAL_API_TOKENS` environment variable (comma-separated)
+- **Rate Limiting**: 10 requests per minute per token using Redis-backed rate limiter
+- **Feature Flag**: Feature can be disabled via `TELEGRAM_INTEGRATION_ENABLED` environment variable
+- **Submission Tracking**: Full analytics tracking via `telegram_submissions` table
+- **GDPR Compliance**: Includes data anonymization and deletion methods
+
+#### Feed Profile Values
+
+The following feed profiles are supported:
+
+```typescript
+enum FeedProfile {
+  DEFAULT = 'default',
+  TECHNOLOGY = 'technology',
+  POLITICS = 'politics',
+  BUSINESS = 'business',
+  HEALTH = 'health',
+  SCIENCE = 'science',
+  BRASIL = 'brasil',
+  TECLAS = 'teclas',
+}
+```
+
+---
+
+## 6. Security Considerations
+
+### Authentication & Authorization
+
+- **Token Authentication**: All requests to `/api/articles/external` must include a valid `X-External-Token` header
+- **Token Storage**: Tokens stored in environment variables, never committed to code
+- **Token Rotation**: Support for multiple valid tokens to enable zero-downtime rotation
+
+### Data Protection
+
+**Encryption**:
+
+- **In Transit**: All communication uses HTTPS/TLS 1.3
+- **Webhook Security**: Telegram webhook secret token validation
+- **API Communication**: TLS for Node-RED to Meridiano API
+
+**PII Handling**:
+
+- Telegram usernames/chat IDs stored only if explicitly needed for replies
+- No persistent storage of Telegram user data in Meridiano database (V1)
+- Metadata stored as transient job data only
+
+### Input Validation
+
+- URL validation using `class-validator` `@IsUrl()` decorator
+- Feed profile validation against `FeedProfile` enum
+- Request size limits (max 10KB)
+- Content-Type enforcement (`application/json`)
+
+### Rate Limiting
+
+| Limit Type       | Threshold     | Window   | Storage |
+| ---------------- | ------------- | -------- | ------- |
+| Per Token        | 10 requests   | 1 minute | Redis   |
+| Global           | 100 requests  | 1 minute | Redis   |
+| IP-based (nginx) | 1000 requests | 1 minute | Memory  |
+
+### Security Best Practices
+
+- ✅ Input validation on URL and feed profile
+- ✅ SQL injection prevention (parameterized queries)
+- ✅ Rate limiting to prevent abuse
+- ✅ Audit logging of all external submissions
+- ❌ No PII storage without explicit consent
+- ❌ No token logging (redact in logs)
+
+### Secrets Management
+
+| Secret                  | Storage Location      | Rotation Policy |
+| ----------------------- | --------------------- | --------------- |
+| EXTERNAL_API_TOKENS     | Environment variables | Every 90 days   |
+| TELEGRAM_BOT_TOKEN      | Node-RED credentials  | Every 90 days   |
+| TELEGRAM_WEBHOOK_SECRET | Node-RED credentials  | Every 90 days   |
+
+---
+
+## 7. Error Handling Strategy
+
+### Error Categories
+
+| Error Code           | HTTP Status | Description                      | User Message                                   |
+| -------------------- | ----------- | -------------------------------- | ---------------------------------------------- |
+| INVALID_URL          | 400         | URL format invalid or missing    | "The URL provided is not valid"                |
+| INVALID_FEED_PROFILE | 400         | Feed profile not in allowed list | "Invalid feed profile. Allowed: default, technology, politics, business, health, science, brasil, teclas" |
+| UNAUTHORIZED         | 401         | Missing or invalid token         | "Authentication failed"                        |
+| RATE_LIMIT_EXCEEDED  | 429         | Too many requests                | "Please wait before submitting again"          |
+| ARTICLE_EXISTS       | 409         | Article already in database      | "This article has already been submitted"      |
+| SCRAPE_FAILED        | 502         | Could not fetch article content  | "Could not access the article URL"             |
+| INTERNAL_ERROR       | 500         | Unexpected server error          | "An error occurred. Please try again later"    |
+
+### Error Response to Telegram
+
+Node-RED will format error messages in a user-friendly way:
+
+```javascript
+// Error message formatting
+const errorMessages = {
+  INVALID_URL: "❌ The URL you provided doesn't seem valid. Please check and try again.",
+  INVALID_FEED_PROFILE: "❌ Invalid feed profile. Use one of: default, technology, politics, business, health, science, brasil, teclas",
+  UNAUTHORIZED: "⚠️ Authentication error. Please contact support.",
+  RATE_LIMIT_EXCEEDED: "⏳ You're submitting too fast. Please wait a minute.",
+  ARTICLE_EXISTS: "ℹ️ This article has already been submitted before.",
+  SCRAPE_FAILED: "❌ Couldn't access the article. Is the URL correct and accessible?",
+  INTERNAL_ERROR: "🔥 Something went wrong on our end. Please try again later."
+};
+```
+
+### Retry Logic
+
+- **Node-RED**: Implements exponential backoff for API calls (3 retries)
+- **Meridiano API**: Article scraping failures are handled by the existing queue retry mechanism
+- **Telegram**: No automatic retry; user must resend message if submission fails
+
+---
+
+## 8. Testing Strategy
+
+### Test Types
+
+| Test Type             | Scope                           | Coverage Target       | Approach            |
+| --------------------- | ------------------------------- | --------------------- | ------------------- |
+| **Unit Tests**        | Controller, service logic       | > 80%                 | Jest with mocks     |
+| **Integration Tests** | API endpoint + database         | Critical paths        | Supertest + test DB |
+| **E2E Tests**         | Full flow simulation            | Happy path            | Custom test harness |
+| **Security Tests**    | Token validation, rate limiting | All security features | Automated + manual  |
+
+### Critical Test Scenarios
+
+**Unit Tests**:
+
+- ✅ Token validation (valid, invalid, missing, expired)
+- ✅ Rate limiting enforcement
+- ✅ URL validation (various formats, edge cases)
+- ✅ Feed profile validation
+- ✅ Error response formatting
+
+**Integration Tests**:
+
+- ✅ POST `/api/articles/external` with valid token creates article job
+- ✅ POST with invalid token returns 401
+- ✅ POST with invalid URL returns 400 with INVALID_URL error
+- ✅ POST with rate limit exceeded returns 429
+- ✅ POST with duplicate article returns 409
+
+**E2E Tests**:
+
+- ✅ Full flow: Telegram message → Node-RED → API → Success response → Telegram reply
+- ✅ Error flow: Invalid URL → Error response → Telegram error message
+
+### Test Data Management
+
+- Use factories for test data generation
+- Separate test database for integration tests
+- Mock Telegram Bot API for E2E tests
+
+---
+
+## 9. Monitoring & Observability
+
+### Metrics to Track
+
+| Metric                         | Type    | Alert Threshold | Dashboard          |
+| ------------------------------ | ------- | --------------- | ------------------ |
+| `external_api.requests`        | Counter | -               | Grafana            |
+| `external_api.errors`          | Counter | > 5% error rate | PagerDuty          |
+| `external_api.latency`         | Latency | p95 > 2s        | Grafana            |
+| `external_api.rate_limit_hits` | Counter | > 100/min       | Slack #alerts      |
+| `article.scrape_failures`      | Counter | > 10/hour       | PagerDuty          |
+| `telegram.submissions`         | Counter | -               | Business Dashboard |
+
+### Structured Logging
+
+**Log Format** (JSON):
+
+```json
+{
+  "level": "info",
+  "timestamp": "2026-03-03T10:00:00Z",
+  "message": "External article submission received",
+  "context": {
+    "source": "telegram",
+    "url": "https://example.com/article",
+    "feedProfile": "technology",
+    "tokenPrefix": "tok_***",
+    "duration_ms": 150,
+    "articleId": "uuid-here"
+  }
+}
+```
+
+### Alerts
+
+| Alert                         | Severity    | Channel            | Action                    |
+| ----------------------------- | ----------- | ------------------ | ------------------------- |
+| Error rate > 5% for 5 minutes | P2 (High)   | Slack #engineering | Investigate API issues    |
+| Rate limit hits > 100/min     | P3 (Medium) | Slack #alerts      | Check for abuse           |
+| Scrape failures > 20/hour     | P2 (High)   | Slack #engineering | Check scraper health      |
+| API latency > 3s (p95)        | P2 (High)   | Slack #engineering | Performance investigation |
+
+---
+
+## 10. Rollback Plan
+
+### Deployment Strategy
+
+- **Feature Flag**: `TELEGRAM_INTEGRATION_ENABLED` (environment variable)
+- **Phased Rollout**:
+  - Phase 1: Deploy API endpoint (disabled)
+  - Phase 2: Enable for specific tokens only
+  - Phase 3: Full enablement
+
+### Rollback Triggers
+
+| Trigger                        | Action                                    |
+| ------------------------------ | ----------------------------------------- |
+| Error rate > 10% for 5 minutes | Disable endpoint via feature flag         |
+| Security incident              | Revoke all tokens immediately             |
+| Telegram Bot API outage        | Disable webhook, queue messages for later |
+| Database migration failure     | Stop deployment, investigate              |
+
+### Rollback Steps
+
+**Immediate Rollback (< 2 minutes)**:
+
+1. Set environment variable `TELEGRAM_INTEGRATION_ENABLED=false`
+2. Restart application or use runtime config update
+3. Verify endpoint returns 503 Service Unavailable
+
+**Token Revocation** (if security issue):
+
+1. Remove compromised token from `EXTERNAL_API_TOKENS`
+2. Generate new token
+3. Update Node-RED configuration
+4. Restart Node-RED flow
+
+**Communication**:
+
+- Notify #engineering Slack channel
+- Update status page if external impact
+- Create incident ticket for tracking
+
+---
+
+## 11. Implementation Phases
+
+| Phase                  | Task                     | Description                                        | Owner   | Estimate | Status   |
+| ---------------------- | ------------------------ | -------------------------------------------------- | ------- | -------- | -------- |
+| **Phase 1 - Setup**    | Telegram Bot creation    | Create bot via BotFather, configure basic settings | @Dev    | 2h       | ✅ Complete |
+|                        | Environment setup        | Add EXTERNAL_API_TOKENS to env, configure Node-RED | @DevOps | 4h       | ✅ Complete (env vars in .env.sample) |
+| **Phase 2 - API**      | Create controller        | Implement POST /api/articles/external endpoint     | @Dev    | 4h       | ✅ Complete |
+|                        | Add authentication guard | Create ExternalTokenGuard for token validation     | @Dev    | 3h       | ✅ Complete |
+|                        | Add rate limiting        | Implement Redis-backed rate limiting               | @Dev    | 3h       | ✅ Complete |
+|                        | DTO validation           | Create DTOs with class-validator decorators        | @Dev    | 2h       | ✅ Complete |
+| **Phase 3 - Node-RED** | Flow development         | Create message parsing and forwarding flow         | @Dev    | 6h       | ✅ Complete |
+|                        | Error handling           | Implement error message formatting and replies     | @Dev    | 3h       | ✅ Complete |
+|                        | Testing                  | Test flow with various message formats            | @Dev    | 2h       | ✅ Complete |
+| **Phase 4 - Testing**  | Unit tests               | Test controller, guard, and service logic          | @Dev    | 4h       | ✅ Complete |
+|                        | Integration tests        | Test API endpoint with test database               | @Dev    | 3h       | ✅ Complete |
+|                        | E2E validation          | Full flow testing from Telegram to API            | @Dev    | 2h       | ✅ Complete |
+| **Phase 5 - Deploy**   | Staging deployment       | Deploy to staging, configure test bot              | @DevOps | 2h       | ⏳ Pending |
+|                        | Production deployment    | Deploy to production with feature flag disabled    | @DevOps | 2h       | ⏳ Pending |
+|                        | Enable and monitor       | Enable feature flag, monitor metrics              | @Team   | 2h       | ⏳ Pending |
+
+**Total Estimate**: ~44 hours (~5-6 working days)
+
+---
+
+## 12. Dependencies
+
+| Dependency             | Type           | Owner         | Status           | Risk |
+| ---------------------- | -------------- | ------------- | ---------------- | ---- |
+| Telegram Bot API       | External       | Telegram Inc. | Production-ready | Low  |
+| Node-RED               | Infrastructure | DevOps        | Ready (docker-compose) | Low  |
+| Redis                  | Infrastructure | DevOps        | Ready            | Low  |
+| Existing Article Queue | Internal       | Backend Team  | Production-ready | Low  |
+| ScraperService         | Internal       | Backend Team  | Production-ready | Low  |
+
+**Approval Requirements**:
+
+- [ ] Security review of token-based authentication approach
+- [ ] DevOps approval for Node-RED flow deployment process
+- [ ] Product sign-off on user experience (message formats)
+
+---
+
+## 13. Open Questions
+
+| #   | Question                                                  | Context                                                          | Owner     | Status     | Decision Date |
+| --- | --------------------------------------------------------- | ---------------------------------------------------------------- | --------- | ---------- | ------------- |
+| 1   | ~~Should we store Telegram metadata persistently?~~       | ✅ **RESOLVED**: Store metadata in new table for analytics        | @TechLead | ✅ Resolved | 2026-03-03    |
+| 2   | Do we need multiple tokens for different sources?         | Future: WhatsApp, Slack integrations                             | @TechLead | 🔴 Open     | TBD           |
+| 3   | ~~Should Node-RED be hosted on existing infrastructure?~~ | ✅ **RESOLVED**: Host on Raspberry Pi alongside API and frontend  | @DevOps   | ✅ Resolved | 2026-03-03    |
+| 4   | ~~What message format should users follow?~~              | ✅ **RESOLVED**: See Section 5.2.1 - 3 options presented          | @Product  | ✅ Resolved | 2026-03-03    |
+| 5   | ~~Do we need to support message editing?~~               | ✅ **RESOLVED**: Not needed for V1 - users can resubmit if needed | @Product  | ✅ Resolved | 2026-03-05    |
+| 6   | ~~Which message format option to implement?~~             | ✅ **RESOLVED**: Option B (Structured Format) - See Section 5.2.1 | @Product  | ✅ Resolved | 2026-03-03    |
+
+---
+
+## 14. Glossary
+
+| Term                 | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| **Telegram Bot**     | Automated account on Telegram that can receive and send messages          |
+| **Node-RED**         | Flow-based development tool for visual programming                        |
+| **Feed Profile**     | Categorization system for articles (technology, politics, business, etc.) |
+| **BullMQ**           | Queue system for handling background jobs in Node.js                      |
+| **External Token**   | Pre-shared secret for authenticating requests from external systems       |
+| **Webhook**          | HTTP callback that delivers events to a specified URL                     |
+| **Rate Limiting**    | Technique to control the rate of requests to an API endpoint              |
+| **Article Scraping** | Process of extracting content from a web page URL                         |
+
+---
+
+## 15. Success Metrics
+
+| Metric                     | Baseline | Target | Measurement          |
+| -------------------------- | -------- | ------ | -------------------- |
+| Article submissions/day    | 0        | > 10   | Database query       |
+| Submission success rate    | N/A      | > 95%  | API logs             |
+| Average submission latency | N/A      | < 3s   | API metrics          |
+| Error rate                 | N/A      | < 2%   | Error tracking       |
+| User adoption              | 0        | > 50%  | User survey (future) |
+
+---
+
+## Appendix A: API Endpoint Comparison
+
+| Aspect         | Existing Endpoint    | New External Endpoint            |
+| -------------- | -------------------- | -------------------------------- |
+| Path           | `POST /api/articles` | `POST /api/articles/external`    |
+| Auth           | JWT Bearer token     | X-External-Token header          |
+| Rate Limiting  | Per-user limits      | Per-token + global limits        |
+| Input          | URL + feedProfile    | URL + feedProfile + metadata     |
+| Response       | Job info + message   | Structured JSON with error codes |
+| Error Handling | HTTP exceptions      | Structured error responses       |
+| User Context   | Authenticated user   | Anonymous (token-based)          |
+
+---
+
+## Appendix B: Message Format Examples
+
+**Valid Message Formats**:
+
+```
+# Format 1: URL on first line, profile on second
+https://addyosmani.com/blog/self-improving-agents/
+technology
+
+# Format 2: Single line with space separator
+https://addyosmani.com/blog/self-improving-agents/ technology
+
+# Format 3: With explicit feedProfile label
+https://addyosmani.com/blog/self-improving-agents/
+feedProfile: technology
+```
+
+**Bot Response Examples**:
+
+```
+✅ Article submitted successfully!
+📝 Title: Self-Improving Agents
+📊 Status: Queued for processing
+🆔 Job ID: 550e8400-e29b-41d4-a716-446655440000
+```
+
+```
+❌ Submission failed
+Reason: The URL provided is not valid
+Please check the URL and try again.
+```
+
+---
+
+## Approval & Sign-off
+
+| Role            | Name | Status    | Date | Comments |
+| --------------- | ---- | --------- | ---- | -------- |
+| Tech Lead       | @TBD | ⏳ Pending | -    | -        |
+| Engineering     | @TBD | ⏳ Pending | -    | -        |
+| Security Review | @TBD | ⏳ Pending | -    | -        |
+| DevOps          | @TBD | ⏳ Pending | -    | -        |
+
+---
+
+*Document Version: 1.1*
+*Last Updated: 2026-03-05*

--- a/libs/auth/rate-limit/rate-limit.types.ts
+++ b/libs/auth/rate-limit/rate-limit.types.ts
@@ -1,5 +1,12 @@
+export interface RateLimitRequest {
+  headers: { [key: string]: string | string[] | undefined };
+  ip?: string;
+  connection?: { remoteAddress?: string };
+  socket?: { remoteAddress?: string };
+}
+
 export interface RateLimitOptions {
   windowMs?: number;
   maxAttempts?: number;
-  keyGenerator?: (request: Request) => string;
+  keyGenerator?: (request: RateLimitRequest) => string;
 }

--- a/src/articles/articles.module.ts
+++ b/src/articles/articles.module.ts
@@ -10,9 +10,13 @@ import { ProfilesModule } from '../profiles/profiles.module';
 import { ScraperModule } from '../scraper/scraper.module';
 import { ArticlesController } from './articles.controller';
 import { ArticlesService } from './articles.service';
+import { ExternalArticlesController } from './external-articles.controller';
 import { MarkdownArticleProcessor } from './processors/markdown-article.processor';
 import { GetArticleByIdQuery } from './queries/get-article-by-id.query';
 import { ListArticlesQuery } from './queries/list-articles.query';
+import { TelegramSubmissionService } from './services/telegram-submission.service';
+import { RateLimitService } from '@libs/auth/rate-limit/rate-limit.service';
+import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
 
 @Module({
   imports: [
@@ -31,8 +35,11 @@ import { ListArticlesQuery } from './queries/list-articles.query';
     ListArticlesQuery,
     GetArticleByIdQuery,
     MarkdownArticleProcessor,
+    TelegramSubmissionService,
+    RateLimitService,
+    RateLimitGuard,
   ],
-  controllers: [ArticlesController],
-  exports: [ArticlesService],
+  controllers: [ArticlesController, ExternalArticlesController],
+  exports: [ArticlesService, TelegramSubmissionService],
 })
 export class ArticlesModule {}

--- a/src/articles/dto/external-article-response.dto.ts
+++ b/src/articles/dto/external-article-response.dto.ts
@@ -1,0 +1,37 @@
+export interface ExternalArticleSuccessResponse {
+  success: true;
+  jobId: string;
+  articleId: string;
+  message: string;
+}
+
+export interface ExternalArticleErrorResponse {
+  success: false;
+  error: {
+    code: ExternalArticleErrorCode;
+    message: string;
+    retryAfter?: number;
+  };
+}
+
+export type ExternalArticleResponse = ExternalArticleSuccessResponse | ExternalArticleErrorResponse;
+
+export enum ExternalArticleErrorCode {
+  INVALID_URL = 'INVALID_URL',
+  INVALID_FEED_PROFILE = 'INVALID_FEED_PROFILE',
+  UNAUTHORIZED = 'UNAUTHORIZED',
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+  ARTICLE_EXISTS = 'ARTICLE_EXISTS',
+  SCRAPE_FAILED = 'SCRAPE_FAILED',
+  INTERNAL_ERROR = 'INTERNAL_ERROR',
+}
+
+export const EXTERNAL_ERROR_MESSAGES: Record<ExternalArticleErrorCode, string> = {
+  [ExternalArticleErrorCode.INVALID_URL]: "The URL you provided doesn't seem valid. Please check and try again.",
+  [ExternalArticleErrorCode.INVALID_FEED_PROFILE]: 'Invalid feed profile. Use one of: technology, politics, business, health, science, brasil, teclas',
+  [ExternalArticleErrorCode.UNAUTHORIZED]: 'Authentication error. Please contact support.',
+  [ExternalArticleErrorCode.RATE_LIMIT_EXCEEDED]: "You're submitting too fast. Please wait a minute.",
+  [ExternalArticleErrorCode.ARTICLE_EXISTS]: 'This article has already been submitted before.',
+  [ExternalArticleErrorCode.SCRAPE_FAILED]: "Couldn't access the article. Is the URL correct and accessible?",
+  [ExternalArticleErrorCode.INTERNAL_ERROR]: 'Something went wrong on our end. Please try again later.',
+};

--- a/src/articles/dto/external-create-article.dto.spec.ts
+++ b/src/articles/dto/external-create-article.dto.spec.ts
@@ -1,0 +1,131 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { ExternalCreateArticleDto } from './external-create-article.dto';
+import { FeedProfile } from '../../shared/types/feed';
+
+describe('ExternalCreateArticleDto', () => {
+  it('should validate with valid data', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+      feedProfile: FeedProfile.TECHNOLOGY,
+      source: 'telegram',
+      metadata: {
+        chatId: '123456789',
+        messageId: '456',
+        username: '@testuser',
+        note: 'Great article',
+      },
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail validation with invalid URL', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'not-a-valid-url',
+      feedProfile: FeedProfile.TECHNOLOGY,
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('url');
+  });
+
+  it('should fail validation with empty URL', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: '',
+      feedProfile: FeedProfile.TECHNOLOGY,
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some(e => e.property === 'url')).toBe(true);
+  });
+
+  it('should fail validation with invalid feed profile', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+      feedProfile: 'invalid-profile',
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('feedProfile');
+  });
+
+  it('should fail validation with missing feed profile', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+    });
+
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some(e => e.property === 'feedProfile')).toBe(true);
+  });
+
+  it('should validate without optional metadata', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+      feedProfile: FeedProfile.BUSINESS,
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should validate with partial metadata', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+      feedProfile: FeedProfile.POLITICS,
+      metadata: {
+        chatId: '123456789',
+      },
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail validation when metadata has invalid field types', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+      feedProfile: FeedProfile.POLITICS,
+      metadata: {
+        chatId: 12345,
+      },
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('metadata');
+    expect(errors[0].children?.some(e => e.property === 'chatId')).toBe(true);
+  });
+
+  it('should fail validation when metadata is not an object', async () => {
+    const dto = plainToInstance(ExternalCreateArticleDto, {
+      url: 'https://example.com/article',
+      feedProfile: FeedProfile.TECHNOLOGY,
+      metadata: 'invalid',
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('metadata');
+  });
+
+  it('should accept all valid feed profiles', async () => {
+    const validProfiles = Object.values(FeedProfile);
+
+    for (const profile of validProfiles) {
+      const dto = plainToInstance(ExternalCreateArticleDto, {
+        url: 'https://example.com/article',
+        feedProfile: profile,
+      });
+
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    }
+  });
+});

--- a/src/articles/dto/external-create-article.dto.ts
+++ b/src/articles/dto/external-create-article.dto.ts
@@ -1,0 +1,47 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  ValidateNested,
+} from 'class-validator';
+import { FeedProfile } from '../../shared/types/feed';
+
+export class ExternalSubmissionMetadataDto {
+  @IsOptional()
+  @IsString()
+  chatId?: string;
+
+  @IsOptional()
+  @IsString()
+  messageId?: string;
+
+  @IsOptional()
+  @IsString()
+  username?: string;
+
+  @IsOptional()
+  @IsString()
+  note?: string;
+}
+
+export class ExternalCreateArticleDto {
+  @IsNotEmpty()
+  @IsUrl()
+  url: string;
+
+  @IsNotEmpty()
+  @IsEnum(FeedProfile, { message: 'Invalid feed profile' })
+  feedProfile: FeedProfile;
+
+  @IsOptional()
+  @IsString()
+  source?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ExternalSubmissionMetadataDto)
+  metadata?: ExternalSubmissionMetadataDto;
+}

--- a/src/articles/external-articles.controller.spec.ts
+++ b/src/articles/external-articles.controller.spec.ts
@@ -1,0 +1,362 @@
+import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
+import { QueueService } from '@libs/queue';
+import {
+  ConflictException,
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '../config/config.service';
+import { ScraperService } from '../scraper/scraper.service';
+import { FeedProfile } from '../shared/types/feed';
+import { ExternalArticlesController } from './external-articles.controller';
+import {
+  ExternalArticleErrorCode,
+  ExternalArticleSuccessResponse,
+  EXTERNAL_ERROR_MESSAGES,
+} from './dto/external-article-response.dto';
+import { TelegramSubmissionService } from './services/telegram-submission.service';
+
+describe('ExternalArticlesController', () => {
+  let controller: ExternalArticlesController;
+  let scraperService: jest.Mocked<ScraperService>;
+  let queueService: jest.Mocked<QueueService>;
+  let telegramSubmissionService: jest.Mocked<TelegramSubmissionService>;
+
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv };
+    process.env.TELEGRAM_INTEGRATION_ENABLED = 'true';
+
+    const mockScraperService = {
+      scrapeSingleArticle: jest.fn(),
+    };
+
+    const mockQueueService = {
+      addArticleProcessingJob: jest.fn(),
+    };
+
+    const mockTelegramSubmissionService = {
+      createSubmission: jest.fn(),
+      updateSubmissionStatus: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const mockConfigService = {
+      getAppConfig: jest.fn().mockReturnValue({}),
+      isExternalArticleSubmissionEnabled: jest.fn(
+        () => process.env.TELEGRAM_INTEGRATION_ENABLED === 'true',
+      ),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExternalArticlesController],
+      providers: [
+        {
+          provide: ScraperService,
+          useValue: mockScraperService,
+        },
+        {
+          provide: QueueService,
+          useValue: mockQueueService,
+        },
+        {
+          provide: TelegramSubmissionService,
+          useValue: mockTelegramSubmissionService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    })
+      .overrideGuard(RateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ExternalArticlesController>(ExternalArticlesController);
+    scraperService = module.get(ScraperService);
+    queueService = module.get(QueueService);
+    telegramSubmissionService = module.get(TelegramSubmissionService);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createExternal', () => {
+    const validDto = {
+      url: 'https://example.com/article',
+      feedProfile: FeedProfile.TECHNOLOGY,
+      source: 'telegram',
+      metadata: {
+        chatId: '123456789',
+        messageId: '456',
+        username: '@testuser',
+        note: 'Great article about AI',
+      },
+    };
+
+    it('should successfully submit an article', async () => {
+      const articleId = 'article-uuid-123';
+      const jobId = 'job-uuid-456';
+
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      scraperService.scrapeSingleArticle.mockResolvedValue(articleId);
+      queueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: articleId,
+        jobId,
+        message: 'Article queued',
+      });
+
+      const result = await controller.createExternal(validDto) as ExternalArticleSuccessResponse;
+
+      expect(result.success).toBe(true);
+      expect(result.articleId).toBe(articleId);
+      expect(result.jobId).toBe(jobId);
+      expect(scraperService.scrapeSingleArticle).toHaveBeenCalledWith(
+        validDto.url,
+        validDto.feedProfile,
+      );
+      expect(queueService.addArticleProcessingJob).toHaveBeenCalledWith(
+        articleId,
+        validDto.feedProfile,
+      );
+    });
+
+    it('should return error when article already exists', async () => {
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      scraperService.scrapeSingleArticle.mockResolvedValue(null); // Article exists
+
+      try {
+        await controller.createExternal(validDto);
+        fail('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(HttpException);
+        const httpError = error as HttpException;
+        expect(httpError.getStatus()).toBe(HttpStatus.CONFLICT);
+        expect(httpError.getResponse()).toEqual({
+          success: false,
+          error: {
+            code: ExternalArticleErrorCode.ARTICLE_EXISTS,
+            message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.ARTICLE_EXISTS],
+          },
+        });
+        expect(telegramSubmissionService.updateSubmissionStatus).toHaveBeenCalledWith(
+          'submission-uuid',
+          'duplicate',
+          undefined,
+        );
+        expect(telegramSubmissionService.updateSubmissionStatus).not.toHaveBeenCalledWith(
+          'submission-uuid',
+          'failed',
+          expect.anything(),
+        );
+      }
+    });
+
+    it('should handle feature disabled', async () => {
+      process.env.TELEGRAM_INTEGRATION_ENABLED = 'false';
+
+      await expect(controller.createExternal(validDto)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('should handle scraping failure', async () => {
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      scraperService.scrapeSingleArticle.mockRejectedValue(new Error('Failed to extract content'));
+
+      try {
+        await controller.createExternal(validDto);
+        fail('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(HttpException);
+        const httpError = error as HttpException;
+        expect(httpError.getStatus()).toBe(HttpStatus.BAD_GATEWAY);
+        expect(httpError.getResponse()).toEqual({
+          success: false,
+          error: {
+            code: ExternalArticleErrorCode.SCRAPE_FAILED,
+            message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.SCRAPE_FAILED],
+          },
+        });
+      }
+    });
+
+    it('should handle bad request with URL error', async () => {
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      scraperService.scrapeSingleArticle.mockRejectedValue(
+        new ConflictException('Article already exists in database'),
+      );
+
+      try {
+        await controller.createExternal(validDto);
+        fail('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(HttpException);
+        const httpError = error as HttpException;
+        expect(httpError.getStatus()).toBe(HttpStatus.CONFLICT);
+        expect(httpError.getResponse()).toEqual({
+          success: false,
+          error: {
+            code: ExternalArticleErrorCode.ARTICLE_EXISTS,
+            message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.ARTICLE_EXISTS],
+          },
+        });
+      }
+    });
+
+    it('should handle rate limit exceeded', async () => {
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      scraperService.scrapeSingleArticle.mockRejectedValue(
+        new HttpException('Too many requests', HttpStatus.TOO_MANY_REQUESTS),
+      );
+
+      try {
+        await controller.createExternal(validDto);
+        fail('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(HttpException);
+        const httpError = error as HttpException;
+        expect(httpError.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+        expect(httpError.getResponse()).toEqual({
+          success: false,
+          error: {
+            code: ExternalArticleErrorCode.RATE_LIMIT_EXCEEDED,
+            message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.RATE_LIMIT_EXCEEDED],
+          },
+        });
+      }
+    });
+
+    it('should handle internal server error', async () => {
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      scraperService.scrapeSingleArticle.mockResolvedValue('article-uuid-123');
+      queueService.addArticleProcessingJob.mockRejectedValue(new Error('Queue down'));
+
+      try {
+        await controller.createExternal(validDto);
+        fail('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(HttpException);
+        const httpError = error as HttpException;
+        expect(httpError.getStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+        expect(httpError.getResponse()).toEqual({
+          success: false,
+          error: {
+            code: ExternalArticleErrorCode.INTERNAL_ERROR,
+            message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.INTERNAL_ERROR],
+          },
+        });
+      }
+    });
+
+    it('should continue even if submission record creation fails', async () => {
+      telegramSubmissionService.createSubmission.mockRejectedValue(new Error('DB error'));
+
+      const articleId = 'article-uuid-123';
+      const jobId = 'job-uuid-456';
+
+      scraperService.scrapeSingleArticle.mockResolvedValue(articleId);
+      queueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: articleId,
+        jobId,
+        message: 'Article queued',
+      });
+
+      const result = await controller.createExternal(validDto) as ExternalArticleSuccessResponse;
+
+      expect(result.success).toBe(true);
+      expect(result.articleId).toBe(articleId);
+    });
+
+    it('should continue even if submission status update fails', async () => {
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      telegramSubmissionService.updateSubmissionStatus.mockRejectedValue(
+        new Error('DB error'),
+      );
+
+      const articleId = 'article-uuid-123';
+      const jobId = 'job-uuid-456';
+
+      scraperService.scrapeSingleArticle.mockResolvedValue(articleId);
+      queueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: articleId,
+        jobId,
+        message: 'Article queued',
+      });
+
+      const result = await controller.createExternal(validDto) as ExternalArticleSuccessResponse;
+
+      expect(result.success).toBe(true);
+      expect(result.articleId).toBe(articleId);
+      expect(telegramSubmissionService.updateSubmissionStatus).toHaveBeenCalledWith(
+        'submission-uuid',
+        'success',
+        { articleId },
+      );
+    });
+
+    it('should handle missing optional metadata', async () => {
+      const dtoWithoutMetadata = {
+        url: 'https://example.com/article',
+        feedProfile: FeedProfile.TECHNOLOGY,
+      };
+
+      telegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+
+      const articleId = 'article-uuid-123';
+      const jobId = 'job-uuid-456';
+
+      scraperService.scrapeSingleArticle.mockResolvedValue(articleId);
+      queueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: articleId,
+        jobId,
+        message: 'Article queued',
+      });
+
+      const result = await controller.createExternal(dtoWithoutMetadata) as ExternalArticleSuccessResponse;
+
+      expect(result.success).toBe(true);
+      expect(telegramSubmissionService.createSubmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: 'unknown',
+          messageId: 'unknown',
+        }),
+      );
+    });
+
+    it('should reject localhost URLs', async () => {
+      const dto = {
+        ...validDto,
+        url: 'http://localhost/internal',
+      };
+
+      await expect(controller.createExternal(dto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('should reject private IPv4 URLs', async () => {
+      const dto = {
+        ...validDto,
+        url: 'http://192.168.1.10/article',
+      };
+
+      await expect(controller.createExternal(dto)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/src/articles/external-articles.controller.ts
+++ b/src/articles/external-articles.controller.ts
@@ -1,3 +1,4 @@
+import { Public } from '@libs/auth';
 import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
 import { RateLimit } from '@libs/auth/rate-limit/rate-limit.decorator';
 import { RateLimitRequest } from '@libs/auth/rate-limit/rate-limit.types';
@@ -46,6 +47,7 @@ const resolveExternalRateLimitKey = (request: RateLimitRequest): string => {
 };
 
 @Controller('api/articles/external')
+@Public()
 @UseGuards(RateLimitGuard, ExternalTokenGuard)
 export class ExternalArticlesController {
   private readonly logger = new Logger(ExternalArticlesController.name);

--- a/src/articles/external-articles.controller.ts
+++ b/src/articles/external-articles.controller.ts
@@ -1,0 +1,376 @@
+import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
+import { RateLimit } from '@libs/auth/rate-limit/rate-limit.decorator';
+import { RateLimitRequest } from '@libs/auth/rate-limit/rate-limit.types';
+import { QueueService } from '@libs/queue';
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Logger,
+  Post,
+  ServiceUnavailableException,
+  UseGuards,
+  forwardRef,
+} from '@nestjs/common';
+import { isIP } from 'net';
+import { ConfigService } from '../config/config.service';
+import { ScraperService } from '../scraper/scraper.service';
+import { FeedProfile } from '../shared/types/feed';
+import { ExternalCreateArticleDto } from './dto/external-create-article.dto';
+import {
+  ExternalArticleErrorCode,
+  ExternalArticleResponse,
+  EXTERNAL_ERROR_MESSAGES,
+} from './dto/external-article-response.dto';
+import { ExternalTokenGuard } from './guards/external-token.guard';
+import { TelegramSubmissionService } from './services/telegram-submission.service';
+
+const resolveExternalRateLimitKey = (request: RateLimitRequest): string => {
+  const tokenHeader = request.headers['x-external-token'];
+  const token = typeof tokenHeader === 'string'
+    ? tokenHeader
+    : Array.isArray(tokenHeader)
+      ? tokenHeader[0]
+      : '';
+
+  if (token.trim()) {
+    return `external:token:${token}`;
+  }
+
+  const ip = request.ip ?? request.socket?.remoteAddress ?? request.connection?.remoteAddress ?? 'unknown';
+  return `external:ip:${ip}`;
+};
+
+@Controller('api/articles/external')
+@UseGuards(RateLimitGuard, ExternalTokenGuard)
+export class ExternalArticlesController {
+  private readonly logger = new Logger(ExternalArticlesController.name);
+
+  constructor(
+    private readonly scraperService: ScraperService,
+    @Inject(forwardRef(() => QueueService))
+    private readonly queueService: QueueService,
+    private readonly telegramSubmissionService: TelegramSubmissionService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Post()
+  @RateLimit({
+    windowMs: 60 * 1000,
+    maxAttempts: 10,
+    keyGenerator: resolveExternalRateLimitKey,
+  })
+  async createExternal(@Body() dto: ExternalCreateArticleDto): Promise<ExternalArticleResponse> {
+    if (!this.isFeatureEnabled()) {
+      throw new ServiceUnavailableException({
+        success: false,
+        error: {
+          code: ExternalArticleErrorCode.INTERNAL_ERROR,
+          message: 'External article submission is currently disabled',
+        },
+      });
+    }
+
+    const { url, feedProfile, source = 'external', metadata } = dto;
+    this.assertSafeExternalUrl(url);
+
+    const submissionMetadata = {
+      // Default to 'unknown' for chatId and messageId to ensure submission record
+      // can be created even if metadata is missing. This allows graceful handling
+      // of non-Telegram sources or misconfigured clients.
+      chatId: metadata?.chatId || 'unknown',
+      username: metadata?.username,
+      messageId: metadata?.messageId || 'unknown',
+      messageText: metadata?.note,
+    };
+
+    let submissionId: string | null = null;
+    try {
+      submissionId = await this.telegramSubmissionService.createSubmission({
+        chatId: submissionMetadata.chatId,
+        username: submissionMetadata.username,
+        messageId: submissionMetadata.messageId,
+        messageText: submissionMetadata.messageText,
+        feedProfile,
+        url,
+        submissionStatus: 'pending',
+      });
+    } catch (error) {
+      // Graceful degradation: If submission record creation fails, log the error
+      // but continue processing the article. This ensures the article submission
+      // still works even if the analytics database has issues.
+      this.logger.error('Failed to create submission record', error);
+    }
+
+    const articleId = await this.scrapeArticleOrThrow(url, feedProfile, submissionId);
+
+    if (articleId === null) {
+      if (submissionId) {
+        await this.safeUpdateSubmissionStatus(submissionId, 'duplicate');
+      }
+
+      throw new ConflictException({
+        success: false,
+        error: {
+          code: ExternalArticleErrorCode.ARTICLE_EXISTS,
+          message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.ARTICLE_EXISTS],
+        },
+      });
+    }
+
+    const jobInfo = await this.enqueueArticleOrThrow(articleId, feedProfile, submissionId);
+
+    if (submissionId) {
+      await this.safeUpdateSubmissionStatus(submissionId, 'success', {
+        articleId,
+      });
+    }
+
+    this.logSubmission({
+      source,
+      url: this.sanitizeUrl(url),
+      feedProfile,
+      articleId,
+    });
+
+    return {
+      success: true,
+      jobId: jobInfo.jobId,
+      articleId,
+      message: 'Article submitted successfully and queued for processing',
+    };
+  }
+
+  private async handleError(
+    error: unknown,
+    submissionId: string | null,
+    fallback: { code: ExternalArticleErrorCode; status: HttpStatus },
+  ): Promise<never> {
+    const mapped = this.mapError(error, fallback);
+
+    if (submissionId && mapped.code !== ExternalArticleErrorCode.ARTICLE_EXISTS) {
+      await this.safeUpdateSubmissionStatus(submissionId, 'failed', {
+        errorMessage: mapped.message,
+      });
+    }
+
+    this.logger.error(`External article submission failed: ${mapped.code}`, error);
+
+    throw new HttpException(
+      {
+        success: false,
+        error: {
+          code: mapped.code,
+          message: mapped.message,
+        },
+      },
+      mapped.status,
+    );
+  }
+
+  private isFeatureEnabled(): boolean {
+    const enabled = this.configService.isExternalArticleSubmissionEnabled();
+    return enabled === true;
+  }
+
+  private mapError(
+    error: unknown,
+    fallback: { code: ExternalArticleErrorCode; status: HttpStatus },
+  ): { code: ExternalArticleErrorCode; message: string; status: HttpStatus } {
+    if (!(error instanceof HttpException)) {
+      return {
+        code: fallback.code,
+        message: EXTERNAL_ERROR_MESSAGES[fallback.code],
+        status: fallback.status,
+      };
+    }
+
+    const statusCode = Number(error.getStatus());
+    if (statusCode === 409) {
+      return {
+        code: ExternalArticleErrorCode.ARTICLE_EXISTS,
+        message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.ARTICLE_EXISTS],
+        status: HttpStatus.CONFLICT,
+      };
+    }
+
+    if (statusCode === 400) {
+      return {
+        code: ExternalArticleErrorCode.INVALID_URL,
+        message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.INVALID_URL],
+        status: HttpStatus.BAD_REQUEST,
+      };
+    }
+
+    if (statusCode === 429) {
+      return {
+        code: ExternalArticleErrorCode.RATE_LIMIT_EXCEEDED,
+        message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.RATE_LIMIT_EXCEEDED],
+        status: HttpStatus.TOO_MANY_REQUESTS,
+      };
+    }
+
+    return {
+      code: fallback.code,
+      message: EXTERNAL_ERROR_MESSAGES[fallback.code],
+      status: fallback.status,
+    };
+  }
+
+  private assertSafeExternalUrl(url: string): void {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      throw this.createInvalidUrlException();
+    }
+
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      throw this.createInvalidUrlException();
+    }
+
+    const hostname = parsedUrl.hostname.toLowerCase();
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+      throw this.createInvalidUrlException();
+    }
+
+    if (this.isBlockedIpAddress(hostname)) {
+      throw this.createInvalidUrlException();
+    }
+  }
+
+  private createInvalidUrlException(): BadRequestException {
+    return new BadRequestException({
+      success: false,
+      error: {
+        code: ExternalArticleErrorCode.INVALID_URL,
+        message: EXTERNAL_ERROR_MESSAGES[ExternalArticleErrorCode.INVALID_URL],
+      },
+    });
+  }
+
+  private isBlockedIpAddress(host: string): boolean {
+    const ipVersion = isIP(host);
+    if (ipVersion === 4) {
+      const octets = host.split('.').map((segment) => Number.parseInt(segment, 10));
+      const first = octets[0];
+      const second = octets[1];
+
+      if (host === '100.100.100.200') {
+        return true;
+      }
+
+      return (
+        first === 0 ||
+        first === 10 ||
+        first === 127 ||
+        (first === 169 && second === 254) ||
+        (first === 172 && second >= 16 && second <= 31) ||
+        (first === 192 && second === 168)
+      );
+    }
+
+    if (ipVersion === 6) {
+      const normalizedHost = host.toLowerCase();
+      if (normalizedHost === '::1') {
+        return true;
+      }
+
+      if (normalizedHost.startsWith('fc') || normalizedHost.startsWith('fd')) {
+        return true;
+      }
+
+      if (
+        normalizedHost.startsWith('fe8') ||
+        normalizedHost.startsWith('fe9') ||
+        normalizedHost.startsWith('fea') ||
+        normalizedHost.startsWith('feb')
+      ) {
+        return true;
+      }
+
+      if (normalizedHost.startsWith('::ffff:')) {
+        const ipv4Part = normalizedHost.replace('::ffff:', '');
+        return this.isBlockedIpAddress(ipv4Part);
+      }
+    }
+
+    return false;
+  }
+
+  private async scrapeArticleOrThrow(
+    url: string,
+    feedProfile: FeedProfile,
+    submissionId: string | null,
+  ): Promise<string | null> {
+    try {
+      return await this.scraperService.scrapeSingleArticle(url, feedProfile);
+    } catch (error) {
+      await this.handleError(error, submissionId, {
+        code: ExternalArticleErrorCode.SCRAPE_FAILED,
+        status: HttpStatus.BAD_GATEWAY,
+      });
+    }
+    throw new Error('Unreachable');
+  }
+
+  private async enqueueArticleOrThrow(
+    articleId: string,
+    feedProfile: FeedProfile,
+    submissionId: string | null,
+  ): Promise<Awaited<ReturnType<QueueService['addArticleProcessingJob']>>> {
+    try {
+      return await this.queueService.addArticleProcessingJob(articleId, feedProfile);
+    } catch (error) {
+      await this.handleError(error, submissionId, {
+        code: ExternalArticleErrorCode.INTERNAL_ERROR,
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+      });
+    }
+    throw new Error('Unreachable');
+  }
+
+  private async safeUpdateSubmissionStatus(
+    submissionId: string,
+    status: 'success' | 'failed' | 'duplicate',
+    options?: { articleId?: string; errorMessage?: string },
+  ): Promise<void> {
+    try {
+      await this.telegramSubmissionService.updateSubmissionStatus(submissionId, status, options);
+    } catch (error) {
+      this.logger.error('Failed to update submission status', error);
+    }
+  }
+
+  private sanitizeUrl(url: string): string {
+    try {
+      const parsedUrl = new URL(url);
+      return `${parsedUrl.origin}${parsedUrl.pathname}`;
+    } catch {
+      return 'invalid-url';
+    }
+  }
+
+  private logSubmission(context: {
+    source: string;
+    url: string;
+    feedProfile: string;
+    articleId: string;
+  }): void {
+    this.logger.log({
+      message: 'External article submission received',
+      level: 'info',
+      timestamp: new Date().toISOString(),
+      context: {
+        source: context.source,
+        url: context.url,
+        feedProfile: context.feedProfile,
+        articleId: context.articleId,
+      },
+    });
+  }
+}

--- a/src/articles/guards/external-token.guard.spec.ts
+++ b/src/articles/guards/external-token.guard.spec.ts
@@ -1,0 +1,153 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ExternalTokenGuard } from './external-token.guard';
+import { ConfigService } from '../../config/config.service';
+
+describe('ExternalTokenGuard', () => {
+  let guard: ExternalTokenGuard;
+  let mockContext: ExecutionContext;
+  let mockConfigService: jest.Mocked<ConfigService>;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    mockConfigService = {
+      getExternalApiTokens: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
+    
+    guard = new ExternalTokenGuard(mockConfigService);
+    process.env = { ...originalEnv };
+
+    mockContext = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          headers: {},
+        }),
+      }),
+    } as unknown as ExecutionContext;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('canActivate', () => {
+    it('should return true for valid token', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue(['valid-token-1', 'valid-token-2']);
+
+      const request = {
+        headers: {
+          'x-external-token': 'valid-token-1',
+        },
+      };
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue(request),
+      });
+
+      const result = guard.canActivate(mockContext);
+
+      expect(result).toBe(true);
+      expect(request['externalToken']).toBe('valid-token-1');
+      expect(mockConfigService.getExternalApiTokens).toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException when token is missing', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue(['valid-token']);
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          headers: {},
+        }),
+      });
+
+      expect(() => guard.canActivate(mockContext)).toThrow(
+        new UnauthorizedException('Missing X-External-Token header'),
+      );
+    });
+
+    it('should throw UnauthorizedException when token is invalid', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue(['valid-token']);
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          headers: {
+            'x-external-token': 'invalid-token',
+          },
+        }),
+      });
+
+      expect(() => guard.canActivate(mockContext)).toThrow(
+        new UnauthorizedException('Invalid authentication token'),
+      );
+    });
+
+    it('should throw UnauthorizedException when no tokens are configured', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue([]);
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          headers: {
+            'x-external-token': 'any-token',
+          },
+        }),
+      });
+
+      expect(() => guard.canActivate(mockContext)).toThrow(
+        new UnauthorizedException('Invalid authentication token'),
+      );
+    });
+
+    it('should handle tokens with whitespace', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue(['token-with-spaces', 'another-token']);
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          headers: {
+            'x-external-token': 'token-with-spaces',
+          },
+        }),
+      });
+
+      const result = guard.canActivate(mockContext);
+
+      expect(result).toBe(true);
+    });
+
+    it('should handle case where EXTERNAL_API_TOKENS is undefined', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue([]);
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          headers: {
+            'x-external-token': 'any-token',
+          },
+        }),
+      });
+
+      expect(() => guard.canActivate(mockContext)).toThrow(
+        new UnauthorizedException('Invalid authentication token'),
+      );
+    });
+
+    it('should accept first token when header is an array', () => {
+      mockConfigService.getExternalApiTokens.mockReturnValue(['valid-token-1', 'valid-token-2']);
+
+      const request = {
+        headers: {
+          'x-external-token': ['valid-token-1', 'ignored-token'],
+        },
+      };
+
+      mockContext.switchToHttp = jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue(request),
+      });
+
+      const result = guard.canActivate(mockContext);
+      expect(result).toBe(true);
+      expect(request['externalToken']).toBe('valid-token-1');
+    });
+  });
+});

--- a/src/articles/guards/external-token.guard.ts
+++ b/src/articles/guards/external-token.guard.ts
@@ -1,0 +1,82 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { timingSafeEqual } from 'crypto';
+import { ConfigService } from '../../config/config.service';
+
+/**
+ * Guard that validates external API tokens from X-External-Token header.
+ * Tokens are configured via EXTERNAL_API_TOKENS environment variable (comma-separated).
+ * Uses constant-time comparison to prevent timing attacks.
+ */
+@Injectable()
+export class ExternalTokenGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const tokenHeader = request.headers['x-external-token'];
+    const token = typeof tokenHeader === 'string'
+      ? tokenHeader
+      : Array.isArray(tokenHeader)
+        ? tokenHeader[0]
+        : undefined;
+
+    if (!token || !token.trim()) {
+      throw new UnauthorizedException('Missing X-External-Token header');
+    }
+
+    const validTokens = this.getValidTokens();
+
+    if (!this.isTokenValid(token, validTokens)) {
+      throw new UnauthorizedException('Invalid authentication token');
+    }
+
+    request.externalToken = token;
+
+    return true;
+  }
+
+  /**
+   * Constant-time token comparison to prevent timing attacks.
+   * Uses crypto.timingSafeEqual for secure comparison.
+   */
+  private isTokenValid(token: string, validTokens: string[]): boolean {
+    return validTokens.some(validToken => this.constantTimeCompare(token, validToken));
+  }
+
+  /**
+   * Constant-time string comparison using crypto.timingSafeEqual.
+   * Returns true only if strings are exactly equal.
+   */
+  private constantTimeCompare(a: string, b: string): boolean {
+    // Convert strings to buffers for timing-safe comparison
+    const aBuffer = Buffer.from(a);
+    const bBuffer = Buffer.from(b);
+    
+    // If lengths differ, use timingSafeEqual with same-length buffers
+    // to maintain constant time
+    if (aBuffer.length !== bBuffer.length) {
+      const dummyBuffer = Buffer.alloc(aBuffer.length);
+      try {
+        timingSafeEqual(aBuffer, dummyBuffer);
+      } catch {
+        // Ignore - just maintaining constant time
+      }
+      return false;
+    }
+
+    try {
+      return timingSafeEqual(aBuffer, bBuffer);
+    } catch {
+      return a === b;
+    }
+  }
+
+  private getValidTokens(): string[] {
+    return this.configService.getExternalApiTokens();
+  }
+}

--- a/src/articles/services/telegram-submission.service.spec.ts
+++ b/src/articles/services/telegram-submission.service.spec.ts
@@ -1,0 +1,514 @@
+import { DatabaseService } from '@libs/database';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TelegramSubmissionService, TelegramSubmissionData, TelegramSubmissionRecord } from './telegram-submission.service';
+
+describe('TelegramSubmissionService', () => {
+  let service: TelegramSubmissionService;
+
+  // Mock database connection
+  const mockDbConnection = {
+    all: jest.fn(),
+    get: jest.fn(),
+    run: jest.fn(),
+    prepare: jest.fn(),
+    close: jest.fn(),
+    serialize: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const mockDatabaseService = {
+      getDbConnection: jest.fn().mockReturnValue(mockDbConnection),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TelegramSubmissionService,
+        {
+          provide: DatabaseService,
+          useValue: mockDatabaseService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TelegramSubmissionService>(TelegramSubmissionService);
+    // Clear mocks
+    mockDbConnection.all.mockClear();
+    mockDbConnection.get.mockClear();
+    mockDbConnection.run.mockClear();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createSubmission', () => {
+    it('should create a submission record successfully', async () => {
+      const submissionId = '550e8400-e29b-41d4-a716-446655440000';
+      mockDbConnection.get.mockImplementation((query, values, callback) => {
+        callback(null, { id: submissionId });
+      });
+
+      const data: TelegramSubmissionData = {
+        chatId: '123456789',
+        username: 'testuser',
+        messageId: '456',
+        messageText: 'Test message',
+        feedProfile: 'technology',
+        url: 'https://example.com/article',
+        submissionStatus: 'pending',
+      };
+
+      const result = await service.createSubmission(data);
+
+      expect(result).toBe(submissionId);
+      expect(mockDbConnection.get).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO telegram_submissions'),
+        expect.arrayContaining([
+          null, // article_id
+          data.chatId,
+          data.username,
+          data.messageId,
+          data.messageText,
+          data.feedProfile,
+          data.url,
+          data.submissionStatus,
+          null, // error_message
+        ]),
+        expect.any(Function),
+      );
+    });
+
+    it('should handle optional fields being undefined', async () => {
+      const submissionId = '550e8400-e29b-41d4-a716-446655440000';
+      mockDbConnection.get.mockImplementation((query, values, callback) => {
+        callback(null, { id: submissionId });
+      });
+
+      const data: TelegramSubmissionData = {
+        chatId: '123456789',
+        messageId: '456',
+        feedProfile: 'technology',
+        url: 'https://example.com/article',
+        submissionStatus: 'pending',
+      };
+
+      const result = await service.createSubmission(data);
+
+      expect(result).toBe(submissionId);
+      expect(mockDbConnection.get).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining([
+          null, // article_id
+          data.chatId,
+          null, // username
+          data.messageId,
+          null, // message_text
+          data.feedProfile,
+          data.url,
+          data.submissionStatus,
+          null, // error_message
+        ]),
+        expect.any(Function),
+      );
+    });
+
+    it('should reject on database error', async () => {
+      mockDbConnection.get.mockImplementation((query, values, callback) => {
+        callback(new Error('Database error'), null);
+      });
+
+      const data: TelegramSubmissionData = {
+        chatId: '123456789',
+        messageId: '456',
+        feedProfile: 'technology',
+        url: 'https://example.com/article',
+        submissionStatus: 'pending',
+      };
+
+      await expect(service.createSubmission(data)).rejects.toThrow('Database error');
+    });
+
+    it('should validate required fields', async () => {
+      const invalidData = {
+        chatId: '', // Empty string
+        messageId: '456',
+        feedProfile: 'technology',
+        url: 'https://example.com/article',
+        submissionStatus: 'pending',
+      } as TelegramSubmissionData;
+
+      await expect(service.createSubmission(invalidData)).rejects.toThrow('chatId is required');
+    });
+  });
+
+  describe('updateSubmissionStatus', () => {
+    it('should update submission status to success', async () => {
+      mockDbConnection.run.mockImplementation((query, values, callback) => {
+        callback(null);
+      });
+
+      const submissionId = '550e8400-e29b-41d4-a716-446655440000';
+      const articleId = 'article-uuid';
+
+      await service.updateSubmissionStatus(submissionId, 'success', { articleId });
+
+      expect(mockDbConnection.run).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE telegram_submissions'),
+        ['success', articleId, null, submissionId],
+        expect.any(Function),
+      );
+    });
+
+    it('should update submission status to failed with error message', async () => {
+      mockDbConnection.run.mockImplementation((query, values, callback) => {
+        callback(null);
+      });
+
+      const submissionId = '550e8400-e29b-41d4-a716-446655440000';
+      const errorMessage = 'Failed to scrape article';
+
+      await service.updateSubmissionStatus(submissionId, 'failed', { errorMessage });
+
+      expect(mockDbConnection.run).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE telegram_submissions'),
+        ['failed', null, errorMessage, submissionId],
+        expect.any(Function),
+      );
+    });
+
+    it('should reject on database error', async () => {
+      mockDbConnection.run.mockImplementation((query, values, callback) => {
+        callback(new Error('Update failed'));
+      });
+
+      await expect(
+        service.updateSubmissionStatus('id', 'success', { articleId: 'article' }),
+      ).rejects.toThrow('Update failed');
+    });
+
+    it('should validate submission ID', async () => {
+      await expect(
+        service.updateSubmissionStatus('', 'success'),
+      ).rejects.toThrow('submissionId is required');
+    });
+
+    it('should validate status value', async () => {
+      await expect(
+        service.updateSubmissionStatus('id', 'invalid' as any),
+      ).rejects.toThrow('Invalid status value');
+    });
+  });
+
+  describe('getSubmissionById', () => {
+    it('should return submission by id', async () => {
+      const dbRow = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        article_id: 'article-uuid',
+        chat_id: '123456789',
+        username: 'testuser',
+        message_id: '456',
+        message_text: 'Test message',
+        feed_profile: 'technology',
+        url: 'https://example.com/article',
+        submission_status: 'success',
+        error_message: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      };
+
+      const expectedRecord: TelegramSubmissionRecord = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        articleId: 'article-uuid',
+        chatId: '123456789',
+        username: 'testuser',
+        messageId: '456',
+        messageText: 'Test message',
+        feedProfile: 'technology',
+        url: 'https://example.com/article',
+        submissionStatus: 'success',
+        errorMessage: null,
+        createdAt: dbRow.created_at,
+        updatedAt: dbRow.updated_at,
+      };
+
+      mockDbConnection.get.mockImplementation((query, values, callback) => {
+        callback(null, dbRow);
+      });
+
+      const result = await service.getSubmissionById(dbRow.id);
+
+      expect(result).toEqual(expectedRecord);
+    });
+
+    it('should return null when submission not found', async () => {
+      mockDbConnection.get.mockImplementation((query, values, callback) => {
+        callback(null, undefined);
+      });
+
+      const result = await service.getSubmissionById('non-existent-id');
+
+      expect(result).toBeNull();
+    });
+
+    it('should validate submission ID', async () => {
+      await expect(service.getSubmissionById('')).rejects.toThrow('submissionId is required');
+    });
+  });
+
+  describe('getSubmissionsByChatId', () => {
+    it('should return submissions for a chat', async () => {
+      const dbRows = [
+        {
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          chat_id: '123456789',
+          submission_status: 'success',
+          article_id: null,
+          username: null,
+          message_id: '123',
+          message_text: null,
+          feed_profile: 'tech',
+          url: 'https://example.com',
+          error_message: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: '550e8400-e29b-41d4-a716-446655440001',
+          chat_id: '123456789',
+          submission_status: 'failed',
+          article_id: null,
+          username: null,
+          message_id: '124',
+          message_text: null,
+          feed_profile: 'tech',
+          url: 'https://example.com',
+          error_message: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ];
+
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, dbRows);
+      });
+
+      const result = await service.getSubmissionsByChatId('123456789');
+
+      expect(result).toHaveLength(2);
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE chat_id = ?'),
+        ['123456789', 100, 0],
+        expect.any(Function),
+      );
+    });
+
+    it('should return empty array when no submissions found', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, null);
+      });
+
+      const result = await service.getSubmissionsByChatId('unknown-chat');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should validate chat ID', async () => {
+      await expect(service.getSubmissionsByChatId('')).rejects.toThrow('chatId is required');
+    });
+
+    it('should accept custom limit and offset', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, []);
+      });
+
+      await service.getSubmissionsByChatId('123456789', { limit: 50, offset: 10 });
+
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE chat_id = ?'),
+        ['123456789', 50, 10],
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('getRecentSubmissions', () => {
+    it('should return recent submissions with default limit', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, []);
+      });
+
+      await service.getRecentSubmissions();
+
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('LIMIT ?'),
+        [100],
+        expect.any(Function),
+      );
+    });
+
+    it('should filter by status', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, []);
+      });
+
+      await service.getRecentSubmissions({ status: 'success', limit: 50 });
+
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('submission_status = ?'),
+        ['success', 50],
+        expect.any(Function),
+      );
+    });
+
+    it('should filter by date range', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, []);
+      });
+
+      const startDate = new Date('2024-01-01');
+      const endDate = new Date('2024-12-31');
+
+      await service.getRecentSubmissions({ startDate, endDate });
+
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('created_at >= ? AND created_at <= ?'),
+        [startDate, endDate, 100],
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('getSubmissionStats', () => {
+    it('should return aggregated stats', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, [
+          { submission_status: 'success', count: '10' },
+          { submission_status: 'failed', count: '2' },
+          { submission_status: 'duplicate', count: '3' },
+          { submission_status: 'pending', count: '1' },
+        ]);
+      });
+
+      const result = await service.getSubmissionStats();
+
+      expect(result).toEqual({
+        total: 16,
+        success: 10,
+        failed: 2,
+        duplicate: 3,
+        pending: 1,
+      });
+    });
+
+    it('should handle empty results', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, []);
+      });
+
+      const result = await service.getSubmissionStats();
+
+      expect(result).toEqual({
+        total: 0,
+        success: 0,
+        failed: 0,
+        duplicate: 0,
+        pending: 0,
+      });
+    });
+
+    it('should handle null results', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, null);
+      });
+
+      const result = await service.getSubmissionStats();
+
+      expect(result).toEqual({
+        total: 0,
+        success: 0,
+        failed: 0,
+        duplicate: 0,
+        pending: 0,
+      });
+    });
+
+    it('should handle invalid count values', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, [
+          { submission_status: 'success', count: 'invalid' },
+          { submission_status: 'failed', count: '2' },
+        ]);
+      });
+
+      const result = await service.getSubmissionStats();
+
+      // Should skip invalid count and only count valid ones
+      expect(result.total).toBe(2);
+      expect(result.failed).toBe(2);
+      expect(result.success).toBe(0);
+    });
+  });
+
+  describe('deleteOldSubmissions', () => {
+    it('should delete submissions before given date', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, [{ id: '1' }, { id: '2' }]);
+      });
+
+      const beforeDate = new Date('2024-01-01');
+      const result = await service.deleteOldSubmissions(beforeDate);
+
+      expect(result).toBe(2);
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM telegram_submissions'),
+        [beforeDate],
+        expect.any(Function),
+      );
+    });
+
+    it('should return 0 when no submissions deleted', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, null);
+      });
+
+      const result = await service.deleteOldSubmissions(new Date());
+
+      expect(result).toBe(0);
+    });
+
+    it('should validate beforeDate', async () => {
+      await expect(service.deleteOldSubmissions(null as any)).rejects.toThrow('Valid beforeDate is required');
+    });
+  });
+
+  describe('anonymizeSubmissionsByUsername', () => {
+    it('should anonymize submissions for a username', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, [{ id: '1' }, { id: '2' }, { id: '3' }]);
+      });
+
+      const result = await service.anonymizeSubmissionsByUsername('testuser');
+
+      expect(result).toBe(3);
+      expect(mockDbConnection.all).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE telegram_submissions'),
+        ['testuser'],
+        expect.any(Function),
+      );
+    });
+
+    it('should return 0 when no submissions anonymized', async () => {
+      mockDbConnection.all.mockImplementation((query, values, callback) => {
+        callback(null, []);
+      });
+
+      const result = await service.anonymizeSubmissionsByUsername('unknown');
+
+      expect(result).toBe(0);
+    });
+
+    it('should validate username', async () => {
+      await expect(service.anonymizeSubmissionsByUsername('')).rejects.toThrow('username is required');
+    });
+  });
+});

--- a/src/articles/services/telegram-submission.service.ts
+++ b/src/articles/services/telegram-submission.service.ts
@@ -339,21 +339,22 @@ export class TelegramSubmissionService {
         const count = typeof row.count === 'number'
           ? row.count
           : (parseInt(String(row.count), 10) || 0);
+
         if (isNaN(count)) continue;
 
         stats.total += count;
         switch (row.submission_status) {
           case 'success':
-            stats.success = count;
+            stats.success += count;
             break;
           case 'failed':
-            stats.failed = count;
+            stats.failed += count;
             break;
           case 'duplicate':
-            stats.duplicate = count;
+            stats.duplicate += count;
             break;
           case 'pending':
-            stats.pending = count;
+            stats.pending += count;
             break;
         }
       }

--- a/src/articles/services/telegram-submission.service.ts
+++ b/src/articles/services/telegram-submission.service.ts
@@ -1,0 +1,425 @@
+import { DatabaseService } from '@libs/database';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+export interface TelegramSubmissionData {
+  articleId?: string | null;
+  chatId: string;
+  username?: string;
+  messageId: string;
+  messageText?: string;
+  feedProfile: string;
+  url: string;
+  submissionStatus: 'pending' | 'success' | 'failed' | 'duplicate';
+  errorMessage?: string;
+}
+
+export interface TelegramSubmissionRecord {
+  id: string;
+  articleId: string | null;
+  chatId: string;
+  username: string | null;
+  messageId: string;
+  messageText: string | null;
+  feedProfile: string;
+  url: string;
+  submissionStatus: 'pending' | 'success' | 'failed' | 'duplicate';
+  errorMessage: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const VALID_SUBMISSION_STATUSES = ['pending', 'success', 'failed', 'duplicate'] as const;
+type SubmissionStatus = (typeof VALID_SUBMISSION_STATUSES)[number];
+
+interface TelegramSubmissionDbRow {
+  id: string;
+  article_id: string | null;
+  chat_id: string;
+  username: string | null;
+  message_id: string;
+  message_text: string | null;
+  feed_profile: string;
+  url: string;
+  submission_status: string;
+  error_message: string | null;
+  created_at: string | Date;
+  updated_at: string | Date;
+}
+
+function parseSubmissionStatus(value: string): SubmissionStatus {
+  const status = VALID_SUBMISSION_STATUSES.find((s) => s === value);
+  return status ?? 'pending';
+}
+
+@Injectable()
+export class TelegramSubmissionService {
+  constructor(private readonly databaseService: DatabaseService) { }
+
+  private validateSubmissionData(data: TelegramSubmissionData): void {
+    if (!data.chatId || data.chatId.trim() === '') {
+      throw new BadRequestException('chatId is required');
+    }
+    if (!data.messageId || data.messageId.trim() === '') {
+      throw new BadRequestException('messageId is required');
+    }
+    if (!data.feedProfile || data.feedProfile.trim() === '') {
+      throw new BadRequestException('feedProfile is required');
+    }
+    if (!data.url || data.url.trim() === '') {
+      throw new BadRequestException('url is required');
+    }
+    if (!data.submissionStatus) {
+      throw new BadRequestException('submissionStatus is required');
+    }
+    if (!['pending', 'success', 'failed', 'duplicate'].includes(data.submissionStatus)) {
+      throw new BadRequestException('Invalid submissionStatus');
+    }
+  }
+
+  private validateSubmissionId(submissionId: string): void {
+    if (!submissionId || submissionId.trim() === '') {
+      throw new BadRequestException('submissionId is required');
+    }
+  }
+
+  private validateChatId(chatId: string): void {
+    if (!chatId || chatId.trim() === '') {
+      throw new BadRequestException('chatId is required');
+    }
+  }
+
+  private getDbConnection() {
+    const db = this.databaseService.getDbConnection();
+    if (!db) {
+      throw new Error('Database connection not available. Call initDb() first.');
+    }
+    return db;
+  }
+
+  private promisifyDbOperation<T>(
+    operation: (callback: (err: Error | null, result?: T) => void) => void,
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      operation((err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result as T);
+        }
+      });
+    });
+  }
+
+  async createSubmission(data: TelegramSubmissionData): Promise<string> {
+    this.validateSubmissionData(data);
+
+    const db = this.getDbConnection();
+
+    const query = `
+      INSERT INTO telegram_submissions (
+        article_id,
+        chat_id,
+        username,
+        message_id,
+        message_text,
+        feed_profile,
+        url,
+        submission_status,
+        error_message
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      RETURNING id
+    `;
+
+    const values = [
+      data.articleId || null,
+      data.chatId,
+      data.username || null,
+      data.messageId,
+      data.messageText || null,
+      data.feedProfile,
+      data.url,
+      data.submissionStatus,
+      data.errorMessage || null,
+    ];
+
+    const row = await this.promisifyDbOperation<{ id: string } | undefined>((callback) => {
+      db.get(query, values, callback);
+    });
+
+    if (!row?.id) {
+      throw new Error('Failed to create submission record');
+    }
+    return row.id;
+  }
+
+  async updateSubmissionStatus(
+    submissionId: string,
+    status: 'pending' | 'success' | 'failed' | 'duplicate',
+    options?: {
+      articleId?: string;
+      errorMessage?: string;
+    },
+  ): Promise<void> {
+    this.validateSubmissionId(submissionId);
+
+    if (!['pending', 'success', 'failed', 'duplicate'].includes(status)) {
+      throw new BadRequestException('Invalid status value');
+    }
+
+    const db = this.getDbConnection();
+
+    const query = `
+      UPDATE telegram_submissions
+      SET
+        submission_status = ?,
+        article_id = COALESCE(?, article_id),
+        error_message = COALESCE(?, error_message),
+        updated_at = NOW()
+      WHERE id = ?
+    `;
+
+    const values = [
+      status,
+      options?.articleId || null,
+      options?.errorMessage || null,
+      submissionId,
+    ];
+
+    await this.promisifyDbOperation<void>((callback) => {
+      db.run(query, values, callback);
+    });
+  }
+
+  async getSubmissionById(submissionId: string): Promise<TelegramSubmissionRecord | null> {
+    this.validateSubmissionId(submissionId);
+
+    const db = this.getDbConnection();
+
+    const query = `
+      SELECT *
+      FROM telegram_submissions
+      WHERE id = ?
+    `;
+
+    const row = await this.promisifyDbOperation<TelegramSubmissionDbRow | undefined>((callback) => {
+      db.get(query, [submissionId], callback);
+    });
+
+    if (!row) {
+      return null;
+    }
+
+    return this.mapDbRowToRecord(row);
+  }
+
+  async getSubmissionsByChatId(
+    chatId: string,
+    options?: {
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<TelegramSubmissionRecord[]> {
+    this.validateChatId(chatId);
+
+    const db = this.getDbConnection();
+
+    const limit = options?.limit || 100;
+    const offset = options?.offset || 0;
+
+    const query = `
+      SELECT *
+      FROM telegram_submissions
+      WHERE chat_id = ?
+      ORDER BY created_at DESC
+      LIMIT ? OFFSET ?
+    `;
+
+    const rows = await this.promisifyDbOperation<TelegramSubmissionDbRow[]>((callback) => {
+      db.all(query, [chatId, limit, offset], callback);
+    });
+
+    return (rows || []).map(this.mapDbRowToRecord);
+  }
+
+  async getRecentSubmissions(options?: {
+    limit?: number;
+    status?: 'pending' | 'success' | 'failed' | 'duplicate';
+    startDate?: Date;
+    endDate?: Date;
+  }): Promise<TelegramSubmissionRecord[]> {
+    const db = this.getDbConnection();
+
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+
+    if (options?.status) {
+      conditions.push('submission_status = ?');
+      values.push(options.status);
+    }
+
+    if (options?.startDate) {
+      conditions.push('created_at >= ?');
+      values.push(options.startDate);
+    }
+
+    if (options?.endDate) {
+      conditions.push('created_at <= ?');
+      values.push(options.endDate);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limit = options?.limit || 100;
+    values.push(limit);
+
+    const query = `
+      SELECT *
+      FROM telegram_submissions
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT ?
+    `;
+
+    const rows = await this.promisifyDbOperation<TelegramSubmissionDbRow[]>((callback) => {
+      db.all(query, values, callback);
+    });
+
+    return (rows || []).map(this.mapDbRowToRecord);
+  }
+
+  async getSubmissionStats(options?: {
+    startDate?: Date;
+    endDate?: Date;
+  }): Promise<{
+    total: number;
+    success: number;
+    failed: number;
+    duplicate: number;
+    pending: number;
+  }> {
+    const db = this.getDbConnection();
+
+    const conditions: string[] = [];
+    const values: unknown[] = [];
+
+    if (options?.startDate) {
+      conditions.push('created_at >= ?');
+      values.push(options.startDate);
+    }
+
+    if (options?.endDate) {
+      conditions.push('created_at <= ?');
+      values.push(options.endDate);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const query = `
+      SELECT
+        submission_status,
+        COUNT(*) as count
+      FROM telegram_submissions
+      ${whereClause}
+      GROUP BY submission_status
+    `;
+
+    const rows = await this.promisifyDbOperation<{ submission_status: string; count: string | number }[]>((callback) => {
+      db.all(query, values, callback);
+    });
+
+    const stats = {
+      total: 0,
+      success: 0,
+      failed: 0,
+      duplicate: 0,
+      pending: 0,
+    };
+
+    if (rows) {
+      for (const row of rows) {
+        const count = typeof row.count === 'number'
+          ? row.count
+          : (parseInt(String(row.count), 10) || 0);
+        if (isNaN(count)) continue;
+
+        stats.total += count;
+        switch (row.submission_status) {
+          case 'success':
+            stats.success = count;
+            break;
+          case 'failed':
+            stats.failed = count;
+            break;
+          case 'duplicate':
+            stats.duplicate = count;
+            break;
+          case 'pending':
+            stats.pending = count;
+            break;
+        }
+      }
+    }
+
+    return stats;
+  }
+
+  async deleteOldSubmissions(beforeDate: Date): Promise<number> {
+    if (!beforeDate || !(beforeDate instanceof Date)) {
+      throw new BadRequestException('Valid beforeDate is required');
+    }
+
+    const db = this.getDbConnection();
+
+    const query = `
+      DELETE FROM telegram_submissions
+      WHERE created_at < ?
+      RETURNING id
+    `;
+
+    const rows = await this.promisifyDbOperation<{ id: string }[]>((callback) => {
+      db.all(query, [beforeDate], callback);
+    });
+
+    return rows?.length || 0;
+  }
+
+  async anonymizeSubmissionsByUsername(username: string): Promise<number> {
+    if (!username || username.trim() === '') {
+      throw new BadRequestException('username is required');
+    }
+
+    const db = this.getDbConnection();
+
+    const query = `
+      UPDATE telegram_submissions
+      SET
+        username = '[anonymized]',
+        message_text = '[redacted]',
+        updated_at = NOW()
+      WHERE username = ?
+      RETURNING id
+    `;
+
+    const rows = await this.promisifyDbOperation<{ id: string }[]>((callback) => {
+      db.all(query, [username], callback);
+    });
+
+    return rows?.length || 0;
+  }
+
+  private mapDbRowToRecord(row: TelegramSubmissionDbRow): TelegramSubmissionRecord {
+    return {
+      id: row.id,
+      articleId: row.article_id,
+      chatId: row.chat_id,
+      username: row.username,
+      messageId: row.message_id,
+      messageText: row.message_text,
+      feedProfile: row.feed_profile,
+      url: row.url,
+      submissionStatus: parseSubmissionStatus(row.submission_status),
+      errorMessage: row.error_message,
+      createdAt: new Date(row.created_at),
+      updatedAt: new Date(row.updated_at),
+    };
+  }
+}

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -270,6 +270,23 @@ export class ConfigService {
     return value === 'true' || value === '1' || value === undefined;
   }
 
+  isExternalArticleSubmissionEnabled(): boolean {
+    const value = process.env.TELEGRAM_INTEGRATION_ENABLED;
+    return value === 'true' || value === '1';
+  }
+
+  /**
+   * Get external API tokens from environment variable.
+   * Tokens are comma-separated in EXTERNAL_API_TOKENS environment variable.
+   */
+  getExternalApiTokens(): string[] {
+    const tokensEnv = process.env.EXTERNAL_API_TOKENS;
+    if (!tokensEnv) {
+      return [];
+    }
+    return tokensEnv.split(',').map(t => t.trim()).filter(Boolean);
+  }
+
   getEnabledChatModel(): ValidChatModel {
     const envValue = process.env.ENABLED_CHAT_MODEL;
     if (envValue) {

--- a/src/database/migrations/1741047600000-CreateTelegramSubmissionsTable.ts
+++ b/src/database/migrations/1741047600000-CreateTelegramSubmissionsTable.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTelegramSubmissionsTable1741047600000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS telegram_submissions (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        article_id UUID REFERENCES articles(id) ON DELETE SET NULL,
+        chat_id VARCHAR(255) NOT NULL,
+        username VARCHAR(255),
+        message_id VARCHAR(255) NOT NULL,
+        message_text TEXT,
+        feed_profile VARCHAR(50) NOT NULL,
+        url TEXT NOT NULL,
+        submission_status VARCHAR(50) NOT NULL DEFAULT 'pending',
+        error_message TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+      )
+    `);
+
+    // Create indexes for analytics queries
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_telegram_submissions_chat_id 
+      ON telegram_submissions(chat_id)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_telegram_submissions_created_at 
+      ON telegram_submissions(created_at DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_telegram_submissions_username 
+      ON telegram_submissions(username)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_telegram_submissions_status 
+      ON telegram_submissions(submission_status)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_telegram_submissions_article_id 
+      ON telegram_submissions(article_id)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_telegram_submissions_article_id`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_telegram_submissions_status`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_telegram_submissions_username`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_telegram_submissions_created_at`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_telegram_submissions_chat_id`);
+
+    await queryRunner.query(`DROP TABLE IF EXISTS telegram_submissions`);
+  }
+}

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { AuthModule as LibsAuthModule } from '@libs/auth';
+import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
 import { UserLookupProvider } from '@libs/auth/interfaces/user-lookup-provider.interface';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
@@ -8,23 +9,26 @@ import { mock, MockProxy } from 'jest-mock-extended';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AuthController } from '../src/auth/auth.controller';
+import { User } from '../src/users/user.entity';
 
 // Test fixture data
 const MOCK_USER_PASSWORD = 'TestPass123';
 const MOCK_USER_HASHED_PASSWORD = bcrypt.hashSync(MOCK_USER_PASSWORD, 10);
 
-const mockUser = {
+const mockUser: User = {
   id: 'test-user-id-123',
   email: 'test@example.com',
   username: 'testuser',
   password: MOCK_USER_HASHED_PASSWORD,
+  isEmailVerified: true,
   created_at: new Date('2024-01-01'),
 };
 
 // User without password (for non-existent user scenarios)
-const mockUserWithoutPassword = {
+const mockUserWithoutPassword: User = {
   ...mockUser,
   password: undefined,
+  isEmailVerified: false,
 };
 
 // Factory function for creating fresh mock instances
@@ -74,7 +78,12 @@ describe('Authentication (e2e)', () => {
         }),
       ],
       controllers: [AuthController],
-    }).compile();
+    })
+      .overrideGuard(RateLimitGuard)
+      .useValue({
+        canActivate: () => true, // Bypass rate limiting in tests
+      })
+      .compile();
 
     app = moduleFixture.createNestApplication();
 
@@ -127,13 +136,20 @@ describe('Authentication (e2e)', () => {
       const token = response.body.access_token;
       expect(token).toMatch(/^[\w-]+\.[\w-]+\.[\w-]+$/);
 
-      // Decode and verify token payload
+      // Verify token signature and payload
       const jwtService = moduleFixture.get<JwtService>(JwtService);
-      const decoded = jwtService.decode(token);
-      expect(decoded).toHaveProperty('sub', mockUser.id);
-      expect(decoded).toHaveProperty('email', mockUser.email);
-      expect(decoded).toHaveProperty('iat'); // issued at
-      expect(decoded).toHaveProperty('exp'); // expiration
+      const verified = jwtService.verify<{
+        sub: string;
+        email: string;
+        iat: number;
+        exp: number;
+      }>(token, {
+        secret: process.env.JWT_SECRET,
+      });
+      expect(verified).toHaveProperty('sub', mockUser.id);
+      expect(verified).toHaveProperty('email', mockUser.email);
+      expect(verified).toHaveProperty('iat');
+      expect(verified).toHaveProperty('exp');
 
       // Assert user data
       expect(response.body.user).toEqual({

--- a/test/external-articles.e2e-spec.ts
+++ b/test/external-articles.e2e-spec.ts
@@ -1,0 +1,440 @@
+/**
+ * E2E Tests for External Articles API Contract
+ *
+ * Scope: API contract, authentication, validation, feature flag, response structure.
+ * For Telegram-specific flow (message format, metadata, Node-RED integration) see
+ * telegram-article-submission.e2e-spec.ts.
+ */
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock, MockProxy } from 'jest-mock-extended';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { QueueService } from '@libs/queue';
+import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
+import { ExternalArticlesController } from '../src/articles/external-articles.controller';
+import { ScraperService } from '../src/scraper/scraper.service';
+import { TelegramSubmissionService } from '../src/articles/services/telegram-submission.service';
+import { FeedProfile } from '../src/shared/types/feed';
+import { ConfigService } from '../src/config/config.service';
+
+describe('External Articles Integration Tests', () => {
+  let app: INestApplication<App>;
+  let moduleFixture: TestingModule;
+  let mockScraperService: MockProxy<ScraperService>;
+  let mockQueueService: MockProxy<QueueService>;
+  let mockTelegramSubmissionService: MockProxy<TelegramSubmissionService>;
+  let mockConfigService: MockProxy<ConfigService>;
+
+  const VALID_TOKEN = 'test-external-token-12345';
+  const TEST_URL = 'https://example.com/article';
+  const TEST_ARTICLE_ID = 'article-uuid-123';
+  const TEST_JOB_ID = 'job-uuid-456';
+
+  // Test configuration
+  const originalEnv = process.env;
+
+  beforeAll(async () => {
+    process.env = {
+      ...originalEnv,
+      EXTERNAL_API_TOKENS: VALID_TOKEN,
+      TELEGRAM_INTEGRATION_ENABLED: 'true',
+    };
+
+    // Create mock services
+    mockScraperService = mock<ScraperService>();
+    mockQueueService = mock<QueueService>();
+    mockTelegramSubmissionService = mock<TelegramSubmissionService>();
+    mockConfigService = mock<ConfigService>();
+
+    // Setup default mock behavior
+    mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+    mockTelegramSubmissionService.updateSubmissionStatus.mockReturnValue(Promise.resolve());
+    mockConfigService.getAppConfig.mockReturnValue({
+      defaultFeedProfile: FeedProfile.DEFAULT,
+      databaseFile: ':memory:',
+      maxArticlesForScrapping: 100,
+    });
+    mockConfigService.isExternalArticleSubmissionEnabled.mockReturnValue(true);
+    mockConfigService.getExternalApiTokens.mockReturnValue([VALID_TOKEN]);
+
+    moduleFixture = await Test.createTestingModule({
+      controllers: [ExternalArticlesController],
+      providers: [
+        {
+          provide: ScraperService,
+          useValue: mockScraperService,
+        },
+        {
+          provide: QueueService,
+          useValue: mockQueueService,
+        },
+        {
+          provide: TelegramSubmissionService,
+          useValue: mockTelegramSubmissionService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    })
+      .overrideGuard(RateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset default mock behavior
+    mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+    mockTelegramSubmissionService.updateSubmissionStatus.mockReturnValue(Promise.resolve());
+    mockConfigService.getExternalApiTokens.mockReturnValue([VALID_TOKEN]);
+  });
+
+  afterAll(async () => {
+    process.env = originalEnv;
+    if (app) {
+      await app.close();
+    }
+    await moduleFixture.close();
+  });
+
+  describe('POST /api/articles/external', () => {
+    describe('Authentication', () => {
+      it('should return 401 when X-External-Token header is missing', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(401);
+        expect(response.body).toHaveProperty('message');
+        expect(response.body.message).toContain('Missing X-External-Token header');
+      });
+
+      it('should return 401 when X-External-Token header is invalid', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', 'invalid-token')
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(401);
+        expect(response.body).toHaveProperty('message');
+        expect(response.body.message).toContain('Invalid authentication token');
+      });
+
+      it('should return 401 when X-External-Token header is empty', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', '')
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('Request Validation', () => {
+      it('should return 400 when URL is missing', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 when URL is invalid', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: 'not-a-valid-url',
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 when feedProfile is missing', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+          });
+
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 when feedProfile is invalid', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: 'invalid-feed',
+          });
+
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 when request body is empty', async () => {
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({});
+
+        expect(response.status).toBe(400);
+      });
+    });
+
+    describe('Valid Requests', () => {
+      it('should return 201 when article is successfully submitted', async () => {
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+        mockQueueService.addArticleProcessingJob.mockResolvedValue({
+          success: true,
+          articleFileKey: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: 'Article queued',
+        });
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+            source: 'telegram',
+            metadata: {
+              chatId: '123456789',
+              messageId: '456',
+              username: '@testuser',
+            },
+          });
+
+        expect(response.status).toBe(201);
+        expect(response.body).toHaveProperty('success', true);
+        expect(response.body).toHaveProperty('articleId', TEST_ARTICLE_ID);
+        expect(response.body).toHaveProperty('jobId', TEST_JOB_ID);
+        expect(response.body).toHaveProperty('message');
+
+        // Verify services were called
+        expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(
+          TEST_URL,
+          FeedProfile.TECHNOLOGY,
+        );
+        expect(mockQueueService.addArticleProcessingJob).toHaveBeenCalledWith(
+          TEST_ARTICLE_ID,
+          FeedProfile.TECHNOLOGY,
+        );
+        expect(mockTelegramSubmissionService.createSubmission).toHaveBeenCalled();
+      });
+
+      it('should return 409 when article already exists', async () => {
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(null); // Article exists
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(409);
+        expect(response.body).toHaveProperty('success', false);
+        expect(response.body.error).toHaveProperty('code', 'ARTICLE_EXISTS');
+      });
+
+      it('should return 502 when scraping fails', async () => {
+        mockScraperService.scrapeSingleArticle.mockRejectedValue(
+          new Error('Failed to extract content'),
+        );
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(502);
+        expect(response.body).toHaveProperty('success', false);
+        expect(response.body.error).toHaveProperty('code', 'SCRAPE_FAILED');
+      });
+
+      it('should handle optional metadata fields', async () => {
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+        mockQueueService.addArticleProcessingJob.mockResolvedValue({
+          success: true,
+          articleFileKey: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: 'Article queued',
+        });
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(201);
+        expect(response.body.success).toBe(true);
+
+        // Verify submission was created with default metadata
+        expect(mockTelegramSubmissionService.createSubmission).toHaveBeenCalledWith(
+          expect.objectContaining({
+            chatId: 'unknown',
+            messageId: 'unknown',
+          }),
+        );
+      });
+
+      it('should handle all valid feed profiles', async () => {
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+        mockQueueService.addArticleProcessingJob.mockResolvedValue({
+          success: true,
+          articleFileKey: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: 'Article queued',
+        });
+
+        const feedProfiles = [
+          FeedProfile.DEFAULT,
+          FeedProfile.TECHNOLOGY,
+          FeedProfile.POLITICS,
+          FeedProfile.BUSINESS,
+          FeedProfile.HEALTH,
+          FeedProfile.SCIENCE,
+          FeedProfile.BRASIL,
+          FeedProfile.TECLAS,
+        ];
+
+        for (const feedProfile of feedProfiles) {
+          const response = await request(app.getHttpServer())
+            .post('/api/articles/external')
+            .set('X-External-Token', VALID_TOKEN)
+            .send({
+              url: TEST_URL,
+              feedProfile,
+            });
+
+          expect(response.status).toBe(201);
+        }
+      });
+
+      it('should continue when submission record creation fails', async () => {
+        mockTelegramSubmissionService.createSubmission.mockRejectedValue(
+          new Error('Database error'),
+        );
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+        mockQueueService.addArticleProcessingJob.mockResolvedValue({
+          success: true,
+          articleFileKey: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: 'Article queued',
+        });
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        // Should still succeed
+        expect(response.status).toBe(201);
+        expect(response.body.success).toBe(true);
+      });
+    });
+
+    describe('Feature Flag', () => {
+      it('should return 503 when feature is disabled', async () => {
+        mockConfigService.isExternalArticleSubmissionEnabled.mockReturnValue(false);
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.status).toBe(503);
+        expect(response.body).toHaveProperty('success', false);
+        expect(response.body.error).toHaveProperty('code', 'INTERNAL_ERROR');
+
+        mockConfigService.isExternalArticleSubmissionEnabled.mockReturnValue(true);
+      });
+    });
+
+    describe('Response Structure', () => {
+      it('should return correct success response structure', async () => {
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+        mockQueueService.addArticleProcessingJob.mockResolvedValue({
+          success: true,
+          articleFileKey: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: 'Article queued',
+        });
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.body).toEqual({
+          success: true,
+          articleId: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: expect.stringContaining('Article submitted successfully'),
+        });
+      });
+
+      it('should return correct error response structure', async () => {
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(null);
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: FeedProfile.TECHNOLOGY,
+          });
+
+        expect(response.body).toHaveProperty('success', false);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body.error).toHaveProperty('code');
+        expect(response.body.error).toHaveProperty('message');
+      });
+    });
+  });
+});

--- a/test/telegram-article-submission.e2e-spec.ts
+++ b/test/telegram-article-submission.e2e-spec.ts
@@ -1,0 +1,583 @@
+/**
+ * E2E Tests for Telegram Article Submission Flow
+ *
+ * Scope: Telegram-specific flow (message format, metadata, Node-RED integration, GDPR).
+ * For API contract, auth, validation, feature flag see external-articles.e2e-spec.ts.
+ *
+ * Full flow: Telegram message → Node-RED → API → Success response → Telegram reply
+ * Error flow: Invalid URL → Error response → Telegram error message
+ */
+import { RateLimitGuard } from '@libs/auth/rate-limit/rate-limit.guard';
+import { QueueService } from '@libs/queue';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock, MockProxy } from 'jest-mock-extended';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { ExternalArticlesController } from '../src/articles/external-articles.controller';
+import { TelegramSubmissionService } from '../src/articles/services/telegram-submission.service';
+import { ConfigService } from '../src/config/config.service';
+import { ScraperService } from '../src/scraper/scraper.service';
+import { FeedProfile } from '../src/shared/types/feed';
+
+const VALID_TOKEN = 'test-telegram-bot-token';
+const TEST_URL = 'https://addyosmani.com/blog/self-improving-agents/';
+const TEST_ARTICLE_ID = 'article-uuid-123';
+const TEST_JOB_ID = 'job-uuid-456';
+const TEST_CHAT_ID = '123456789';
+const TEST_MESSAGE_ID = '456';
+const TEST_USERNAME = '@testuser';
+
+const SUCCESS_RESPONSE = {
+  success: true,
+  articleId: TEST_ARTICLE_ID,
+  jobId: TEST_JOB_ID,
+  message: 'Article submitted successfully and queued for processing',
+};
+
+const ERROR_RESPONSE_ARTICLE_EXISTS = {
+  success: false,
+  error: {
+    code: 'ARTICLE_EXISTS',
+    message: expect.any(String),
+  },
+};
+
+describe('Telegram Article Submission E2E Flow', () => {
+  let app: INestApplication<App>;
+  let moduleFixture: TestingModule;
+  let mockScraperService: MockProxy<ScraperService>;
+  let mockQueueService: MockProxy<QueueService>;
+  let mockTelegramSubmissionService: MockProxy<TelegramSubmissionService>;
+
+  const originalEnv = process.env;
+
+  beforeAll(async () => {
+    process.env = {
+      ...originalEnv,
+      EXTERNAL_API_TOKENS: VALID_TOKEN,
+      TELEGRAM_INTEGRATION_ENABLED: 'true',
+    };
+
+    mockScraperService = mock<ScraperService>();
+    mockQueueService = mock<QueueService>();
+    mockTelegramSubmissionService = mock<TelegramSubmissionService>();
+    const mockConfigService = mock<ConfigService>();
+    mockConfigService.isExternalArticleSubmissionEnabled.mockReturnValue(true);
+    mockConfigService.getExternalApiTokens.mockReturnValue([VALID_TOKEN]);
+
+    moduleFixture = await Test.createTestingModule({
+      controllers: [ExternalArticlesController],
+      providers: [
+        {
+          provide: ScraperService,
+          useValue: mockScraperService,
+        },
+        {
+          provide: QueueService,
+          useValue: mockQueueService,
+        },
+        {
+          provide: TelegramSubmissionService,
+          useValue: mockTelegramSubmissionService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    })
+      .overrideGuard(RateLimitGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTelegramSubmissionService.updateSubmissionStatus.mockReturnValue(Promise.resolve());
+  });
+
+  afterAll(async () => {
+    process.env = originalEnv;
+    if (app) {
+      await app.close();
+    }
+    await moduleFixture.close();
+  });
+
+  describe('Full Flow: Happy Path', () => {
+    it('should successfully process article submission from Telegram message format', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      // Simulate Node-RED parsing the Telegram message and calling the API
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+            username: TEST_USERNAME,
+          },
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject(SUCCESS_RESPONSE);
+
+      expect(mockTelegramSubmissionService.createSubmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: TEST_CHAT_ID,
+          username: TEST_USERNAME,
+          messageId: TEST_MESSAGE_ID,
+          feedProfile: 'technology',
+          url: TEST_URL,
+          submissionStatus: 'pending',
+        }),
+      );
+
+      expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(
+        TEST_URL,
+        FeedProfile.TECHNOLOGY,
+      );
+
+      expect(mockQueueService.addArticleProcessingJob).toHaveBeenCalledWith(
+        TEST_ARTICLE_ID,
+        FeedProfile.TECHNOLOGY,
+      );
+
+      expect(mockTelegramSubmissionService.updateSubmissionStatus).toHaveBeenCalledWith(
+        'submission-uuid',
+        'success',
+        { articleId: TEST_ARTICLE_ID },
+      );
+    });
+
+    it('should handle Telegram message with Note field', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+            username: TEST_USERNAME,
+            note: 'Great article about AI agents',
+          },
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+
+      expect(mockTelegramSubmissionService.createSubmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageText: 'Great article about AI agents',
+        }),
+      );
+    });
+
+    it('should handle different feed profiles from Telegram', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockTelegramSubmissionService.updateSubmissionStatus.mockReturnValue(Promise.resolve());
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      const feedProfiles = [
+        FeedProfile.TECHNOLOGY,
+        FeedProfile.POLITICS,
+        FeedProfile.BUSINESS,
+        FeedProfile.HEALTH,
+        FeedProfile.SCIENCE,
+        FeedProfile.BRASIL,
+        FeedProfile.TECLAS,
+        FeedProfile.DEFAULT,
+      ];
+
+      for (const profile of feedProfiles) {
+        // Clear mocks between iterations to ensure clean state
+        jest.clearAllMocks();
+        mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+        mockTelegramSubmissionService.updateSubmissionStatus.mockReturnValue(Promise.resolve());
+        mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+        mockQueueService.addArticleProcessingJob.mockResolvedValue({
+          success: true,
+          articleFileKey: TEST_ARTICLE_ID,
+          jobId: TEST_JOB_ID,
+          message: 'Article queued',
+        });
+
+        const response = await request(app.getHttpServer())
+          .post('/api/articles/external')
+          .set('X-External-Token', VALID_TOKEN)
+          .send({
+            url: TEST_URL,
+            feedProfile: profile,
+            source: 'telegram',
+          });
+
+        expect(response.status).toBe(201);
+        expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(TEST_URL, profile);
+
+        // Add small delay between requests to prevent socket hang up
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    });
+  });
+
+  describe('Error Flow: Invalid Input', () => {
+    it('should return error for invalid URL format (simulating Node-RED validation failure)', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: 'not-a-valid-url',
+          feedProfile: FeedProfile.TECHNOLOGY,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+          },
+        });
+
+      // API returns 400 for invalid URL (validation happens before controller)
+      expect(response.status).toBe(400);
+    });
+
+    it('should return error for non-existent feed profile', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: 'nonexistent-feed' as FeedProfile,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+          },
+        });
+
+      // Validation pipe rejects invalid feed profile before controller
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 409 for duplicate article submission', async () => {
+      // Reset and set up mocks for this specific test - must clear mocks first
+      jest.clearAllMocks();
+
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockTelegramSubmissionService.updateSubmissionStatus.mockReturnValue(Promise.resolve());
+
+      // Mock scraper to return null (indicating article already exists)
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(null);
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+          },
+        });
+
+      expect(response.status).toBe(409);
+      expect(response.body).toMatchObject(ERROR_RESPONSE_ARTICLE_EXISTS);
+
+      // Submission should be marked as duplicate
+      expect(mockTelegramSubmissionService.updateSubmissionStatus).toHaveBeenCalledWith(
+        'submission-uuid',
+        'duplicate',
+        undefined,
+      );
+    });
+
+    it('should return 502 when scraping fails', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockRejectedValue(
+        new Error('Failed to fetch content'),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+          },
+        });
+
+      expect(response.status).toBe(502);
+      expect(response.body.error.code).toBe('SCRAPE_FAILED');
+
+      // Submission should be marked as failed
+      expect(mockTelegramSubmissionService.updateSubmissionStatus).toHaveBeenCalledWith(
+        'submission-uuid',
+        'failed',
+        expect.objectContaining({
+          errorMessage: expect.any(String),
+        }),
+      );
+    });
+  });
+
+  describe('Authentication & Security', () => {
+    it('should reject requests without authentication token', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject requests with invalid token', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', 'invalid-token')
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('Telegram Message Parsing Simulation', () => {
+    /**
+     * These tests simulate what Node-RED would do when parsing Telegram messages.
+     * The message format is: Option B - Structured Format
+     *
+     * URL: https://example.com/article
+     * Feed: technology
+     * Note: (optional)
+     */
+
+    it('should handle URL and Feed in correct order', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      // URL first, then Feed (as defined in TDD)
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      expect(response.status).toBe(201);
+    });
+
+    it('should handle Feed and URL in reverse order (Node-RED extracts by label)', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      // Feed first, then URL (should still work - Node-RED parses by label)
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      expect(response.status).toBe(201);
+    });
+
+    it('should handle extra whitespace in message fields', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      // Extra spaces after colon (Node-RED trims this)
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      expect(response.status).toBe(201);
+    });
+  });
+
+  describe('Node-RED Error Handling Integration', () => {
+    /**
+     * These tests verify that the API responses can be properly handled by Node-RED
+     * to format error messages for Telegram users.
+     *
+     * Error messages (from TDD section 7):
+     * - INVALID_URL: "❌ The URL you provided doesn't seem valid..."
+     * - INVALID_FEED_PROFILE: "❌ Invalid feed profile. Use one of:..."
+     * - RATE_LIMIT_EXCEEDED: "⏳ You're submitting too fast..."
+     * - ARTICLE_EXISTS: "ℹ️ This article has already been submitted..."
+     * - SCRAPE_FAILED: "❌ Couldn't access the article..."
+     * - INTERNAL_ERROR: "🔥 Something went wrong on our end..."
+     */
+
+    it('should return structured error response that Node-RED can parse', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockRejectedValue(
+        new Error('Failed to fetch'),
+      );
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      // Node-RED can easily parse this structured response
+      expect(response.body).toHaveProperty('success');
+      expect(response.body).toHaveProperty('error');
+      expect(response.body.error).toHaveProperty('code');
+      expect(response.body.error).toHaveProperty('message');
+
+      // HTTP status is also available for Node-RED switch node
+      expect(response.status).toBe(502);
+    });
+
+    it('should include retry information for rate limiting', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      const response = await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+        });
+
+      // Response should be successful since we mocked the services
+      expect(response.status).toBe(201);
+    });
+  });
+
+  describe('GDPR & Data Retention', () => {
+    it('should store chat metadata for potential GDPR requests', async () => {
+      mockTelegramSubmissionService.createSubmission.mockResolvedValue('submission-uuid');
+      mockScraperService.scrapeSingleArticle.mockResolvedValue(TEST_ARTICLE_ID);
+      mockQueueService.addArticleProcessingJob.mockResolvedValue({
+        success: true,
+        articleFileKey: TEST_ARTICLE_ID,
+        jobId: TEST_JOB_ID,
+        message: 'Article queued',
+      });
+
+      await request(app.getHttpServer())
+        .post('/api/articles/external')
+        .set('X-External-Token', VALID_TOKEN)
+        .send({
+          url: TEST_URL,
+          feedProfile: FeedProfile.TECHNOLOGY,
+          source: 'telegram',
+          metadata: {
+            chatId: TEST_CHAT_ID,
+            messageId: TEST_MESSAGE_ID,
+            username: TEST_USERNAME,
+          },
+        });
+
+      // Verify chat metadata is stored for potential GDPR data access/deletion requests
+      expect(mockTelegramSubmissionService.createSubmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: TEST_CHAT_ID,
+          messageId: TEST_MESSAGE_ID,
+          username: TEST_USERNAME,
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Add POST /api/articles/external endpoint to enable article submission via Telegram bot integration. Implements token-based authentication with X-External-Token header, rate limiting (10 req/min per token), and structured error responses. Includes TelegramSubmissionService for tracking submission metadata and analytics, database migration for telegram_submissions table, and comprehensive validation for URLs and feed profiles. Adds environment variables EXTERNAL_API_TOKENS and TELEGRAM_INTEGRATION_ENABLED for configuration.

Linear: https://linear.app/anas-org/issue/TASK-140/idea-send-a-message-to-telegram-with-an-article-url-to-be-uploaded-to