### PR TITLE
feat(articles): add custom prompt support for article processing

### DIFF
--- a/libs/queue/interfaces/markdown-article-job.interface.ts
+++ b/libs/queue/interfaces/markdown-article-job.interface.ts
@@ -4,4 +4,5 @@ export interface ProcessMarkdownArticleJobData {
   s3Bucket: string;
   s3Key: string;
   feedProfile: FeedProfile;
+  customPrompt?: string;
 }

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -281,11 +281,13 @@ Please investigate the issue.`,
     s3Bucket: string,
     s3Key: string,
     feedProfile: FeedProfile,
+    customPrompt?: string,
   ): Promise<JobInfo> {
     const jobData: ProcessMarkdownArticleJobData = {
       s3Bucket,
       s3Key,
       feedProfile,
+      customPrompt,
     };
 
     const job = await this.markdownArticleQueue.add(

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -44,12 +44,13 @@ export class ArticlesController {
 
   @Post()
   async create(@Body() createArticleDto: CreateArticleDto) {
-    const { url, feedProfile } = createArticleDto;
+    const { url, feedProfile, customPrompt } = createArticleDto;
 
     try {
       const articleId = await this.scraperService.scrapeSingleArticle(
         url,
         feedProfile,
+        customPrompt,
       );
 
       if (articleId === null) {
@@ -116,7 +117,7 @@ export class ArticlesController {
 
   @Post('markdown')
   async processMarkdownArticle(@Body() dto: ProcessMarkdownArticleDto) {
-    const { s3Key, feedProfile, s3Bucket } = dto;
+    const { s3Key, feedProfile, s3Bucket, customPrompt } = dto;
 
     try {
       const bucketName = s3Bucket || process.env.S3_ARTICLES_BUCKET_NAME;
@@ -131,6 +132,7 @@ export class ArticlesController {
         bucketName,
         s3Key,
         feedProfile,
+        customPrompt,
       );
 
       return {

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -21,6 +21,7 @@ interface ArticleRow {
   feed_profile: string;
   image_url?: string | null;
   categories?: string | null;
+  custom_prompt?: string | null;
   created_at: string;
   content?: string;
 }
@@ -42,13 +43,14 @@ export class ArticlesService {
     feedProfile: FeedProfile,
     imageUrl?: string,
     categories?: ArticleCategory[],
+    customPrompt?: string,
   ): Promise<string | null> {
     return new Promise((resolve, reject) => {
       const db = this.databaseService.getDbConnection();
 
       const stmt = db.prepare(`
-        INSERT INTO articles (url, title, published_date, feed_source, raw_content, feed_profile, image_url, categories)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO articles (url, title, published_date, feed_source, raw_content, feed_profile, image_url, categories, custom_prompt)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       stmt.run(
@@ -61,6 +63,7 @@ export class ArticlesService {
           feedProfile,
           imageUrl,
           categories ? JSON.stringify(categories) : null,
+          customPrompt || null,
         ],
         function (this: { lastID?: string }, err: Error | null) {
           if (err) {
@@ -321,7 +324,7 @@ export class ArticlesService {
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
           raw_content as content, processed_content, impact_rating,
-          image_url, categories, created_at
+          image_url, categories, custom_prompt, created_at
         FROM articles
         WHERE id = ?
       `;
@@ -435,7 +438,7 @@ export class ArticlesService {
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
           raw_content as content, processed_content, impact_rating,
-          image_url, categories, created_at
+          image_url, categories, custom_prompt, created_at
         FROM articles
         WHERE 1=1
       `;
@@ -592,7 +595,7 @@ export class ArticlesService {
           SELECT
             id, url, title, published_date, feed_source, feed_profile,
             raw_content as content, processed_content, impact_rating,
-            image_url, categories, created_at
+            image_url, categories, custom_prompt, created_at
           FROM articles
           WHERE feed_profile = ?
           AND id != ?

--- a/src/articles/dto/create-article.dto.ts
+++ b/src/articles/dto/create-article.dto.ts
@@ -1,5 +1,14 @@
-import { IsEnum, IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 import { FeedProfile } from '../../shared/types/feed';
+
+const CUSTOM_PROMPT_MAX_LENGTH = 500;
 
 export class CreateArticleDto {
   @IsNotEmpty()
@@ -10,4 +19,11 @@ export class CreateArticleDto {
   @IsEnum(FeedProfile, { message: 'Invalid feed profile' })
   @IsString()
   feedProfile: FeedProfile;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(CUSTOM_PROMPT_MAX_LENGTH, {
+    message: `customPrompt must not exceed ${CUSTOM_PROMPT_MAX_LENGTH} characters`,
+  })
+  customPrompt?: string;
 }

--- a/src/articles/dto/external-create-article.dto.ts
+++ b/src/articles/dto/external-create-article.dto.ts
@@ -5,9 +5,12 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  MaxLength,
   ValidateNested,
 } from 'class-validator';
 import { FeedProfile } from '../../shared/types/feed';
+
+const CUSTOM_PROMPT_MAX_LENGTH = 500;
 
 export class ExternalSubmissionMetadataDto {
   @IsOptional()
@@ -39,6 +42,13 @@ export class ExternalCreateArticleDto {
   @IsOptional()
   @IsString()
   source?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(CUSTOM_PROMPT_MAX_LENGTH, {
+    message: `customPrompt must not exceed ${CUSTOM_PROMPT_MAX_LENGTH} characters`,
+  })
+  customPrompt?: string;
 
   @IsOptional()
   @ValidateNested()

--- a/src/articles/dto/process-markdown-article.dto.ts
+++ b/src/articles/dto/process-markdown-article.dto.ts
@@ -1,5 +1,13 @@
-import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { FeedProfile } from '../../shared/types/feed';
+
+const CUSTOM_PROMPT_MAX_LENGTH = 500;
 
 export class ProcessMarkdownArticleDto {
   @IsString()
@@ -13,4 +21,11 @@ export class ProcessMarkdownArticleDto {
   @IsString()
   @IsOptional()
   s3Bucket?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(CUSTOM_PROMPT_MAX_LENGTH, {
+    message: `customPrompt must not exceed ${CUSTOM_PROMPT_MAX_LENGTH} characters`,
+  })
+  customPrompt?: string;
 }

--- a/src/articles/external-articles.controller.spec.ts
+++ b/src/articles/external-articles.controller.spec.ts
@@ -124,6 +124,7 @@ describe('ExternalArticlesController', () => {
       expect(scraperService.scrapeSingleArticle).toHaveBeenCalledWith(
         validDto.url,
         validDto.feedProfile,
+        undefined,
       );
       expect(queueService.addArticleProcessingJob).toHaveBeenCalledWith(
         articleId,

--- a/src/articles/external-articles.controller.ts
+++ b/src/articles/external-articles.controller.ts
@@ -77,7 +77,7 @@ export class ExternalArticlesController {
       });
     }
 
-    const { url, feedProfile, source = 'external', metadata } = dto;
+    const { url, feedProfile, customPrompt, source = 'external', metadata } = dto;
     this.assertSafeExternalUrl(url);
 
     const submissionMetadata = {
@@ -108,7 +108,12 @@ export class ExternalArticlesController {
       this.logger.error('Failed to create submission record', error);
     }
 
-    const articleId = await this.scrapeArticleOrThrow(url, feedProfile, submissionId);
+    const articleId = await this.scrapeArticleOrThrow(
+      url,
+      feedProfile,
+      submissionId,
+      customPrompt,
+    );
 
     if (articleId === null) {
       if (submissionId) {
@@ -124,7 +129,11 @@ export class ExternalArticlesController {
       });
     }
 
-    const jobInfo = await this.enqueueArticleOrThrow(articleId, feedProfile, submissionId);
+    const jobInfo = await this.enqueueArticleOrThrow(
+      articleId,
+      feedProfile,
+      submissionId,
+    );
 
     if (submissionId) {
       await this.safeUpdateSubmissionStatus(submissionId, 'success', {
@@ -308,9 +317,14 @@ export class ExternalArticlesController {
     url: string,
     feedProfile: FeedProfile,
     submissionId: string | null,
+    customPrompt?: string,
   ): Promise<string | null> {
     try {
-      return await this.scraperService.scrapeSingleArticle(url, feedProfile);
+      return await this.scraperService.scrapeSingleArticle(
+        url,
+        feedProfile,
+        customPrompt,
+      );
     } catch (error) {
       await this.handleError(error, submissionId, {
         code: ExternalArticleErrorCode.SCRAPE_FAILED,

--- a/src/articles/processors/markdown-article.processor.spec.ts
+++ b/src/articles/processors/markdown-article.processor.spec.ts
@@ -109,6 +109,9 @@ describe('MarkdownArticleProcessor', () => {
         'S3 Upload',
         markdownContent,
         FeedProfile.DEFAULT,
+        undefined,
+        undefined,
+        undefined,
       );
       expect(mockProcessorService.processArticles).toHaveBeenCalledWith(
         FeedProfile.DEFAULT,

--- a/src/articles/processors/markdown-article.processor.ts
+++ b/src/articles/processors/markdown-article.processor.ts
@@ -59,7 +59,7 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
   async processMarkdownArticle(
     job: Job<ProcessMarkdownArticleJobData>,
   ): Promise<{ success: boolean; message: string }> {
-    const { s3Bucket, s3Key, feedProfile } = job.data;
+    const { s3Bucket, s3Key, feedProfile, customPrompt } = job.data;
 
     console.log(
       `\n>>> Processing markdown article from S3 (Job ${job.id}) <<<`,
@@ -84,6 +84,9 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
         'S3 Upload',
         parsedArticle.content,
         feedProfile,
+        undefined,
+        undefined,
+        customPrompt,
       );
 
       if (!articleId) {

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -6,6 +6,7 @@ import { ArticleCategory, DBArticle } from '../articles/article.entity';
 import { ArticlesService } from '../articles/articles.service';
 import { ConfigService } from '../config/config.service';
 import { ProfilesService } from '../profiles/profiles.service';
+import { buildFinalPrompt } from '../shared/helpers/build-final-prompt';
 import { ProcessingStats } from '../shared/types/ai';
 import { FeedProfile } from '../shared/types/feed';
 
@@ -66,13 +67,18 @@ export class ProcessorService {
       console.log(`Processing article ID: ${article.id} - ${article.title}...`);
 
       try {
-        const summaryPrompt = profilePrompts.articleSummary
+        const baseSummaryPrompt = profilePrompts.articleSummary
           ? this.configService.formatPrompt(profilePrompts.articleSummary, {
             article_content: article.raw_content.substring(0, 4000),
           })
           : this.configService.getArticleSummaryPrompt(
             article.raw_content.substring(0, 4000),
           );
+
+        const summaryPrompt = buildFinalPrompt(
+          baseSummaryPrompt,
+          article.custom_prompt,
+        );
 
         const summary = await this.aiService.callChat(summaryPrompt);
 

--- a/src/scraper/scraper.service.ts
+++ b/src/scraper/scraper.service.ts
@@ -150,6 +150,7 @@ export class ScraperService {
   async scrapeSingleArticle(
     url: string,
     feedProfile: FeedProfile,
+    customPrompt?: string,
   ): Promise<string | null> {
     // console.log(`\n--- Scraping single article: ${url} ---`);
 
@@ -197,7 +198,6 @@ export class ScraperService {
     const publishedDate = new Date();
     const feedSource = 'Manual';
 
-    // console.log(`Adding article: ${title}`);
     const articleId = await this.articlesService.addArticle(
       url,
       title,
@@ -206,6 +206,8 @@ export class ScraperService {
       rawContent,
       feedProfile,
       ogImageUrl || undefined,
+      undefined,
+      customPrompt,
     );
 
     if (articleId) {

--- a/src/shared/helpers/build-final-prompt.spec.ts
+++ b/src/shared/helpers/build-final-prompt.spec.ts
@@ -1,0 +1,31 @@
+import { buildFinalPrompt } from './build-final-prompt';
+
+describe('buildFinalPrompt', () => {
+  it('returns base prompt when custom prompt is undefined', () => {
+    const base = 'Summarize this article.';
+    expect(buildFinalPrompt(base, undefined)).toBe(base);
+  });
+
+  it('returns base prompt when custom prompt is null', () => {
+    const base = 'Summarize this article.';
+    expect(buildFinalPrompt(base, null)).toBe(base);
+  });
+
+  it('returns base prompt when custom prompt is empty string', () => {
+    const base = 'Summarize this article.';
+    expect(buildFinalPrompt(base, '')).toBe(base);
+  });
+
+  it('returns base prompt when custom prompt is whitespace only', () => {
+    const base = 'Summarize this article.';
+    expect(buildFinalPrompt(base, '   ')).toBe(base);
+  });
+
+  it('appends custom prompt with delimiter when present', () => {
+    const base = 'Summarize this article.';
+    const custom = 'Focus on technical details.';
+    expect(buildFinalPrompt(base, custom)).toBe(
+      'Summarize this article.\n\nAdditional instructions: Focus on technical details.',
+    );
+  });
+});

--- a/src/shared/helpers/build-final-prompt.ts
+++ b/src/shared/helpers/build-final-prompt.ts
@@ -1,0 +1,10 @@
+export function buildFinalPrompt(
+  basePrompt: string,
+  customPrompt?: string | null,
+): string {
+  if (!customPrompt || customPrompt.trim() === '') {
+    return basePrompt;
+  }
+
+  return basePrompt + '\n\nAdditional instructions: ' + customPrompt;
+}


### PR DESCRIPTION
Adds customPrompt field to article creation and markdown processing endpoints. The custom prompt is passed through the scraping and processing pipeline, allowing users to influence how articles are summarized by AI. Includes a helper function to combine base prompts with custom prompts.

Closes https://linear.app/anas-org/issue/TASK-280