### PR TITLE
test(custom-prompt): add backward compatibility tests for custom_prompt handling

### DIFF
--- a/src/processor/processor.service.spec.ts
+++ b/src/processor/processor.service.spec.ts
@@ -64,6 +64,61 @@ describe('ProcessorService', () => {
     jest.clearAllMocks();
   });
 
+  describe('processArticles - backward compatibility (custom prompt)', () => {
+    it('sends base prompt to AI when article has no custom_prompt', async () => {
+      const articleWithoutCustomPrompt: DBArticle = {
+        ...mockArticle,
+        custom_prompt: undefined,
+      };
+      mockArticlesService.getUnprocessedArticles.mockResolvedValue([
+        articleWithoutCustomPrompt,
+      ]);
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockAiService.callChat).toHaveBeenCalledWith('summary prompt');
+      expect(mockAiService.callChat).not.toHaveBeenCalledWith(
+        expect.stringContaining('Additional instructions:'),
+      );
+    });
+
+    it('sends base prompt to AI when article has custom_prompt null', async () => {
+      const articleWithNullCustomPrompt: DBArticle = {
+        ...mockArticle,
+        custom_prompt: null,
+      };
+      mockArticlesService.getUnprocessedArticles.mockResolvedValue([
+        articleWithNullCustomPrompt,
+      ]);
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockAiService.callChat).toHaveBeenCalledWith('summary prompt');
+    });
+
+    it('appends custom prompt when article has custom_prompt set', async () => {
+      const articleWithCustomPrompt: DBArticle = {
+        ...mockArticle,
+        custom_prompt: 'Focus on security implications.',
+      };
+      mockArticlesService.getUnprocessedArticles.mockResolvedValue([
+        articleWithCustomPrompt,
+      ]);
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockAiService.callChat).toHaveBeenCalledWith(
+        'summary prompt\n\nAdditional instructions: Focus on security implications.',
+      );
+    });
+  });
+
   describe('processArticles - embedding failure isolation', () => {
     it('should continue processing when embedding fails and save article without embedding', async () => {
       mockAiService.callChat.mockResolvedValue('Article summary');

--- a/src/shared/helpers/custom-prompt-backward-compat.spec.ts
+++ b/src/shared/helpers/custom-prompt-backward-compat.spec.ts
@@ -1,0 +1,82 @@
+import { prepareArticleContent } from '../../articles/helpers/prepareArticleContent';
+import { buildFinalPrompt } from './build-final-prompt';
+
+describe('Custom Prompt Backward Compatibility', () => {
+  describe('buildFinalPrompt - null/empty variants produce identical base prompt', () => {
+    const basePrompt = 'Summarize this content.';
+
+    it('returns base prompt when custom prompt is undefined', () => {
+      expect(buildFinalPrompt(basePrompt, undefined)).toBe(basePrompt);
+    });
+
+    it('returns base prompt when custom prompt is null', () => {
+      expect(buildFinalPrompt(basePrompt, null)).toBe(basePrompt);
+    });
+
+    it('returns base prompt when custom prompt is empty string', () => {
+      expect(buildFinalPrompt(basePrompt, '')).toBe(basePrompt);
+    });
+
+    it('returns base prompt when custom prompt is whitespace only', () => {
+      expect(buildFinalPrompt(basePrompt, '   ')).toBe(basePrompt);
+    });
+
+    it('returns base prompt when custom prompt is tab-only', () => {
+      expect(buildFinalPrompt(basePrompt, '\t')).toBe(basePrompt);
+    });
+
+    it('does NOT append delimiter when custom prompt is null', () => {
+      const result = buildFinalPrompt(basePrompt, null);
+      expect(result).not.toContain('Additional instructions:');
+      expect(result).toBe(basePrompt);
+    });
+  });
+
+  describe('buildFinalPrompt - custom prompt present appends correctly', () => {
+    it('appends custom prompt with delimiter when present', () => {
+      const base = 'Summarize this article.';
+      const custom = 'Focus on technical details.';
+      expect(buildFinalPrompt(base, custom)).toBe(
+        'Summarize this article.\n\nAdditional instructions: Focus on technical details.',
+      );
+    });
+  });
+
+  describe('prepareArticleContent - API response includes custom_prompt', () => {
+    it('includes custom_prompt null in article response for existing records', async () => {
+      const article = {
+        id: 'article-1',
+        url: 'https://example.com',
+        title: 'Test',
+        published_date: new Date(),
+        feed_source: 'test',
+        raw_content: 'Content',
+        feed_profile: 'default',
+        created_at: new Date(),
+        custom_prompt: null as string | null,
+      };
+
+      const result = await prepareArticleContent(article as never);
+
+      expect(result).toHaveProperty('custom_prompt', null);
+    });
+
+    it('includes custom_prompt value when set', async () => {
+      const article = {
+        id: 'article-1',
+        url: 'https://example.com',
+        title: 'Test',
+        published_date: new Date(),
+        feed_source: 'test',
+        raw_content: 'Content',
+        feed_profile: 'default',
+        created_at: new Date(),
+        custom_prompt: 'Focus on security.',
+      };
+
+      const result = await prepareArticleContent(article as never);
+
+      expect(result).toHaveProperty('custom_prompt', 'Focus on security.');
+    });
+  });
+});

--- a/src/youtube-transcriptions/processors/youtube-transcription.processor.spec.ts
+++ b/src/youtube-transcriptions/processors/youtube-transcription.processor.spec.ts
@@ -1,0 +1,94 @@
+import { AudioJobService } from '@libs/audio';
+import { ProcessTranscriptionSummaryJobData } from '@libs/queue';
+import { mock } from 'jest-mock-extended';
+import { Job } from 'bullmq';
+import { AiService } from '../../ai/ai.service';
+import { ConfigService } from '../../config/config.service';
+import { YoutubeTranscriptionsService } from '../services/youtube-transcriptions.service';
+import { YoutubeTranscriptionProcessor } from './youtube-transcription.processor';
+
+describe('YoutubeTranscriptionProcessor', () => {
+  let processor: YoutubeTranscriptionProcessor;
+  const mockYoutubeTranscriptionsService = mock<YoutubeTranscriptionsService>();
+  const mockAiService = mock<AiService>();
+  const mockConfigService = mock<ConfigService>();
+  const mockAudioJobService = mock<AudioJobService>();
+
+  const basePrompt = 'Summarize this transcription.';
+  const transcriptionId = 'transcription-uuid-123';
+  const transcriptText = 'Video transcript content...';
+  const videoTitle = 'Test Video';
+
+  const createJob = (
+    overrides?: Partial<ProcessTranscriptionSummaryJobData>,
+  ): Job<ProcessTranscriptionSummaryJobData> =>
+    ({
+      data: {
+        transcriptionId,
+        transcriptText,
+        videoTitle,
+        ...overrides,
+      },
+      id: 'job-1',
+    }) as Job<ProcessTranscriptionSummaryJobData>;
+
+  beforeEach(() => {
+    processor = new YoutubeTranscriptionProcessor(
+      { getClient: () => ({}) } as never,
+      mockYoutubeTranscriptionsService,
+      mockAiService,
+      mockConfigService,
+      mockAudioJobService,
+    );
+
+    mockConfigService.getTranscriptionSummaryPrompt.mockReturnValue(basePrompt);
+    mockYoutubeTranscriptionsService.updateTranscriptionSummary.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('processTranscriptionSummary - backward compatibility (custom prompt)', () => {
+    it('sends base prompt to AI when transcription has no custom_prompt', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue({
+        id: transcriptionId,
+        custom_prompt: undefined,
+      } as never);
+      mockAiService.callDeepseekChat.mockResolvedValue('Generated summary');
+
+      await processor.processTranscriptionSummary(createJob());
+
+      expect(mockAiService.callDeepseekChat).toHaveBeenCalledWith(basePrompt);
+      expect(mockAiService.callDeepseekChat).not.toHaveBeenCalledWith(
+        expect.stringContaining('Additional instructions:'),
+      );
+    });
+
+    it('sends base prompt to AI when transcription has custom_prompt null', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue({
+        id: transcriptionId,
+        custom_prompt: null,
+      } as never);
+      mockAiService.callDeepseekChat.mockResolvedValue('Generated summary');
+
+      await processor.processTranscriptionSummary(createJob());
+
+      expect(mockAiService.callDeepseekChat).toHaveBeenCalledWith(basePrompt);
+    });
+
+    it('appends custom prompt when transcription has custom_prompt set', async () => {
+      mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue({
+        id: transcriptionId,
+        custom_prompt: 'Focus on actionable takeaways.',
+      } as never);
+      mockAiService.callDeepseekChat.mockResolvedValue('Generated summary');
+
+      await processor.processTranscriptionSummary(createJob());
+
+      expect(mockAiService.callDeepseekChat).toHaveBeenCalledWith(
+        `${basePrompt}\n\nAdditional instructions: Focus on actionable takeaways.`,
+      );
+    });
+  });
+});

--- a/src/youtube-transcriptions/queries/get-youtube-transcription-by-id.query.spec.ts
+++ b/src/youtube-transcriptions/queries/get-youtube-transcription-by-id.query.spec.ts
@@ -98,6 +98,39 @@ describe('GetYoutubeTranscriptionByIdQuery', () => {
     expect(mockS3Service.generatePresignedGetUrl).not.toHaveBeenCalled();
   });
 
+  it('should include custom_prompt in response when transcription has custom_prompt null (backward compat)', async () => {
+    const transcriptionWithNullCustomPrompt = {
+      ...mockTranscription,
+      custom_prompt: null as string | null,
+    };
+    mockService.getTranscriptionById.mockResolvedValue(
+      transcriptionWithNullCustomPrompt,
+    );
+
+    const result = await query.execute(transcriptionId, false);
+
+    expect(result).not.toBeNull();
+    expect(result?.transcription).toHaveProperty('custom_prompt', null);
+  });
+
+  it('should include custom_prompt in response when transcription has custom_prompt set', async () => {
+    const transcriptionWithCustomPrompt = {
+      ...mockTranscription,
+      custom_prompt: 'Focus on technical details.',
+    };
+    mockService.getTranscriptionById.mockResolvedValue(
+      transcriptionWithCustomPrompt,
+    );
+
+    const result = await query.execute(transcriptionId, false);
+
+    expect(result).not.toBeNull();
+    expect(result?.transcription).toHaveProperty(
+      'custom_prompt',
+      'Focus on technical details.',
+    );
+  });
+
   it('should return null when transcription does not exist', async () => {
     mockService.getTranscriptionById.mockResolvedValue(null);
 

--- a/test/external-articles.e2e-spec.ts
+++ b/test/external-articles.e2e-spec.ts
@@ -239,10 +239,11 @@ describe('External Articles Integration Tests', () => {
         expect(response.body).toHaveProperty('jobId', TEST_JOB_ID);
         expect(response.body).toHaveProperty('message');
 
-        // Verify services were called
+        // Verify services were called (customPrompt undefined when not provided - backward compat)
         expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(
           TEST_URL,
           FeedProfile.TECHNOLOGY,
+          undefined,
         );
         expect(mockQueueService.addArticleProcessingJob).toHaveBeenCalledWith(
           TEST_ARTICLE_ID,

--- a/test/telegram-article-submission.e2e-spec.ts
+++ b/test/telegram-article-submission.e2e-spec.ts
@@ -158,6 +158,7 @@ describe('Telegram Article Submission E2E Flow', () => {
       expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(
         TEST_URL,
         FeedProfile.TECHNOLOGY,
+        undefined,
       );
 
       expect(mockQueueService.addArticleProcessingJob).toHaveBeenCalledWith(
@@ -252,7 +253,11 @@ describe('Telegram Article Submission E2E Flow', () => {
           });
 
         expect(response.status).toBe(201);
-        expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(TEST_URL, profile);
+        expect(mockScraperService.scrapeSingleArticle).toHaveBeenCalledWith(
+          TEST_URL,
+          profile,
+          undefined,
+        );
 
         // Add small delay between requests to prevent socket hang up
         await new Promise((resolve) => setTimeout(resolve, 50));


### PR DESCRIPTION
Adds unit and e2e tests verifying that articles and transcriptions with null, undefined, or empty custom_prompt values are handled correctly, ensuring backward compatibility with the custom prompt feature.


Closes https://linear.app/anas-org/issue/TASK-283