### PR TITLE
feat(audio): add generateAudio option to article processing pipeline

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -404,9 +404,12 @@ Processes one video URL and stores transcription.
 ```json
 {
   "url": "https://www.youtube.com/watch?v=abc123",
-  "channelId": "channel-id"
+  "channelId": "channel-id",
+  "generateAudio": true
 }
 ```
+
+`generateAudio` is optional. When `true`, audio generation is enqueued after transcription summary processing.
 
 ```json
 {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -162,9 +162,12 @@ Scrapes one article and queues processing.
 ```json
 {
   "url": "https://example.com/article",
-  "feedProfile": "technology"
+  "feedProfile": "technology",
+  "generateAudio": true
 }
 ```
+
+`generateAudio` is optional. When `true`, the processing pipeline also enqueues article audio generation.
 
 Response includes queue metadata:
 
@@ -210,9 +213,12 @@ Queues a markdown article stored in S3.
 {
   "s3Key": "article.md",
   "feedProfile": "technology",
-  "s3Bucket": "optional-bucket-name"
+  "s3Bucket": "optional-bucket-name",
+  "generateAudio": true
 }
 ```
+
+`generateAudio` is optional. When `true`, the processing pipeline also enqueues article audio generation.
 
 Response:
 
@@ -284,6 +290,7 @@ Public endpoint for external sources (for example bots) to submit article URLs.
 {
   "url": "https://example.com/news",
   "feedProfile": "technology",
+  "generateAudio": true,
   "source": "telegram",
   "metadata": {
     "chatId": "12345",
@@ -293,6 +300,8 @@ Public endpoint for external sources (for example bots) to submit article URLs.
   }
 }
 ```
+
+`generateAudio` is optional. When `true`, the processing pipeline also enqueues article audio generation.
 
 - Success response:
 

--- a/libs/queue/interfaces/article-job.interface.ts
+++ b/libs/queue/interfaces/article-job.interface.ts
@@ -3,4 +3,5 @@ import { FeedProfile } from '../../../src/shared/types/feed';
 export interface ProcessArticleJobData {
   articleFileKey: string;
   feedProfile: FeedProfile;
+  generateAudio?: boolean;
 }

--- a/libs/queue/interfaces/markdown-article-job.interface.ts
+++ b/libs/queue/interfaces/markdown-article-job.interface.ts
@@ -5,4 +5,5 @@ export interface ProcessMarkdownArticleJobData {
   s3Key: string;
   feedProfile: FeedProfile;
   customPrompt?: string;
+  generateAudio?: boolean;
 }

--- a/libs/queue/processors/article.processor.ts
+++ b/libs/queue/processors/article.processor.ts
@@ -51,7 +51,7 @@ export class ArticleProcessor implements OnModuleInit, OnModuleDestroy {
   async processArticle(
     job: Job<ProcessArticleJobData>,
   ): Promise<{ success: boolean; message: string }> {
-    const { articleFileKey: articleId, feedProfile } = job.data;
+    const { articleFileKey: articleId, feedProfile, generateAudio } = job.data;
 
     console.log(
       `\n>>> Processing article ID ${articleId} from queue (Job ${job.id}) <<<`,
@@ -64,6 +64,7 @@ export class ArticleProcessor implements OnModuleInit, OnModuleDestroy {
         feedProfile,
         1,
         articleId,
+        generateAudio,
       );
 
       if (processStats.errors > 0 || processStats.articlesProcessed === 0) {

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -254,10 +254,12 @@ Please investigate the issue.`,
   async addArticleProcessingJob(
     articleFileKey: string,
     feedProfile: FeedProfile,
+    generateAudio?: boolean,
   ): Promise<JobInfo> {
     const jobData: ProcessArticleJobData = {
       articleFileKey,
       feedProfile,
+      generateAudio,
     };
 
     const job = await this.articleQueue.add(PROCESS_ARTICLE_JOB, jobData);
@@ -282,12 +284,14 @@ Please investigate the issue.`,
     s3Key: string,
     feedProfile: FeedProfile,
     customPrompt?: string,
+    generateAudio?: boolean,
   ): Promise<JobInfo> {
     const jobData: ProcessMarkdownArticleJobData = {
       s3Bucket,
       s3Key,
       feedProfile,
       customPrompt,
+      generateAudio,
     };
 
     const job = await this.markdownArticleQueue.add(

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -43,7 +43,7 @@ export class ArticlesController {
 
   @Post()
   async create(@Body() createArticleDto: CreateArticleDto) {
-    const { url, feedProfile, customPrompt } = createArticleDto;
+    const { url, feedProfile, customPrompt, generateAudio } = createArticleDto;
 
     try {
       const articleId = await this.scraperService.scrapeSingleArticle(
@@ -59,6 +59,7 @@ export class ArticlesController {
       const jobInfo = await this.queueService.addArticleProcessingJob(
         articleId,
         feedProfile,
+        generateAudio,
       );
 
       return {
@@ -116,7 +117,7 @@ export class ArticlesController {
 
   @Post('markdown')
   async processMarkdownArticle(@Body() dto: ProcessMarkdownArticleDto) {
-    const { s3Key, feedProfile, s3Bucket, customPrompt } = dto;
+    const { s3Key, feedProfile, s3Bucket, customPrompt, generateAudio } = dto;
 
     try {
       const bucketName = s3Bucket || process.env.S3_ARTICLES_BUCKET_NAME;
@@ -132,6 +133,7 @@ export class ArticlesController {
         s3Key,
         feedProfile,
         customPrompt,
+        generateAudio,
       );
 
       return {

--- a/src/articles/dto/create-article.dto.ts
+++ b/src/articles/dto/create-article.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsEnum,
   IsNotEmpty,
   IsOptional,
@@ -26,4 +27,8 @@ export class CreateArticleDto {
     message: `customPrompt must not exceed ${CUSTOM_PROMPT_MAX_LENGTH} characters`,
   })
   customPrompt?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  generateAudio?: boolean;
 }

--- a/src/articles/dto/external-create-article.dto.ts
+++ b/src/articles/dto/external-create-article.dto.ts
@@ -1,5 +1,6 @@
 import { Type } from 'class-transformer';
 import {
+  IsBoolean,
   IsEnum,
   IsNotEmpty,
   IsOptional,
@@ -49,6 +50,10 @@ export class ExternalCreateArticleDto {
     message: `customPrompt must not exceed ${CUSTOM_PROMPT_MAX_LENGTH} characters`,
   })
   customPrompt?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  generateAudio?: boolean;
 
   @IsOptional()
   @ValidateNested()

--- a/src/articles/dto/process-markdown-article.dto.ts
+++ b/src/articles/dto/process-markdown-article.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsEnum,
   IsNotEmpty,
   IsOptional,
@@ -28,4 +29,8 @@ export class ProcessMarkdownArticleDto {
     message: `customPrompt must not exceed ${CUSTOM_PROMPT_MAX_LENGTH} characters`,
   })
   customPrompt?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  generateAudio?: boolean;
 }

--- a/src/articles/external-articles.controller.spec.ts
+++ b/src/articles/external-articles.controller.spec.ts
@@ -129,6 +129,7 @@ describe('ExternalArticlesController', () => {
       expect(queueService.addArticleProcessingJob).toHaveBeenCalledWith(
         articleId,
         validDto.feedProfile,
+        undefined,
       );
     });
 

--- a/src/articles/external-articles.controller.ts
+++ b/src/articles/external-articles.controller.ts
@@ -77,7 +77,14 @@ export class ExternalArticlesController {
       });
     }
 
-    const { url, feedProfile, customPrompt, source = 'external', metadata } = dto;
+    const {
+      url,
+      feedProfile,
+      customPrompt,
+      generateAudio,
+      source = 'external',
+      metadata,
+    } = dto;
     this.assertSafeExternalUrl(url);
 
     const submissionMetadata = {
@@ -133,6 +140,7 @@ export class ExternalArticlesController {
       articleId,
       feedProfile,
       submissionId,
+      generateAudio,
     );
 
     if (submissionId) {
@@ -338,9 +346,14 @@ export class ExternalArticlesController {
     articleId: string,
     feedProfile: FeedProfile,
     submissionId: string | null,
+    generateAudio?: boolean,
   ): Promise<Awaited<ReturnType<QueueService['addArticleProcessingJob']>>> {
     try {
-      return await this.queueService.addArticleProcessingJob(articleId, feedProfile);
+      return await this.queueService.addArticleProcessingJob(
+        articleId,
+        feedProfile,
+        generateAudio,
+      );
     } catch (error) {
       await this.handleError(error, submissionId, {
         code: ExternalArticleErrorCode.INTERNAL_ERROR,

--- a/src/articles/processors/markdown-article.processor.spec.ts
+++ b/src/articles/processors/markdown-article.processor.spec.ts
@@ -117,6 +117,7 @@ describe('MarkdownArticleProcessor', () => {
         FeedProfile.DEFAULT,
         1,
         articleId,
+        undefined,
       );
       expect(mockProcessorService.rateArticles).toHaveBeenCalledWith(
         FeedProfile.DEFAULT,
@@ -308,6 +309,7 @@ describe('MarkdownArticleProcessor', () => {
         FeedProfile.TECHNOLOGY,
         1,
         articleId,
+        undefined,
       );
       expect(mockProcessorService.rateArticles).toHaveBeenCalledWith(
         FeedProfile.TECHNOLOGY,

--- a/src/articles/processors/markdown-article.processor.ts
+++ b/src/articles/processors/markdown-article.processor.ts
@@ -59,7 +59,8 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
   async processMarkdownArticle(
     job: Job<ProcessMarkdownArticleJobData>,
   ): Promise<{ success: boolean; message: string }> {
-    const { s3Bucket, s3Key, feedProfile, customPrompt } = job.data;
+    const { s3Bucket, s3Key, feedProfile, customPrompt, generateAudio } =
+      job.data;
 
     console.log(
       `\n>>> Processing markdown article from S3 (Job ${job.id}) <<<`,
@@ -102,6 +103,7 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
         feedProfile,
         1,
         articleId,
+        generateAudio,
       );
 
       if (processStats.errors > 0 || processStats.articlesProcessed === 0) {

--- a/src/youtube-transcriptions/commands/create-youtube-transcription.command.ts
+++ b/src/youtube-transcriptions/commands/create-youtube-transcription.command.ts
@@ -9,6 +9,7 @@ export type CreateYoutubeTranscriptionCommandInput = {
   url: string;
   channelId: string;
   customPrompt?: string;
+  generateAudio?: boolean;
 };
 
 export type CreateYoutubeTranscriptionCommandResponse = {
@@ -24,7 +25,7 @@ export class CreateYoutubeTranscriptionCommand {
   async execute(
     input: CreateYoutubeTranscriptionCommandInput,
   ): Promise<CreateYoutubeTranscriptionCommandResponse> {
-    const { url, channelId, customPrompt } = input;
+    const { url, channelId, customPrompt, generateAudio } = input;
 
     try {
       const transcriptionId = await this.service.processSingleVideoUrl(
@@ -32,6 +33,7 @@ export class CreateYoutubeTranscriptionCommand {
         channelId,
         undefined,
         customPrompt,
+        generateAudio,
       );
 
       if (transcriptionId === null) {

--- a/src/youtube-transcriptions/dto/create-youtube-transcription.dto.ts
+++ b/src/youtube-transcriptions/dto/create-youtube-transcription.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -21,4 +22,8 @@ export class CreateYoutubeTranscriptionDto {
     message: 'customPrompt must not exceed 500 characters',
   })
   customPrompt?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  generateAudio?: boolean;
 }

--- a/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
+++ b/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
@@ -263,6 +263,7 @@ export class YoutubeTranscriptionsService {
    * @param channelId - The channel ID from config
    * @param proxyUrl - Optional proxy URL for transcript fetching
    * @param customPrompt - Optional custom prompt for summary (max 500 chars)
+   * @param generateAudio - Optional flag to enqueue audio generation after summary
    * @returns The transcription ID or null if video already exists
    */
   async processSingleVideoUrl(
@@ -270,6 +271,7 @@ export class YoutubeTranscriptionsService {
     channelId: string,
     proxyUrl?: string,
     customPrompt?: string,
+    generateAudio?: boolean,
   ): Promise<string | null> {
     try {
       console.log(`\n========================================`);
@@ -416,6 +418,7 @@ export class YoutubeTranscriptionsService {
         transcriptionId,
         transcriptText.substring(0, 8000), // Limit text length
         videoWithTranscript.title,
+        generateAudio,
       );
 
       console.log(

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.spec.ts
@@ -70,6 +70,36 @@ describe('YoutubeTranscriptionsController', () => {
     expect(controller).toBeDefined();
   });
 
+  describe('createTranscription', () => {
+    it('should pass generateAudio to create command flow', async () => {
+      mockYoutubeTranscriptionsService.processSingleVideoUrl.mockResolvedValue(
+        transcriptionId,
+      );
+
+      const result = await controller.createTranscription({
+        url: 'https://www.youtube.com/watch?v=abc123',
+        channelId: 'channel-1',
+        customPrompt: 'Focus on backend architecture',
+        generateAudio: true,
+      });
+
+      expect(result).toEqual({
+        success: true,
+        transcriptionId,
+        message: 'Video transcription saved successfully',
+      });
+      expect(
+        mockYoutubeTranscriptionsService.processSingleVideoUrl,
+      ).toHaveBeenCalledWith(
+        'https://www.youtube.com/watch?v=abc123',
+        'channel-1',
+        undefined,
+        'Focus on backend architecture',
+        true,
+      );
+    });
+  });
+
   describe('getTranscription', () => {
     it('should return transcription without audio when includeAudio is falsy', async () => {
       mockYoutubeTranscriptionsService.getTranscriptionById.mockResolvedValue(

--- a/src/youtube-transcriptions/youtube-transcriptions.controller.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.controller.ts
@@ -43,6 +43,7 @@ export class YoutubeTranscriptionsController {
       url: dto.url,
       channelId: dto.channelId,
       customPrompt: dto.customPrompt,
+      generateAudio: dto.generateAudio,
     });
   }
 


### PR DESCRIPTION
Add optional generateAudio boolean parameter throughout the article processing system, including job interfaces, queue service, controllers, and DTOs with validation. This enables audio generation to be triggered as part of article processing jobs.

Relates to https://linear.app/anas-org/issue/TASK-284