### PR TITLE
feat(youtube-transcriptions): add custom prompt support for transcription summaries

### DIFF
--- a/src/youtube-transcriptions/commands/create-youtube-transcription.command.ts
+++ b/src/youtube-transcriptions/commands/create-youtube-transcription.command.ts
@@ -8,6 +8,7 @@ import { YoutubeTranscriptionsService } from '../services/youtube-transcriptions
 export type CreateYoutubeTranscriptionCommandInput = {
   url: string;
   channelId: string;
+  customPrompt?: string;
 };
 
 export type CreateYoutubeTranscriptionCommandResponse = {
@@ -23,12 +24,14 @@ export class CreateYoutubeTranscriptionCommand {
   async execute(
     input: CreateYoutubeTranscriptionCommandInput,
   ): Promise<CreateYoutubeTranscriptionCommandResponse> {
-    const { url, channelId } = input;
+    const { url, channelId, customPrompt } = input;
 
     try {
       const transcriptionId = await this.service.processSingleVideoUrl(
         url,
         channelId,
+        undefined,
+        customPrompt,
       );
 
       if (transcriptionId === null) {

--- a/src/youtube-transcriptions/dto/create-youtube-transcription.dto.ts
+++ b/src/youtube-transcriptions/dto/create-youtube-transcription.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
 
 export class CreateYoutubeTranscriptionDto {
   @IsNotEmpty()
@@ -8,4 +14,11 @@ export class CreateYoutubeTranscriptionDto {
   @IsNotEmpty()
   @IsString()
   channelId: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, {
+    message: 'customPrompt must not exceed 500 characters',
+  })
+  customPrompt?: string;
 }

--- a/src/youtube-transcriptions/processors/youtube-transcription.processor.ts
+++ b/src/youtube-transcriptions/processors/youtube-transcription.processor.ts
@@ -8,6 +8,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { Job, Worker } from 'bullmq';
 import { AiService } from '../../ai/ai.service';
 import { ConfigService } from '../../config/config.service';
+import { buildFinalPrompt } from '../../shared/helpers/build-final-prompt';
 import { YoutubeTranscriptionsService } from '../services/youtube-transcriptions.service';
 
 @Injectable()
@@ -67,8 +68,16 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
     );
 
     try {
-      const summaryPrompt =
+      const transcription =
+        await this.youtubeTranscriptionsService.getTranscriptionById(
+          transcriptionId,
+        );
+      const basePrompt =
         this.configService.getTranscriptionSummaryPrompt(transcriptText);
+      const summaryPrompt = buildFinalPrompt(
+        basePrompt,
+        transcription?.custom_prompt ?? null,
+      );
 
       console.log(`Generating summary for transcription ${transcriptionId}...`);
       const summary = await this.aiService.callDeepseekChat(summaryPrompt);

--- a/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
+++ b/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
@@ -262,12 +262,14 @@ export class YoutubeTranscriptionsService {
    * @param videoUrl - The YouTube video URL
    * @param channelId - The channel ID from config
    * @param proxyUrl - Optional proxy URL for transcript fetching
+   * @param customPrompt - Optional custom prompt for summary (max 500 chars)
    * @returns The transcription ID or null if video already exists
    */
   async processSingleVideoUrl(
     videoUrl: string,
     channelId: string,
     proxyUrl?: string,
+    customPrompt?: string,
   ): Promise<string | null> {
     try {
       console.log(`\n========================================`);
@@ -396,8 +398,11 @@ export class YoutubeTranscriptionsService {
 
       await this.storageService.saveTranscript(channelId, videoWithTranscript);
 
-      // Save transcription to database first without summary
-      const transcriptionId = await this.addTranscription(videoWithTranscript);
+      const transcriptionId = await this.addTranscription(
+        videoWithTranscript,
+        undefined,
+        customPrompt,
+      );
 
       if (transcriptionId === null) {
         console.log('Video already exists in database');
@@ -429,11 +434,13 @@ export class YoutubeTranscriptionsService {
    * Save a transcription to the database
    * @param videoData - The video with transcript data
    * @param transcriptionSummary - Optional summary of the transcription
+   * @param customPrompt - Optional custom prompt for summary (max 500 chars)
    * @returns The inserted ID or null on error
    */
   async addTranscription(
     videoData: VideoWithTranscript,
     transcriptionSummary?: string,
+    customPrompt?: string,
   ): Promise<string | null> {
     return new Promise((resolve, reject) => {
       const db = this.databaseService.getDbConnection();
@@ -441,9 +448,9 @@ export class YoutubeTranscriptionsService {
       const stmt = db.prepare(`
         INSERT INTO youtube_transcriptions (
           channel_id, channel_name, video_title, posted_at, video_url,
-          processed_at, transcription_text, transcription_summary, thumbnail_url
+          processed_at, transcription_text, transcription_summary, thumbnail_url, custom_prompt
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       stmt.run(
@@ -457,6 +464,7 @@ export class YoutubeTranscriptionsService {
           videoData.transcriptText,
           transcriptionSummary || null,
           videoData.thumbnailUrl || null,
+          customPrompt || null,
         ],
         function (this: { lastID?: string }, err: Error | null) {
           if (err) {
@@ -647,7 +655,8 @@ export class YoutubeTranscriptionsService {
           processed_at AS "processedAt",
           transcription_text AS "transcriptionText",
           transcription_summary AS "transcriptionSummary",
-          thumbnail_url AS "thumbnailUrl"
+          thumbnail_url AS "thumbnailUrl",
+          custom_prompt
         FROM youtube_transcriptions
         WHERE id = ?
       `;

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -42,6 +42,7 @@ export class YoutubeTranscriptionsController {
     return await this.createYoutubeTranscriptionCommand.execute({
       url: dto.url,
       channelId: dto.channelId,
+      customPrompt: dto.customPrompt,
     });
   }
 


### PR DESCRIPTION
Allow users to optionally provide a custom prompt (max 500 characters) when creating YouTube transcriptions. The custom prompt is stored in the database and used to customize the summary generation prompt via the buildFinalPrompt helper.

Closes https://linear.app/anas-org/issue/TASK-281