### PR TITLE
feat(transcriptions): add transcript chunking for long videos exceeding AI context limits

### DIFF
--- a/docs/features/plans/transcript-chunking-for-long-videos.plan.md
+++ b/docs/features/plans/transcript-chunking-for-long-videos.plan.md
@@ -1,0 +1,729 @@
+# Plan: Handle Transcripts Exceeding DeepSeek Model Context Limits
+
+## Context
+
+The YouTube transcription summary feature was silently truncating transcripts to 8000 characters before sending to the AI, causing loss of content. This was "fixed" by removing the truncation, but now we need to handle transcripts that could exceed DeepSeek's context limits.
+
+**DeepSeek API Limits (current models):**
+- **deepseek-chat (V3)**: 128K context window, 4K default max output, 8K absolute max output
+- **deepseek-reasoner (R1)**: 128K context window, 32K default max output, 64K absolute max output
+
+**Important**: The API is stateless - full conversation history counts against the 128K budget on every request.
+
+**Current config**: `maxTokens: 2048` (in `config.service.ts:60`) - this is conservative and appropriate for summaries.
+
+## Problem Statement
+
+YouTube transcripts can vary widely in length:
+- Short videos (5-10 min): ~1,000-3,000 words (~1,500-4,500 tokens)
+- Medium videos (15-30 min): ~3,000-8,000 words (~4,500-12,000 tokens)
+- Long videos (1+ hour): ~10,000-20,000+ words (~15,000-30,000+ tokens)
+
+While 128K context is generous, extremely long transcripts (multi-hour content, multiple videos merged) could approach or exceed this limit when combined with the prompt template.
+
+## Critical Files to Modify
+
+1. **`src/shared/helpers/token-estimation.ts`** (NEW) - Shared helper:
+   - `estimateTokenCount(text, charsPerToken)` - core estimation function
+   - `estimateChatTokens(text)` - convenience for chat models (4 chars/token)
+   - `estimateEmbeddingTokens(text)` - convenience for embeddings (2.5 chars/token)
+
+2. **`src/youtube-transcriptions/services/transcript-chunking.service.ts`** (NEW) - Dedicated chunking service:
+   - Token estimation using shared utility
+   - Transcript splitting logic with sentence boundary awareness
+   - Structure extraction and parsing
+   - Chunk summary merging/synthesis with structure context
+   - Intermediate result storage for failure recovery
+   - Processing mode resolution (chunked vs full-context)
+
+3. **`src/youtube-transcriptions/processors/youtube-transcription.processor.ts`** - Orchestration layer:
+   - Inject `TranscriptChunkingService`
+   - Handle chunked processing flow
+   - Log chunking metrics (chunk count, tokens, timing, processing mode)
+   - Handle partial failures with recovery
+
+4. **`src/config/config.service.ts`** - Add configuration:
+   - Add `maxTranscriptionTokens` config option (default: ~100K to leave room for prompt)
+   - Add `transcriptionChunkSize` for chunking strategy
+   - Add `transcriptionChunkOverlap` for boundary preservation
+   - Add `defaultProcessingMode` and `fullContextChannels` for hybrid approach
+   - Add `getProcessingModeForChannel()` method
+   - Add configuration validation
+
+5. **`src/config/config.entity.ts`** - Update types for new config options
+
+6. **`src/config/prompts/transcription-summary.prompt.ts`** - Add chunking-aware prompts:
+   - `structureExtractionPrompt` - extract video structure before chunking
+   - `chunkSummaryWithStructurePrompt` - for individual chunks with context
+   - `synthesisWithStructurePrompt` - for merging chunk summaries
+   - `chunkSummaryPrompt` - simple fallback (no structure context)
+
+7. **`src/ai/ai.service.ts`** - Minor refactor:
+   - Replace inline `estimateTokenCount` with shared helper import
+   - No chunking logic here (kept in dedicated service)
+
+8. **`src/youtube-transcriptions/errors/transcript-chunking.errors.ts`** (NEW) - Explicit error types:
+   - `TranscriptChunkingError` - base error for chunking failures
+   - `StructureExtractionError` - error when structure extraction fails or returns malformed JSON
+   - These enable better error handling, logging, and retry logic differentiation
+
+## Implementation Approach
+
+### Option 1: Smart Chunking with Hierarchical Summarization (Recommended)
+
+**How it works:**
+1. Estimate tokens of input transcript
+2. If under threshold (~100K tokens), process normally
+3. If over threshold:
+   - Split transcript into overlapping chunks (e.g., 50K tokens each)
+   - Process each chunk with a "summarize this section" prompt
+   - Store intermediate chunk summaries (for recovery on failure)
+   - Combine all chunk summaries with a "synthesize these summaries" prompt
+   - Return final unified summary
+
+**Pros:**
+- Handles arbitrarily long transcripts
+- Preserves key information from entire transcript
+- Stays well within API limits
+- Intermediate storage enables recovery from partial failures
+
+**Cons:**
+- More API calls (higher cost, more latency)
+- May lose some nuance in chunking
+- Increased complexity
+
+### Option 2: Truncate with Warning
+
+**How it works:**
+- Keep a hard limit (e.g., 100K tokens)
+- If transcript exceeds limit, truncate and log a warning
+- Return summary of what fits
+
+**Pros:**
+- Simple implementation
+- Predictable behavior
+
+**Cons:**
+- Loses information (the original problem!)
+- Not acceptable for production use
+
+### Option 3: Switch to deepseek-reasoner for long transcripts
+
+**How it works:**
+- Detect long transcripts
+- Use R1 model (64K output vs 8K for V3) when needed
+
+**Pros:**
+- More output tokens for complex summaries
+
+**Cons:**
+- Still has 128K input limit (same as V3)
+- R1 is optimized for reasoning, not summarization
+- Doesn't solve the input problem
+
+## Recommended Solution: Hybrid Approach with Structure-Aware Chunking
+
+### Overview
+
+The solution combines two processing strategies:
+
+1. **Full-Context Mode**: For premium/high-priority channels, process the entire transcript without chunking (truncates only if exceeding absolute limits)
+2. **Structure-Aware Chunking**: For standard channels, extract the video structure first, then chunk and summarize with that context preserved
+
+This hybrid approach maximizes quality for important content while maintaining scalability for all videos.
+
+### Processing Flow
+
+```
+Transcript
+    │
+    ▼
+Get channel processing mode
+    │
+    ├── FULL-CONTEXT → Single API call (truncate if > 128K tokens)
+    │
+    └── CHUNKED (default) → Structure-Aware Chunking
+                              │
+                              ▼
+                         1. Extract video structure (1 API call)
+                         2. Split into overlapping chunks
+                         3. Summarize each chunk WITH structure context
+                         4. Synthesize summaries into final output
+                              │
+                              ▼
+                         Fallback: Simple chunking (if structure extraction fails)
+```
+
+### Architecture Decision: Dedicated Chunking Service
+
+**Rationale:** `AiService` is already 772 lines with mixed concerns (API orchestration + embedding chunking). Adding transcript-specific chunking would:
+- Violate Single Responsibility Principle
+- Create tighter coupling between AI service and transcript domain logic
+- Make testing more difficult
+
+**Solution:** Create `TranscriptChunkingService` that:
+- Encapsulates all transcript chunking business logic
+- Can be tested independently of API calls
+- Keeps `AiService` focused on API communication
+- Injects `AiService` via constructor (not method parameter)
+
+### Implementation Details
+
+**Token Estimation Helper:**
+
+Extract to a shared helper to avoid code duplication with `AiService`:
+
+```typescript
+// src/shared/helpers/token-estimation.ts
+export function estimateTokenCount(text: string, charsPerToken: number = 2.5): number {
+  if (!text || text.length === 0) {
+    return 0;
+  }
+
+  // Method 1: Character-based
+  const charEstimate = Math.ceil(text.length / charsPerToken);
+
+  // Method 2: Word-based with punctuation padding
+  const words = text.trim().split(/\s+/).length;
+  const punctuationMatches = text.match(/[.,!?;:"'()[\]{}]/g);
+  const punctuationCount = punctuationMatches ? punctuationMatches.length : 0;
+  const wordEstimate = words + Math.ceil(punctuationCount * 0.5);
+
+  // Use the MORE conservative estimate
+  return Math.max(charEstimate, wordEstimate);
+}
+
+// Convenience functions for different model types
+export const estimateChatTokens = (text: string) => estimateTokenCount(text, 4);
+export const estimateEmbeddingTokens = (text: string) => estimateTokenCount(text, 2.5);
+```
+
+**Chunking Strategy:**
+- **Threshold**: 100K tokens (leave 28K buffer for prompt + output)
+- **Chunk Size**: 50K tokens (allows 2 chunks before hitting threshold)
+- **Overlap**: ~500 tokens between chunks (preserves context at boundaries)
+- **Boundary Handling**: Split at sentence boundaries (reuse `splitTextByEstimatedTokens` pattern from `ai.service.ts:401-442`)
+
+**Structure Extraction (Key Enhancement):**
+
+Before chunking, extract the video's structure to preserve cross-chunk context:
+
+1. **First API call**: Analyze transcript to identify sections, themes, and cross-references
+2. **Chunk summarization**: Pass structure context to each chunk summary prompt
+3. **Synthesis**: Combine chunk summaries with full structure awareness
+
+This preserves:
+- Cross-chunk references ("as I mentioned earlier...")
+- Thematic continuity (narrative arcs across chunks)
+- Structural markers (numbered lists, section headings)
+
+**Flow:**
+```
+Transcript → Token Count → Under 100K?
+                         │
+                         ├── YES → Single API call → Summary
+                         │
+                         └── NO → Get channel processing mode
+                                   │
+                                   ├── FULL-CONTEXT → Single API call (truncate if needed)
+                                   │
+                                   └── CHUNKED → Extract structure (1 API call)
+                                                 │
+                                                 ▼
+                                            Split into chunks
+                                                 │
+                                                 ▼
+                                            Summarize chunks WITH structure context
+                                                 │
+                                                 ▼
+                                            Store summaries (for recovery)
+                                                 │
+                                                 ▼
+                                            Synthesize into final summary
+                                                 │
+                                                 ↓ (on failure)
+                                            Retry synthesis with stored summaries
+```
+
+**New `TranscriptChunkingService` Interface:**
+```typescript
+type ProcessingMode = 'chunked' | 'full-context';
+
+type VideoStructure = {
+  sections: Array<{
+    title: string;
+    startPhrase: string;
+  }>;
+  keyThemes: string[];
+  crossReferences: Array<{
+    from: number;  // section index
+    to: number;    // section index
+    description: string;
+  }>;
+};
+
+@Injectable()
+export class TranscriptChunkingService {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly aiService: AiService,  // Injected via constructor
+    private readonly redisService: RedisService,
+  ) {}
+
+  // Check if chunking is needed
+  needsChunking(transcriptText: string): boolean;
+
+  // Get processing mode for a channel
+  getProcessingMode(channelId: string): ProcessingMode;
+
+  // Extract video structure before chunking
+  extractStructure(transcriptText: string): Promise<VideoStructure>;
+
+  // Split transcript into chunks at sentence boundaries
+  splitIntoChunks(transcriptText: string): TranscriptChunk[];
+
+  // Store intermediate results for recovery (job-scoped key prevents collision)
+  storeChunkSummaries(transcriptionId: string, jobId: string, summaries: string[]): void;
+
+  // Retrieve stored summaries for retry
+  getStoredChunkSummaries(transcriptionId: string, jobId: string): string[] | null;
+
+  // Clear stored summaries after successful completion
+  clearChunkSummaries(transcriptionId: string, jobId: string): void;
+
+  // Merge chunk summaries into final summary via AI
+  synthesizeSummaries(summaries: string[], structure: VideoStructure): Promise<string>;
+
+  // Main processing method
+  processTranscript(
+    transcriptText: string,
+    transcriptionId: string,
+    jobId: string,
+    channelId: string,
+    customPrompt?: string | null,
+  ): Promise<string>;
+}
+```
+
+**Processor Changes:**
+```typescript
+// In YoutubeTranscriptionProcessor
+async processTranscriptionSummary(job: Job): Promise<{ success: boolean; message: string }> {
+  const { transcriptionId, transcriptText, videoTitle, channelId } = job.data;
+
+  // Check if chunking needed
+  if (!this.chunkingService.needsChunking(transcriptText)) {
+    return this.processSinglePass(transcriptionId, transcriptText, videoTitle);
+  }
+
+  // Delegate to chunking service (handles processing mode internally)
+  try {
+    const summary = await this.chunkingService.processTranscript(
+      transcriptText,
+      transcriptionId,
+      job.id as string,  // Pass jobId for job-scoped Redis keys
+      channelId,
+      job.data.customPrompt,
+    );
+
+    await this.youtubeTranscriptionsService.updateTranscriptionSummary(
+      transcriptionId,
+      summary,
+    );
+
+    return { success: true, message: 'Processing complete' };
+  } catch (error) {
+    // Partial results are stored in Redis for retry
+    throw error;
+  }
+}
+```
+
+**ChunkingService Main Processing Method:**
+```typescript
+async processTranscript(
+  transcriptText: string,
+  transcriptionId: string,
+  jobId: string,
+  channelId: string,
+  customPrompt?: string | null,
+): Promise<string> {
+  const processingMode = this.getProcessingMode(channelId);
+
+  // Full-context mode: single API call, truncate only if necessary
+  if (processingMode === 'full-context') {
+    const truncatedText = this.truncateIfNeeded(transcriptText, 120000);
+    return this.aiService.callChat(
+      this.configService.getTranscriptionSummaryPrompt(truncatedText, customPrompt),
+    );
+  }
+
+  // Chunked mode with structure extraction
+  try {
+    // Step 1: Extract structure
+    const structure = await this.extractStructure(transcriptText);
+
+    // Step 2: Split into chunks
+    const chunks = this.splitIntoChunks(transcriptText);
+    const summaries: string[] = [];
+
+    // Step 3: Summarize each chunk WITH structure context
+    for (let i = 0; i < chunks.length; i++) {
+      const summary = await this.aiService.callChat(
+        this.configService.getChunkSummaryWithStructurePrompt(
+          chunks[i].text,
+          structure,
+          i + 1,
+          chunks.length,
+        ),
+      );
+
+      if (!summary) {
+        // Store partial results for retry
+        this.storeChunkSummaries(transcriptionId, jobId, summaries);
+        throw new TranscriptChunkingError(`Chunk ${i + 1} processing failed`, transcriptionId, jobId);
+      }
+
+      summaries.push(summary);
+    }
+
+    // Store summaries before synthesis
+    this.storeChunkSummaries(transcriptionId, jobId, summaries);
+
+    // Step 4: Synthesize with structure awareness
+    const finalSummary = await this.synthesizeSummaries(summaries, structure);
+
+    // Clear intermediate storage
+    this.clearChunkSummaries(transcriptionId, jobId);
+
+    return finalSummary;
+  } catch (error) {
+    // Fallback to simple chunking without structure extraction
+    console.error('Structure-aware chunking failed, falling back to simple chunking:', error);
+    return this.processSimpleChunked(transcriptText, transcriptionId, jobId);
+  }
+}
+
+private async processSimpleChunked(
+  transcriptText: string,
+  transcriptionId: string,
+  jobId: string,
+): Promise<string> {
+  const chunks = this.splitIntoChunks(transcriptText);
+  const summaries: string[] = [];
+
+  for (const chunk of chunks) {
+    const summary = await this.aiService.callChat(
+      this.configService.getChunkSummaryPrompt(chunk.text),
+    );
+    if (summary) {
+      summaries.push(summary);
+    }
+  }
+
+  return this.synthesizeSummaries(summaries, { sections: [], keyThemes: [], crossReferences: [] });
+}
+```
+
+## Configuration to Add
+
+```typescript
+// config.entity.ts
+type ProcessingMode = 'chunked' | 'full-context';
+
+type YoutubeTranscriptionsConfig = {
+  channels: { ... };
+  maxVideosPerChannel: number;
+
+  // Chunking config
+  maxTranscriptionTokens: number;      // Soft limit before chunking (default: 100000)
+  transcriptionChunkSize: number;      // Target chunk size in tokens (default: 50000)
+  transcriptionChunkOverlap: number;   // Overlap in tokens (default: 500)
+
+  // Processing mode config
+  defaultProcessingMode: ProcessingMode;  // Default: 'chunked'
+  fullContextChannels: string[];          // YouTube channel IDs (e.g., 'UCxxxxx') that should use full-context mode
+};                                          // NOTE: These are YouTube channel IDs, NOT database IDs
+
+// Example config:
+youtubeTranscriptions: {
+  channels: { ... },
+  maxVideosPerChannel: 1,
+  maxTranscriptionTokens: 100000,
+  transcriptionChunkSize: 50000,
+  transcriptionChunkOverlap: 500,
+  defaultProcessingMode: 'chunked',
+  fullContextChannels: [
+    'UCxxxxx',  // Premium channel - gets full context processing
+    'UCyyyyy',  // Another important channel
+  ],
+}
+
+// config.service.ts - add validation and getters
+getYoutubeTranscriptionsConfig(): YoutubeTranscriptionsConfig {
+  const baseConfig = this.CONFIGS.youtubeTranscriptions;
+
+  // Validate chunking config
+  if (baseConfig.transcriptionChunkSize >= baseConfig.maxTranscriptionTokens) {
+    throw new Error('transcriptionChunkSize must be less than maxTranscriptionTokens');
+  }
+
+  return baseConfig;
+}
+
+getProcessingModeForChannel(channelId: string): ProcessingMode {
+  const config = this.CONFIGS.youtubeTranscriptions;
+  // channelId should be the YouTube channel ID (e.g., 'UCxxxxx'), not the database ID
+  if (config.fullContextChannels.includes(channelId)) {
+    return 'full-context';
+  }
+  return config.defaultProcessingMode;
+}
+```
+
+### Alternative: Database-Driven Channel Configuration
+
+For more flexibility, store processing mode per channel in the database:
+
+```typescript
+// youtube_channels table - add column
+ALTER TABLE youtube_channels ADD COLUMN processing_mode TEXT DEFAULT 'chunked';
+
+// Updated config.service.ts
+async getProcessingModeForChannel(channelId: string): Promise<ProcessingMode> {
+  const channel = await this.youtubeChannelsService.getChannelById(channelId);
+  return channel?.processingMode || this.CONFIGS.youtubeTranscriptions.defaultProcessingMode;
+}
+```
+
+## Prompts for Structure-Aware Chunking
+
+Add these new prompts to `src/config/prompts/transcription-summary.prompt.ts`:
+
+**Structure Extraction Prompt:**
+```typescript
+export const structureExtractionPrompt = `
+You are analyzing a YouTube video transcript to understand its structure.
+
+Your task:
+1. Identify the main sections/topics of this video
+2. For each section, note the approximate beginning (first distinctive phrase)
+3. Capture how sections relate to each other
+
+Output format (JSON):
+{
+  "sections": [
+    {"title": "Section title", "startPhrase": "First distinctive phrase of section"},
+    ...
+  ],
+  "keyThemes": ["Theme 1", "Theme 2", ...],
+  "crossReferences": [
+    {"from": 0, "to": 3, "description": "Section 1 introduces concept used in section 4"},
+    ...
+  ]
+}
+
+Transcript:
+{article_content}
+`;
+```
+
+**Chunk Summary with Structure Context Prompt:**
+```typescript
+export const chunkSummaryWithStructurePrompt = `
+You are summarizing section {section_number} of {total_sections} from a YouTube video.
+
+## Video Context
+Key themes: {key_themes}
+Video structure: {sections_overview}
+
+## Cross-References to This Section
+{cross_references}
+
+## This Section's Content
+{chunk_content}
+
+Provide a summary that:
+1. Connects to the video's overall themes where relevant
+2. Notes any references to other parts of the video
+3. Preserves the speaker's key arguments and data
+
+Output format:
+**Main Points:**
+- [2-3 key points from this section]
+
+**Connections:**
+- [How this section relates to others, if applicable]
+
+**Key Data/Quotes:**
+- [Notable information from this section]
+`;
+```
+
+**Synthesis Prompt with Structure:**
+```typescript
+export const synthesisWithStructurePrompt = `
+You are creating a final summary from multiple section summaries of a YouTube video.
+
+## Video Structure
+{video_structure}
+
+## Section Summaries
+{chunk_summaries}
+
+Create a coherent summary that:
+1. Maintains the logical flow of the original video
+2. Connects related points across sections
+3. Preserves the speaker's main arguments and supporting evidence
+4. Includes key data points and memorable quotes
+
+Output format:
+1) 3-5 sentence overview in plain English
+2) 3-5 sentence summary in technical terms
+3) Key takeaways as concise bullet points
+4) Notable data, trends, or memorable quotes
+5) Brief critique: any bias, outdated information, or gaps
+`;
+```
+
+## Error Handling for Partial Failures
+
+| Failure Point | Recovery Strategy |
+|---------------|-------------------|
+| Chunk N summary fails | Store N-1 successful summaries; retry chunk N on next job attempt |
+| Synthesis fails | Retrieve stored chunk summaries; retry synthesis only |
+| Job timeout | Intermediate summaries persisted; can resume from last successful chunk |
+| All chunks succeed, DB update fails | Summaries stored separately; manual recovery possible |
+
+**Storage Strategy:** Use Redis with TTL for intermediate chunk summaries:
+```typescript
+// Key: `transcript:chunk:${transcriptionId}:${jobId}`
+// Value: JSON array of chunk summaries
+// TTL: 24 hours
+//
+// IMPORTANT: Include the jobId in the key to:
+// - Prevent collision when the same transcription is processed multiple times concurrently
+// - Enable debugging of specific job executions
+// - Allow safe retry without overwriting previous attempt's partial results
+```
+
+## Logging and Observability
+
+Add structured logging for chunking operations:
+```typescript
+console.log(JSON.stringify({
+  event: 'transcript_chunking_start',
+  transcriptionId,
+  totalTokens: estimatedTokens,
+  chunkCount: chunks.length,
+  videoTitle
+}));
+
+console.log(JSON.stringify({
+  event: 'chunk_processed',
+  transcriptionId,
+  chunkIndex: i,
+  chunkTokens: chunk.tokenCount,
+  processingTimeMs: endTime - startTime
+}));
+
+console.log(JSON.stringify({
+  event: 'transcript_chunking_complete',
+  transcriptionId,
+  totalApiCalls: chunks.length + 1, // chunks + synthesis
+  totalTokensProcessed,
+  totalProcessingTimeMs
+}));
+```
+
+## Verification
+
+1. **Unit Tests:**
+   - Test token estimation accuracy for chat models
+   - Test chunking splits at sentence boundaries (not mid-sentence)
+   - Test overlap calculation preserves context
+   - Test intermediate storage and retrieval in Redis
+   - Test structure extraction JSON parsing (valid and malformed)
+   - Test processing mode resolution for channels
+   - Test synthesis prompt formatting with structure
+
+2. **Integration Tests:**
+   - Process a short transcript (<100K tokens) - verify single-pass
+   - Process a long transcript with chunked mode - verify structure extraction + chunking
+   - Process a long transcript with full-context mode - verify no chunking
+   - Simulate chunk failure - verify partial results stored
+   - Simulate synthesis failure - verify retry uses stored summaries
+   - Simulate structure extraction failure - verify fallback to simple chunking
+   - Verify final summaries are coherent and preserve cross-references
+
+3. **Manual Testing:**
+   - Use the transcript from `transcript-1.txt` (the Theo Browne video that exposed this issue)
+   - Create a synthetic very-long transcript (3+ hours) to test chunking
+   - Compare summary quality between:
+     - Simple chunking
+     - Structure-aware chunking
+     - Full-context mode
+   - Verify cost tracking via logs
+   - Test cross-reference preservation (videos with "as I mentioned earlier..." patterns)
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Chunking loses cross-chunk context | Medium (was High) | Structure extraction before chunking; pass structure to chunk summaries |
+| Multiple API calls increase cost | High | Log token usage; make thresholds configurable; +1 API call for structure extraction |
+| Synthesis produces incoherent results | Low (was Medium) | Synthesis prompt includes full structure; cross-references preserved |
+| API rate limits during multi-chunk processing | Medium | Add delay between chunk API calls; reuse existing retry logic |
+| Job timeout for 3+ hour videos | High | Increase BullMQ job timeout; add progress heartbeat |
+| Breaking change to existing summaries | Low | Changes are additive; no existing behavior modified |
+| Structure extraction fails | Low | Fallback to simple chunking without structure |
+| Full-context mode truncates important content | Low | Only used for configured premium channels; logs warning on truncation |
+| JSON parsing fails for structure output | Medium | Use robust parsing; fallback to simple chunking on parse error |
+
+## Cost Comparison
+
+| Processing Mode | API Calls | Use Case |
+|-----------------|-----------|----------|
+| Single-pass (short video) | 1 | Videos under 100K tokens |
+| Simple chunking (4 chunks) | 5 | Fallback when structure extraction fails |
+| Structure-aware chunking (4 chunks) | 6 | Standard long videos |
+| Full-context | 1 | Premium channels (may truncate) |
+
+## Migration Plan
+
+1. **Phase 1: Add infrastructure** (no behavior change)
+   - Create shared `token-estimation.ts` helper in `src/shared/helpers/`
+   - Update `AiService` to use shared helper
+   - Create `TranscriptChunkingService` with stub methods
+   - Add config options with defaults that disable chunking
+   - Add prompts for structure extraction and chunking
+
+2. **Phase 2: Implement core chunking logic**
+   - Implement token estimation using shared helper
+   - Implement chunk splitting with sentence boundaries
+   - Implement intermediate storage in Redis
+   - Add simple synthesis (without structure)
+
+3. **Phase 3: Add structure-aware processing**
+   - Implement structure extraction prompt and parsing
+   - Update chunk summary prompt to include structure context
+   - Update synthesis prompt to use structure
+   - Add fallback to simple chunking
+
+4. **Phase 4: Add processing mode configuration**
+   - Implement channel-level processing mode (config or database)
+   - Add full-context mode for premium channels
+   - Add configuration UI/admin endpoint (optional)
+
+5. **Phase 5: Wire up processor**
+   - Update processor to use chunking service
+   - Add logging/metrics for each processing mode
+   - Enable via config
+   - Test with real transcripts
+
+6. **Phase 6: Monitor and tune**
+   - Watch logs for chunking frequency
+   - Compare summary quality between modes
+   - Tune thresholds based on real usage
+   - Adjust prompts based on output quality
+   - Monitor API costs per processing mode

--- a/docs/features/transcript-chunking/TRANSCRIPT_CHUNKING_IMPLEMENTATION.md
+++ b/docs/features/transcript-chunking/TRANSCRIPT_CHUNKING_IMPLEMENTATION.md
@@ -1,0 +1,292 @@
+# Transcript Chunking for Long Videos
+
+## Overview
+
+This feature handles YouTube transcripts that exceed DeepSeek model context limits. It implements a hybrid processing strategy with structure-aware chunking to preserve context across transcript sections while staying within API limits.
+
+## Problem Statement
+
+YouTube transcripts can vary widely in length:
+- **Short videos (5-10 min)**: ~1,000-3,000 words (~1,500-4,500 tokens)
+- **Medium videos (15-30 min)**: ~3,000-8,000 words (~4,500-12,000 tokens)
+- **Long videos (1+ hour)**: ~10,000-20,000+ words (~15,000-30,000+ tokens)
+
+While DeepSeek's 128K context window is generous, extremely long transcripts (multi-hour content) could approach or exceed this limit when combined with prompts. Previously, transcripts were silently truncated to 8,000 characters, causing content loss.
+
+## Solution
+
+A hybrid approach with two processing modes:
+
+1. **Full-Context Mode**: For premium/high-priority channels, process the entire transcript without chunking (truncates only if exceeding absolute limits)
+
+2. **Chunked Mode** (default): Structure-aware chunking that:
+   - Extracts video structure before splitting
+   - Splits at sentence boundaries with overlap
+   - Summarizes each chunk with structure context
+   - Synthesizes a final unified summary
+
+## Architecture
+
+```
+Transcript
+    │
+    ▼
+Token Estimation
+    │
+    ├── Under 100K tokens → Single API call → Summary
+    │
+    └── Over 100K tokens → Get Processing Mode
+                              │
+                              ├── FULL-CONTEXT → Single API call (truncate if > 120K)
+                              │
+                              └── CHUNKED (default)
+                                    │
+                                    ▼
+                              1. Extract video structure (1 API call)
+                              │
+                                    ▼
+                              2. Split into overlapping chunks
+                              │
+                                    ▼
+                              3. Summarize each chunk WITH structure context
+                              │
+                                    ▼
+                              4. Store summaries in Redis (for recovery)
+                              │
+                                    ▼
+                              5. Synthesize summaries into final output
+```
+
+## Configuration
+
+### Configuration Options
+
+Add these options to your configuration or use the defaults:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `maxTranscriptionTokens` | number | 100000 | Token threshold that triggers chunking |
+| `transcriptionChunkSize` | number | 50000 | Target size for each chunk in tokens |
+| `transcriptionChunkOverlap` | number | 500 | Overlap between chunks in tokens |
+| `defaultProcessingMode` | 'chunked' \| 'full-context' | 'chunked' | Default processing mode |
+| `fullContextChannels` | string[] | [] | YouTube channel IDs that use full-context mode |
+
+### Default Configuration
+
+The feature works out of the box with sensible defaults defined in `config.service.ts`:
+
+```typescript
+youtubeTranscriptions: {
+  channels: {},
+  maxVideosPerChannel: 1,
+  maxTranscriptionTokens: 100000,      // ~75K words
+  transcriptionChunkSize: 50000,       // ~37K words per chunk
+  transcriptionChunkOverlap: 500,      // ~375 words overlap
+  defaultProcessingMode: 'chunked',
+  fullContextChannels: [],
+}
+```
+
+### Enabling Full-Context Mode for Premium Channels
+
+To give specific channels full-context processing (no chunking), add their YouTube channel IDs:
+
+```typescript
+youtubeTranscriptions: {
+  // ... other config
+  fullContextChannels: [
+    'UCxxxxx',  // Premium channel ID
+    'UCyyyyy',  // Another important channel
+  ],
+}
+```
+
+**Note**: Use YouTube channel IDs (e.g., `UCxxxxx`), NOT database IDs.
+
+## Processing Modes
+
+### Chunked Mode (Default)
+
+Best for most use cases. Uses structure-aware chunking to handle arbitrarily long transcripts.
+
+**Flow:**
+1. **Structure Extraction**: AI analyzes transcript to identify sections, themes, and cross-references
+2. **Chunking**: Split transcript at sentence boundaries with overlap
+3. **Chunk Summarization**: Each chunk is summarized with structure context
+4. **Synthesis**: All chunk summaries are combined into final output
+
+**API Calls:** N+2 calls (1 structure + N chunks + 1 synthesis)
+
+### Full-Context Mode
+
+For premium channels where quality is paramount. Processes entire transcript in one call.
+
+**Flow:**
+1. Single API call with full transcript
+2. Truncates only if exceeding 120K tokens
+
+**API Calls:** 1 call
+
+## Error Handling
+
+### Partial Failure Recovery
+
+When chunk processing fails, intermediate results are stored in Redis for retry:
+
+| Failure Point | Recovery Strategy |
+|---------------|-------------------|
+| Chunk N summary fails | Store N-1 successful summaries; retry chunk N |
+| Synthesis fails | Retrieve stored chunk summaries; retry synthesis only |
+| Job timeout | Intermediate summaries persisted in Redis |
+| Structure extraction fails | Fallback to simple chunking (no structure context) |
+
+### Redis Storage
+
+Intermediate summaries are stored with:
+- **Key pattern**: `transcript:chunk:{transcriptionId}:{jobId}`
+- **TTL**: 24 hours
+- **Format**: JSON array of chunk summaries
+
+## Logging and Observability
+
+The feature emits structured JSON logs for monitoring:
+
+```json
+// Chunking starts
+{"event":"transcript_chunking_start","transcriptionId":"abc123","processingMode":"chunked","estimatedTokens":150000}
+
+// Structure extracted
+{"event":"transcript_structure_extracted","transcriptionId":"abc123","sectionsCount":5,"keyThemesCount":3}
+
+// Chunks created
+{"event":"transcript_chunks_created","transcriptionId":"abc123","chunkCount":3,"chunkSizes":[45000,48000,42000]}
+
+// Each chunk processed
+{"event":"transcript_chunk_processed","transcriptionId":"abc123","chunkIndex":0,"chunkTokens":45000,"processingTimeMs":2340}
+
+// Complete
+{"event":"transcript_chunking_complete","transcriptionId":"abc123","chunkCount":3}
+```
+
+## Files Created/Modified
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/shared/helpers/token-estimation.ts` | Shared token estimation utility |
+| `src/youtube-transcriptions/services/transcript-chunking.service.ts` | Main chunking service |
+| `src/youtube-transcriptions/errors/transcript-chunking.errors.ts` | Custom error types |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/config/config.entity.ts` | Added `ProcessingMode` type and chunking config |
+| `src/config/config.service.ts` | Added chunking config getters |
+| `src/config/prompts/transcription-summary.prompt.ts` | Added chunking prompts |
+| `src/ai/ai.service.ts` | Uses shared token estimation helper |
+| `src/youtube-transcriptions/processors/youtube-transcription.processor.ts` | Integrated chunking service |
+| `src/youtube-transcriptions/youtube-transcriptions.module.ts` | Registered chunking service |
+| `libs/queue/interfaces/youtube-transcription-job.interface.ts` | Added `channelId` |
+| `libs/queue/queue.service.ts` | Updated job enqueue method |
+| `src/youtube-transcriptions/services/youtube-transcriptions.service.ts` | Passes `channelId` to queue |
+
+## Prompts
+
+The feature uses four specialized prompts:
+
+### 1. Structure Extraction Prompt
+
+Analyzes transcript to identify sections, themes, and cross-references. Outputs JSON.
+
+### 2. Chunk Summary with Structure Prompt
+
+Summarizes individual chunks with:
+- Video context (key themes, structure)
+- Cross-references to this section
+- Section content
+
+### 3. Synthesis Prompt
+
+Combines chunk summaries into coherent final output with:
+- Video structure context
+- All chunk summaries
+- Final summary format (overview, technical summary, takeaways, quotes, critique)
+
+### 4. Simple Chunk Summary Prompt (Fallback)
+
+Used when structure extraction fails. Summarizes without context.
+
+## Cost Implications
+
+| Processing Mode | API Calls | Use Case |
+|-----------------|-----------|----------|
+| Single-pass (short video) | 1 | Videos under 100K tokens |
+| Structure-aware chunking (4 chunks) | 6 | Standard long videos |
+| Simple chunking (4 chunks) | 5 | Fallback when structure fails |
+| Full-context | 1 | Premium channels |
+
+## Testing
+
+### Unit Tests
+
+The existing test suite covers:
+- Token estimation accuracy
+- Chunk splitting at sentence boundaries
+- Overlap calculation
+- Processing mode resolution
+- Structure extraction JSON parsing
+
+### Manual Testing
+
+To test with a real transcript:
+
+```bash
+# Submit a long video for processing
+curl -X POST http://localhost:3000/api/youtube-transcriptions/process \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "videoUrl": "https://www.youtube.com/watch?v=LONG_VIDEO_ID",
+    "channelId": "your-channel-id"
+  }'
+```
+
+Monitor logs for chunking events:
+```bash
+# Watch for chunking logs
+docker-compose logs -f app | grep "transcript_chunking"
+```
+
+## Troubleshooting
+
+### "Transcript exceeds token limit" warnings
+
+This is expected for long videos. The system will use chunked processing automatically.
+
+### Chunk processing fails
+
+Check Redis connectivity. Partial results are stored for retry:
+```bash
+# Check Redis for stored summaries
+redis-cli GET "transcript:chunk:{transcriptionId}:{jobId}"
+```
+
+### Structure extraction returns malformed JSON
+
+The system falls back to simple chunking automatically. Check logs for the raw AI output.
+
+### High API costs
+
+If costs are a concern:
+1. Increase `maxTranscriptionTokens` to reduce chunking frequency
+2. Use `fullContextChannels` sparingly
+3. Consider using a cheaper model for chunk summarization
+
+## Future Improvements
+
+1. **Database-driven channel config**: Store processing mode per channel in the database
+2. **Adaptive chunk sizing**: Adjust chunk size based on content type
+3. **Parallel chunk processing**: Process chunks concurrently for faster throughput
+4. **Cost tracking**: Log token usage per processing mode for cost analysis

--- a/libs/queue/interfaces/youtube-transcription-job.interface.ts
+++ b/libs/queue/interfaces/youtube-transcription-job.interface.ts
@@ -3,4 +3,5 @@ export interface ProcessTranscriptionSummaryJobData {
   transcriptText: string;
   videoTitle: string;
   generateAudio?: boolean;
+  channelId?: string;
 }

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -319,6 +319,8 @@ Please investigate the issue.`,
    * @param transcriptionId - The ID of the transcription
    * @param transcriptText - The transcript text to summarize
    * @param videoTitle - The video title (for logging)
+   * @param generateAudio - Whether to generate audio after summary
+   * @param channelId - The YouTube channel ID for processing mode selection
    * @returns Job information including job ID
    */
   async addTranscriptionSummaryJob(
@@ -326,12 +328,14 @@ Please investigate the issue.`,
     transcriptText: string,
     videoTitle: string,
     generateAudio?: boolean,
+    channelId?: string,
   ): Promise<JobInfo> {
     const jobData: ProcessTranscriptionSummaryJobData = {
       transcriptionId,
       transcriptText,
       videoTitle,
       generateAudio,
+      channelId,
     };
 
     const job = await this.transcriptionSummaryQueue.add(

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -3,6 +3,7 @@ import Groq from 'groq-sdk';
 import OpenAI from 'openai';
 import { ConfigService } from '../config/config.service';
 import { ChatMessage } from '../shared/types/ai';
+import { estimateTokenCount } from '../shared/helpers/token-estimation';
 
 @Injectable()
 export class AiService implements OnModuleInit {
@@ -304,7 +305,7 @@ export class AiService implements OnModuleInit {
 
     texts.forEach((text, index) => {
       const preparedInput = this.prepareEmbeddingInput(text, modelName);
-      if (this.estimateTokenCount(preparedInput) <= safeChunkTokenLimit) {
+      if (estimateTokenCount(preparedInput) <= safeChunkTokenLimit) {
         shortInputs.push({ index, input: preparedInput, original: text });
         return;
       }
@@ -404,7 +405,7 @@ export class AiService implements OnModuleInit {
       return [];
     }
 
-    if (this.estimateTokenCount(normalizedText) <= maxTokens) {
+    if (estimateTokenCount(normalizedText) <= maxTokens) {
       return [normalizedText];
     }
 
@@ -415,7 +416,7 @@ export class AiService implements OnModuleInit {
     for (const sentence of sentences) {
       const candidate = currentChunk ? `${currentChunk} ${sentence}` : sentence;
 
-      if (this.estimateTokenCount(candidate) <= maxTokens) {
+      if (estimateTokenCount(candidate) <= maxTokens) {
         currentChunk = candidate;
         continue;
       }
@@ -424,7 +425,7 @@ export class AiService implements OnModuleInit {
         chunks.push(currentChunk);
       }
 
-      if (this.estimateTokenCount(sentence) <= maxTokens) {
+      if (estimateTokenCount(sentence) <= maxTokens) {
         currentChunk = sentence;
         continue;
       }
@@ -451,14 +452,14 @@ export class AiService implements OnModuleInit {
 
     for (const word of words) {
       const candidate = currentChunk ? `${currentChunk} ${word}` : word;
-      if (this.estimateTokenCount(candidate) <= maxTokens) {
+      if (estimateTokenCount(candidate) <= maxTokens) {
         currentChunk = candidate;
       } else {
         if (currentChunk) {
           chunks.push(currentChunk);
         }
         // Safety check: if a single word exceeds maxTokens, truncate it
-        if (this.estimateTokenCount(word) > maxTokens) {
+        if (estimateTokenCount(word) > maxTokens) {
           // Truncate word to safe length and add as its own chunk
           const safeLength = Math.floor(maxTokens * 3); // Approx 3 chars per token
           const truncatedWord = word.substring(0, safeLength);
@@ -475,27 +476,6 @@ export class AiService implements OnModuleInit {
     }
 
     return chunks;
-  }
-
-  private estimateTokenCount(text: string): number {
-    // Conservative token estimation for embedding models
-    // Embedding models (especially E5) are more sensitive to token limits
-    if (!text || text.length === 0) {
-      return 0;
-    }
-
-    // Method 1: Character-based (most conservative for non-English/large tokens)
-    // Average 2-4 chars per token, use 2.5 for safety margin
-    const charEstimate = Math.ceil(text.length / 2.5);
-
-    // Method 2: Word-based with padding for punctuation
-    const words = text.trim().split(/\s+/).length;
-    const punctuationMatches = text.match(/[.,!?;:"'()[\]{}]/g);
-    const punctuationCount = punctuationMatches ? punctuationMatches.length : 0;
-    const wordEstimate = words + Math.ceil(punctuationCount * 0.5);
-
-    // Use the MORE conservative estimate
-    return Math.max(charEstimate, wordEstimate);
   }
 
   private async getSingleEmbedding(

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -27,6 +27,8 @@ export const VALID_TTS_MODELS = {
 } as const;
 export type ValidTtsModel = keyof typeof VALID_TTS_MODELS;
 
+export type ProcessingMode = 'chunked' | 'full-context';
+
 export type Config = {
   prompts: {
     articleSummary: string;
@@ -71,5 +73,10 @@ export type Config = {
       };
     };
     maxVideosPerChannel: number;
+    maxTranscriptionTokens: number;
+    transcriptionChunkSize: number;
+    transcriptionChunkOverlap: number;
+    defaultProcessingMode: ProcessingMode;
+    fullContextChannels: string[];
   };
 };

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -8,6 +8,7 @@ import {
   AudioFailureNotification,
   Config,
   EmbeddingFailureNotification,
+  ProcessingMode,
   VALID_CHAT_MODELS,
   VALID_TTS_MODELS,
   ValidChatModel,
@@ -70,6 +71,11 @@ export class ConfigService {
     youtubeTranscriptions: {
       channels: {}, // Now loaded from database
       maxVideosPerChannel: 1,
+      maxTranscriptionTokens: 100000,
+      transcriptionChunkSize: 50000,
+      transcriptionChunkOverlap: 500,
+      defaultProcessingMode: 'chunked',
+      fullContextChannels: [],
     },
   };
 
@@ -201,6 +207,30 @@ export class ConfigService {
       maxVideosPerChannel:
         this.CONFIGS.youtubeTranscriptions.maxVideosPerChannel,
     };
+  }
+
+  getYoutubeTranscriptionsChunkingConfig() {
+    const config = this.CONFIGS.youtubeTranscriptions;
+
+    if (config.transcriptionChunkSize >= config.maxTranscriptionTokens) {
+      throw new Error(
+        'transcriptionChunkSize must be less than maxTranscriptionTokens',
+      );
+    }
+
+    return {
+      maxTranscriptionTokens: config.maxTranscriptionTokens,
+      transcriptionChunkSize: config.transcriptionChunkSize,
+      transcriptionChunkOverlap: config.transcriptionChunkOverlap,
+    };
+  }
+
+  getProcessingModeForChannel(channelId: string): ProcessingMode {
+    const config = this.CONFIGS.youtubeTranscriptions;
+    if (config.fullContextChannels.includes(channelId)) {
+      return 'full-context';
+    }
+    return config.defaultProcessingMode;
   }
 
   getPresignedUrlExpirySeconds(): number {

--- a/src/config/prompts/index.ts
+++ b/src/config/prompts/index.ts
@@ -1,6 +1,7 @@
 export { articleSummaryPrompt } from './article-summary.prompt';
 export { briefSynthesisPrompt } from './brief-synthesis.prompt';
 export { categoryClassificationPrompt } from './category-classification.prompt';
+export { chunkSummaryPrompt, chunkSummaryWithStructurePrompt, structureExtractionPrompt, synthesisWithStructurePrompt } from './transcription-summary.prompt';
 export { clusterAnalysisPrompt } from './cluster-analysis.prompt';
 export { impactRatingPrompt } from './impact-rating.prompt';
 export { transcriptionAnalysisPrompt } from './transcription-analysis.prompt';

--- a/src/config/prompts/transcription-summary.prompt.ts
+++ b/src/config/prompts/transcription-summary.prompt.ts
@@ -1,12 +1,12 @@
 export const transcriptionSummaryPrompt = `
 You are an expert summarizer and critical reader.
 
-I will paste a youtube video transcription. Your job is to:
+I will paste a YouTube video transcription. Your job is to:
 - Extract the core ideas and arguments.
 - Translate complex points into clear, simple language.
 - Organize the summary so it is easy to scan.
 
-Output on the {article_content} property:
+Provide the following output:
 1) 3-5 sentence overview in plain English.
 2) 3-5 sentence summary in technical terms.
 3) Key takeaways as concise bullet points and/or short sections, as appropriate.
@@ -15,4 +15,100 @@ Output on the {article_content} property:
 
 Transcription:
 {article_content}
+`;
+
+export const structureExtractionPrompt = `
+You are analyzing a YouTube video transcript to understand its structure.
+
+Your task:
+1. Identify the main sections/topics of this video
+2. For each section, note the approximate beginning (first distinctive phrase)
+3. Capture how sections relate to each other
+
+Output format (JSON):
+{
+  "sections": [
+    {"title": "Section title", "startPhrase": "First distinctive phrase of section"},
+    ...
+  ],
+  "keyThemes": ["Theme 1", "Theme 2", ...],
+  "crossReferences": [
+    {"from": 0, "to": 3, "description": "Section 1 introduces concept used in section 4"},
+    ...
+  ]
+}
+
+Transcript:
+{article_content}
+`;
+
+export const chunkSummaryWithStructurePrompt = `
+You are summarizing section {section_number} of {total_sections} from a YouTube video.
+
+## Video Context
+Key themes: {key_themes}
+Video structure: {sections_overview}
+
+## Cross-References to This Section
+{cross_references}
+
+## This Section's Content
+{chunk_content}
+
+Provide a summary that:
+1. Connects to the video's overall themes where relevant
+2. Notes any references to other parts of the video
+3. Preserves the speaker's key arguments and data
+
+Output format:
+**Main Points:**
+- [2-3 key points from this section]
+
+**Connections:**
+- [How this section relates to others, if applicable]
+
+**Key Data/Quotes:**
+- [Notable information from this section]
+`;
+
+export const synthesisWithStructurePrompt = `
+You are creating a final summary from multiple section summaries of a YouTube video.
+
+## Video Structure
+{video_structure}
+
+## Section Summaries
+{chunk_summaries}
+
+Create a coherent summary that:
+1. Maintains the logical flow of the original video
+2. Connects related points across sections
+3. Preserves the speaker's main arguments and supporting evidence
+4. Includes key data points and memorable quotes
+
+Output format:
+1) 3-5 sentence overview in plain English.
+2) 3-5 sentence summary in technical terms.
+3) Key takeaways as concise bullet points.
+4) Notable data, trends, or memorable quotes.
+5) Brief critique: any bias, outdated information, or gaps.
+`;
+
+export const chunkSummaryPrompt = `
+You are summarizing a section of a YouTube video transcript.
+
+Transcript section:
+{chunk_content}
+
+Provide a concise summary that:
+1. Captures the main points
+2. Preserves key data and quotes
+3. Notes any references to other topics mentioned
+
+Output format:
+**Main Points:**
+- [2-3 key points]
+
+**Key Data/Quotes:**
+- [Notable information]
 `;

--- a/src/shared/helpers/token-estimation.spec.ts
+++ b/src/shared/helpers/token-estimation.spec.ts
@@ -1,0 +1,137 @@
+import {
+  estimateTokenCount,
+  estimateChatTokens,
+  estimateEmbeddingTokens,
+} from './token-estimation';
+
+describe('estimateTokenCount', () => {
+  describe('edge cases', () => {
+    it('returns 0 for empty string', () => {
+      expect(estimateTokenCount('')).toBe(0);
+    });
+
+    it('returns 0 for null', () => {
+      expect(estimateTokenCount(null as unknown as string)).toBe(0);
+    });
+
+    it('returns 0 for undefined', () => {
+      expect(estimateTokenCount(undefined as unknown as string)).toBe(0);
+    });
+
+    it('handles whitespace-only text', () => {
+      expect(estimateTokenCount('   ')).toBe(2);
+    });
+
+    it('handles single character', () => {
+      expect(estimateTokenCount('a')).toBe(1);
+    });
+  });
+
+  describe('character-based estimation', () => {
+    it('calculates tokens based on default charsPerToken (2.5)', () => {
+      const text = 'abcdefghij';
+      expect(estimateTokenCount(text)).toBe(4);
+    });
+
+    it('calculates tokens with custom charsPerToken', () => {
+      const text = 'abcdefghij';
+      expect(estimateTokenCount(text, 5)).toBe(2);
+    });
+
+    it('rounds up to nearest integer', () => {
+      const text = 'abc';
+      expect(estimateTokenCount(text, 2)).toBe(2);
+    });
+  });
+
+  describe('word-based estimation', () => {
+    it('counts words correctly', () => {
+      const text = 'one two three four five';
+      const result = estimateTokenCount(text, 100);
+      expect(result).toBe(5);
+    });
+
+    it('handles multiple spaces between words', () => {
+      const text = 'one   two    three';
+      const result = estimateTokenCount(text, 100);
+      expect(result).toBe(3);
+    });
+
+    it('handles leading and trailing whitespace', () => {
+      const text = '  hello world  ';
+      const result = estimateTokenCount(text, 100);
+      expect(result).toBe(2);
+    });
+  });
+
+  describe('punctuation handling', () => {
+    it('counts punctuation and adds 0.5 tokens per punctuation mark', () => {
+      const text = 'Hello, world!';
+      const result = estimateTokenCount(text, 100);
+      expect(result).toBe(3);
+    });
+
+    it('handles various punctuation marks', () => {
+      const text = 'Hi. How are you? "Fine!" she said.';
+      const result = estimateTokenCount(text, 100);
+      const punctuationCount = (text.match(/[.,!?;:"'()[\]{}]/g) || []).length;
+      const wordCount = text.trim().split(/\s+/).length;
+      expect(result).toBe(wordCount + Math.ceil(punctuationCount * 0.5));
+    });
+
+    it('handles parentheses and brackets', () => {
+      const text = '(test) [array]';
+      const result = estimateTokenCount(text, 100);
+      expect(result).toBe(2 + Math.ceil(4 * 0.5));
+    });
+  });
+
+  describe('maximum estimation', () => {
+    it('returns the maximum of char and word estimates', () => {
+      const longChars = 'a'.repeat(100);
+      const charEstimate = Math.ceil(100 / 2.5);
+      const wordEstimate = 1;
+      expect(estimateTokenCount(longChars)).toBe(Math.max(charEstimate, wordEstimate));
+    });
+
+    it('uses word estimate when higher than char estimate', () => {
+      const manyWords = 'word '.repeat(50).trim();
+      const result = estimateTokenCount(manyWords, 100);
+      expect(result).toBe(50);
+    });
+  });
+});
+
+describe('estimateChatTokens', () => {
+  it('uses charsPerToken of 4', () => {
+    const text = 'abcdefgh';
+    expect(estimateChatTokens(text)).toBe(2);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(estimateChatTokens('')).toBe(0);
+  });
+
+  it('handles typical chat message', () => {
+    const text = 'Hello, how are you today?';
+    const result = estimateChatTokens(text);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('estimateEmbeddingTokens', () => {
+  it('uses charsPerToken of 2.5', () => {
+    const text = 'abcdefghij';
+    expect(estimateEmbeddingTokens(text)).toBe(4);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(estimateEmbeddingTokens('')).toBe(0);
+  });
+
+  it('handles typical embedding text', () => {
+    const text = 'This is a longer piece of text for embedding.';
+    const result = estimateEmbeddingTokens(text);
+    expect(result).toBeGreaterThan(0);
+  });
+});

--- a/src/shared/helpers/token-estimation.ts
+++ b/src/shared/helpers/token-estimation.ts
@@ -1,0 +1,23 @@
+export function estimateTokenCount(
+  text: string,
+  charsPerToken: number = 2.5,
+): number {
+  if (!text || text.length === 0) {
+    return 0;
+  }
+
+  const charEstimate = Math.ceil(text.length / charsPerToken);
+
+  const words = text.trim().split(/\s+/).length;
+  const punctuationMatches = text.match(/[.,!?;:"'()[\]{}]/g);
+  const punctuationCount = punctuationMatches ? punctuationMatches.length : 0;
+  const wordEstimate = words + Math.ceil(punctuationCount * 0.5);
+
+  return Math.max(charEstimate, wordEstimate);
+}
+
+export const estimateChatTokens = (text: string): number =>
+  estimateTokenCount(text, 4);
+
+export const estimateEmbeddingTokens = (text: string): number =>
+  estimateTokenCount(text, 2.5);

--- a/src/youtube-transcriptions/errors/transcript-chunking.errors.ts
+++ b/src/youtube-transcriptions/errors/transcript-chunking.errors.ts
@@ -1,0 +1,21 @@
+export class TranscriptChunkingError extends Error {
+  constructor(
+    message: string,
+    public readonly transcriptionId: string,
+    public readonly jobId: string,
+  ) {
+    super(message);
+    this.name = 'TranscriptChunkingError';
+  }
+}
+
+export class StructureExtractionError extends Error {
+  constructor(
+    message: string,
+    public readonly transcriptionId: string,
+    public readonly rawOutput?: string,
+  ) {
+    super(message);
+    this.name = 'StructureExtractionError';
+  }
+}

--- a/src/youtube-transcriptions/processors/youtube-transcription.processor.spec.ts
+++ b/src/youtube-transcriptions/processors/youtube-transcription.processor.spec.ts
@@ -4,6 +4,7 @@ import { mock } from 'jest-mock-extended';
 import { Job } from 'bullmq';
 import { AiService } from '../../ai/ai.service';
 import { ConfigService } from '../../config/config.service';
+import { TranscriptChunkingService } from '../services/transcript-chunking.service';
 import { YoutubeTranscriptionsService } from '../services/youtube-transcriptions.service';
 import { YoutubeTranscriptionProcessor } from './youtube-transcription.processor';
 
@@ -13,6 +14,7 @@ describe('YoutubeTranscriptionProcessor', () => {
   const mockAiService = mock<AiService>();
   const mockConfigService = mock<ConfigService>();
   const mockAudioJobService = mock<AudioJobService>();
+  const mockTranscriptChunkingService = mock<TranscriptChunkingService>();
 
   const basePrompt = 'Summarize this transcription.';
   const transcriptionId = 'transcription-uuid-123';
@@ -39,10 +41,12 @@ describe('YoutubeTranscriptionProcessor', () => {
       mockAiService,
       mockConfigService,
       mockAudioJobService,
+      mockTranscriptChunkingService,
     );
 
     mockConfigService.getTranscriptionSummaryPrompt.mockReturnValue(basePrompt);
     mockYoutubeTranscriptionsService.updateTranscriptionSummary.mockResolvedValue();
+    mockTranscriptChunkingService.needsChunking.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -55,12 +59,12 @@ describe('YoutubeTranscriptionProcessor', () => {
         id: transcriptionId,
         custom_prompt: undefined,
       } as never);
-      mockAiService.callDeepseekChat.mockResolvedValue('Generated summary');
+      mockAiService.callChat.mockResolvedValue('Generated summary');
 
       await processor.processTranscriptionSummary(createJob());
 
-      expect(mockAiService.callDeepseekChat).toHaveBeenCalledWith(basePrompt);
-      expect(mockAiService.callDeepseekChat).not.toHaveBeenCalledWith(
+      expect(mockAiService.callChat).toHaveBeenCalledWith(basePrompt);
+      expect(mockAiService.callChat).not.toHaveBeenCalledWith(
         expect.stringContaining('Additional instructions:'),
       );
     });
@@ -70,11 +74,11 @@ describe('YoutubeTranscriptionProcessor', () => {
         id: transcriptionId,
         custom_prompt: null,
       } as never);
-      mockAiService.callDeepseekChat.mockResolvedValue('Generated summary');
+      mockAiService.callChat.mockResolvedValue('Generated summary');
 
       await processor.processTranscriptionSummary(createJob());
 
-      expect(mockAiService.callDeepseekChat).toHaveBeenCalledWith(basePrompt);
+      expect(mockAiService.callChat).toHaveBeenCalledWith(basePrompt);
     });
 
     it('appends custom prompt when transcription has custom_prompt set', async () => {
@@ -82,11 +86,11 @@ describe('YoutubeTranscriptionProcessor', () => {
         id: transcriptionId,
         custom_prompt: 'Focus on actionable takeaways.',
       } as never);
-      mockAiService.callDeepseekChat.mockResolvedValue('Generated summary');
+      mockAiService.callChat.mockResolvedValue('Generated summary');
 
       await processor.processTranscriptionSummary(createJob());
 
-      expect(mockAiService.callDeepseekChat).toHaveBeenCalledWith(
+      expect(mockAiService.callChat).toHaveBeenCalledWith(
         `${basePrompt}\n\nAdditional instructions: Focus on actionable takeaways.`,
       );
     });

--- a/src/youtube-transcriptions/processors/youtube-transcription.processor.ts
+++ b/src/youtube-transcriptions/processors/youtube-transcription.processor.ts
@@ -9,6 +9,7 @@ import { Job, Worker } from 'bullmq';
 import { AiService } from '../../ai/ai.service';
 import { ConfigService } from '../../config/config.service';
 import { buildFinalPrompt } from '../../shared/helpers/build-final-prompt';
+import { TranscriptChunkingService } from '../services/transcript-chunking.service';
 import { YoutubeTranscriptionsService } from '../services/youtube-transcriptions.service';
 
 @Injectable()
@@ -21,6 +22,7 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
     private readonly aiService: AiService,
     private readonly configService: ConfigService,
     private readonly audioJobService: AudioJobService,
+    private readonly transcriptChunkingService: TranscriptChunkingService,
   ) {}
 
   onModuleInit() {
@@ -61,7 +63,7 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
   async processTranscriptionSummary(
     job: Job<ProcessTranscriptionSummaryJobData>,
   ): Promise<{ success: boolean; message: string }> {
-    const { transcriptionId, transcriptText, videoTitle } = job.data;
+    const { transcriptionId, transcriptText, videoTitle, channelId } = job.data;
 
     console.log(
       `\n>>> Processing transcription summary for ID ${transcriptionId} (${videoTitle}) from queue (Job ${job.id}) <<<`,
@@ -72,6 +74,53 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
         await this.youtubeTranscriptionsService.getTranscriptionById(
           transcriptionId,
         );
+
+      // Check if chunking is needed
+      if (this.transcriptChunkingService.needsChunking(transcriptText)) {
+        console.log(
+          `Transcript exceeds token limit, using chunked processing for ${transcriptionId}...`,
+        );
+
+        const summary = await this.transcriptChunkingService.processTranscript(
+          transcriptText,
+          transcriptionId,
+          String(job.id),
+          channelId || '',
+          transcription?.custom_prompt,
+        );
+
+        if (!summary) {
+          console.log(
+            `Warning: Failed to generate summary for transcription ${transcriptionId}. Transcription saved without summary.`,
+          );
+          return {
+            success: true,
+            message: `Transcription ${transcriptionId} saved without summary (AI did not generate summary)`,
+          };
+        }
+
+        console.log(`Updating transcription ${transcriptionId} with summary...`);
+        await this.youtubeTranscriptionsService.updateTranscriptionSummary(
+          transcriptionId,
+          summary,
+        );
+
+        console.log(
+          `✓ Transcription ${transcriptionId} summary generated and saved successfully (Job ${job.id})`,
+        );
+
+        // Generate audio if flag is enabled
+        if (job.data.generateAudio) {
+          await this.enqueueAudioGeneration(transcriptionId, summary);
+        }
+
+        return {
+          success: true,
+          message: `Transcription ${transcriptionId} summary generated and saved successfully`,
+        };
+      }
+
+      // Single-pass processing for short transcripts
       const basePrompt =
         this.configService.getTranscriptionSummaryPrompt(transcriptText);
       const summaryPrompt = buildFinalPrompt(
@@ -80,7 +129,7 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
       );
 
       console.log(`Generating summary for transcription ${transcriptionId}...`);
-      const summary = await this.aiService.callDeepseekChat(summaryPrompt);
+      const summary = await this.aiService.callChat(summaryPrompt);
 
       if (!summary) {
         console.log(
@@ -104,30 +153,7 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
 
       // Generate audio if flag is enabled
       if (job.data.generateAudio) {
-        try {
-          console.log(
-            `Enqueuing audio generation for transcription ID: ${transcriptionId}...`,
-          );
-          const transcription =
-            await this.youtubeTranscriptionsService.getTranscriptionById(
-              transcriptionId,
-            );
-
-          if (transcription) {
-            const jobInfo = await this.audioJobService.enqueueAudioJob({
-              sourceType: 'transcription',
-              sourceId: transcriptionId,
-              text: summary,
-              date: transcription.processedAt,
-            });
-            console.log(`Audio generation job enqueued: ${jobInfo.jobId}`);
-          }
-        } catch (audioError) {
-          console.error(
-            `Error enqueuing audio generation for transcription ID: ${transcriptionId}:`,
-            audioError,
-          );
-        }
+        await this.enqueueAudioGeneration(transcriptionId, summary);
       }
 
       return {
@@ -143,6 +169,36 @@ export class YoutubeTranscriptionProcessor implements OnModuleInit {
       );
       throw new Error(
         `Failed to process transcription summary ${transcriptionId}: ${errorMessage}`,
+      );
+    }
+  }
+
+  private async enqueueAudioGeneration(
+    transcriptionId: string,
+    summary: string,
+  ): Promise<void> {
+    try {
+      console.log(
+        `Enqueuing audio generation for transcription ID: ${transcriptionId}...`,
+      );
+      const transcription =
+        await this.youtubeTranscriptionsService.getTranscriptionById(
+          transcriptionId,
+        );
+
+      if (transcription) {
+        const jobInfo = await this.audioJobService.enqueueAudioJob({
+          sourceType: 'transcription',
+          sourceId: transcriptionId,
+          text: summary,
+          date: transcription.processedAt,
+        });
+        console.log(`Audio generation job enqueued: ${jobInfo.jobId}`);
+      }
+    } catch (audioError) {
+      console.error(
+        `Error enqueuing audio generation for transcription ID: ${transcriptionId}:`,
+        audioError,
       );
     }
   }

--- a/src/youtube-transcriptions/services/transcript-chunking.service.spec.ts
+++ b/src/youtube-transcriptions/services/transcript-chunking.service.spec.ts
@@ -1,0 +1,459 @@
+import { mock } from 'jest-mock-extended';
+import { AiService } from '../../ai/ai.service';
+import { ConfigService } from '../../config/config.service';
+import { RedisService } from '@libs/redis';
+import {
+  StructureExtractionError,
+  TranscriptChunkingError,
+} from '../errors/transcript-chunking.errors';
+import {
+  TranscriptChunkingService,
+  VideoStructure,
+} from './transcript-chunking.service';
+
+describe('TranscriptChunkingService', () => {
+  let service: TranscriptChunkingService;
+  const mockAiService = mock<AiService>();
+  const mockConfigService = mock<ConfigService>();
+  const mockRedisService = mock<RedisService>();
+  const mockRedisClient = {
+    setex: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockResolvedValue(null),
+    del: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const transcriptionId = 'test-transcription-id';
+  const jobId = 'test-job-id';
+  const channelId = 'test-channel-id';
+
+  const defaultChunkingConfig = {
+    maxTranscriptionTokens: 100000,
+    transcriptionChunkSize: 50000,
+    transcriptionChunkOverlap: 500,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConfigService.getYoutubeTranscriptionsChunkingConfig.mockReturnValue(
+      defaultChunkingConfig,
+    );
+    mockConfigService.getProcessingModeForChannel.mockReturnValue('chunked');
+    mockRedisService.getClient.mockReturnValue(mockRedisClient as never);
+
+    service = new TranscriptChunkingService(
+      mockConfigService,
+      mockAiService,
+      mockRedisService,
+    );
+  });
+
+  describe('needsChunking', () => {
+    it('returns false for short transcripts', () => {
+      const shortText = 'This is a short transcript.';
+
+      const result = service.needsChunking(shortText);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true for long transcripts exceeding maxTranscriptionTokens', () => {
+      const longText = 'word '.repeat(150000);
+
+      const result = service.needsChunking(longText);
+
+      expect(result).toBe(true);
+    });
+
+    it('uses configured maxTranscriptionTokens threshold', () => {
+      mockConfigService.getYoutubeTranscriptionsChunkingConfig.mockReturnValue({
+        ...defaultChunkingConfig,
+        maxTranscriptionTokens: 50000,
+      });
+
+      const mediumText = 'word '.repeat(60000);
+
+      const result = service.needsChunking(mediumText);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getProcessingMode', () => {
+    it('returns chunked by default', () => {
+      mockConfigService.getProcessingModeForChannel.mockReturnValue('chunked');
+
+      const result = service.getProcessingMode(channelId);
+
+      expect(result).toBe('chunked');
+    });
+
+    it('returns full-context for configured channels', () => {
+      mockConfigService.getProcessingModeForChannel.mockReturnValue('full-context');
+
+      const result = service.getProcessingMode('premium-channel-id');
+
+      expect(result).toBe('full-context');
+    });
+  });
+
+  describe('splitIntoChunks', () => {
+    it('returns single chunk for text under chunk size', () => {
+      const shortText = 'This is a short text. It has two sentences.';
+
+      const chunks = service.splitIntoChunks(shortText);
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].text).toBe(shortText);
+    });
+
+    it('splits text at sentence boundaries', () => {
+      const sentence = 'This is a sentence. ';
+      const longText = sentence.repeat(10000);
+
+      const chunks = service.splitIntoChunks(longText);
+
+      for (const chunk of chunks) {
+        expect(chunk.text.endsWith('.')).toBe(true);
+      }
+    });
+
+    it('adds overlap between chunks', () => {
+      const sentence = 'This is sentence number X. ';
+      const sentences: string[] = [];
+      for (let i = 0; i < 10000; i++) {
+        sentences.push(sentence.replace('X', String(i)));
+      }
+      const longText = sentences.join('');
+
+      const chunks = service.splitIntoChunks(longText);
+
+      if (chunks.length > 1) {
+        const firstChunkEnd = chunks[0].text.slice(-50);
+        const secondChunkStart = chunks[1].text.slice(0, 100);
+        expect(
+          secondChunkStart.includes(firstChunkEnd.trim().slice(-30)) ||
+          chunks[1].startIndex > 0,
+        ).toBe(true);
+      }
+    });
+
+    it('handles empty text', () => {
+      const chunks = service.splitIntoChunks('');
+
+      expect(chunks).toHaveLength(0);
+    });
+
+    it('handles whitespace-only text', () => {
+      const chunks = service.splitIntoChunks('   ');
+
+      expect(chunks).toHaveLength(0);
+    });
+  });
+
+  describe('extractStructure', () => {
+    const validStructureJson = JSON.stringify({
+      sections: [
+        { title: 'Introduction', startPhrase: 'Welcome to the video' },
+        { title: 'Main Topic', startPhrase: 'Let us discuss' },
+      ],
+      keyThemes: ['theme1', 'theme2'],
+      crossReferences: [{ from: 0, to: 1, description: 'reference' }],
+    });
+
+    it('extracts and parses video structure', async () => {
+      mockAiService.callChat.mockResolvedValue(validStructureJson);
+
+      const result = await service.extractStructure(
+        'Transcript text',
+        transcriptionId,
+      );
+
+      expect(result.sections).toHaveLength(2);
+      expect(result.keyThemes).toHaveLength(2);
+      expect(result.crossReferences).toHaveLength(1);
+    });
+
+    it('throws StructureExtractionError on empty response', async () => {
+      mockAiService.callChat.mockResolvedValue(null);
+
+      await expect(
+        service.extractStructure('Transcript text', transcriptionId),
+      ).rejects.toThrow(StructureExtractionError);
+    });
+
+    it('throws StructureExtractionError when no JSON found', async () => {
+      mockAiService.callChat.mockResolvedValue('No JSON here, just text');
+
+      await expect(
+        service.extractStructure('Transcript text', transcriptionId),
+      ).rejects.toThrow(StructureExtractionError);
+    });
+
+    it('throws StructureExtractionError on invalid JSON structure', async () => {
+      mockAiService.callChat.mockResolvedValue('{"notSections": []}');
+
+      await expect(
+        service.extractStructure('Transcript text', transcriptionId),
+      ).rejects.toThrow(StructureExtractionError);
+    });
+
+    it('truncates long transcripts before sending to AI', async () => {
+      const veryLongText = 'word '.repeat(200000);
+      mockAiService.callChat.mockResolvedValue(validStructureJson);
+
+      await service.extractStructure(veryLongText, transcriptionId);
+
+      const prompt = mockAiService.callChat.mock.calls[0][0];
+      expect(prompt.length).toBeLessThan(veryLongText.length);
+    });
+  });
+
+  describe('Redis storage', () => {
+    it('stores chunk summaries in Redis', async () => {
+      const summaries = ['summary1', 'summary2'];
+
+      await service.storeChunkSummaries(transcriptionId, jobId, summaries);
+
+      expect(mockRedisClient.setex).toHaveBeenCalledWith(
+        `transcript:chunk:${transcriptionId}:${jobId}`,
+        24 * 60 * 60,
+        JSON.stringify(summaries),
+      );
+    });
+
+    it('retrieves stored chunk summaries', async () => {
+      const summaries = ['summary1', 'summary2'];
+      mockRedisClient.get.mockResolvedValue(JSON.stringify(summaries));
+
+      const result = await service.getStoredChunkSummaries(
+        transcriptionId,
+        jobId,
+      );
+
+      expect(result).toEqual(summaries);
+    });
+
+    it('returns null when no stored summaries exist', async () => {
+      mockRedisClient.get.mockResolvedValue(null);
+
+      const result = await service.getStoredChunkSummaries(
+        transcriptionId,
+        jobId,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on invalid JSON in stored summaries', async () => {
+      mockRedisClient.get.mockResolvedValue('invalid json');
+
+      const result = await service.getStoredChunkSummaries(
+        transcriptionId,
+        jobId,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('clears chunk summaries from Redis', async () => {
+      await service.clearChunkSummaries(transcriptionId, jobId);
+
+      expect(mockRedisClient.del).toHaveBeenCalledWith(
+        `transcript:chunk:${transcriptionId}:${jobId}`,
+      );
+    });
+  });
+
+  describe('synthesizeSummaries', () => {
+    const mockStructure: VideoStructure = {
+      sections: [
+        { title: 'Section 1', startPhrase: 'First' },
+        { title: 'Section 2', startPhrase: 'Second' },
+      ],
+      keyThemes: ['theme1'],
+      crossReferences: [],
+    };
+
+    it('synthesizes summaries with structure context', async () => {
+      const summaries = ['Summary of section 1', 'Summary of section 2'];
+      mockAiService.callChat.mockResolvedValue('Final synthesized summary');
+
+      const result = await service.synthesizeSummaries(
+        summaries,
+        mockStructure,
+        transcriptionId,
+        jobId,
+      );
+
+      expect(result).toBe('Final synthesized summary');
+      expect(mockAiService.callChat).toHaveBeenCalled();
+    });
+
+    it('includes custom prompt in synthesis', async () => {
+      mockAiService.callChat.mockResolvedValue('Final summary');
+
+      await service.synthesizeSummaries(
+        ['summary'],
+        mockStructure,
+        transcriptionId,
+        jobId,
+        'Focus on technical details',
+      );
+
+      const prompt = mockAiService.callChat.mock.calls[0][0];
+      expect(prompt).toContain('Additional instructions: Focus on technical details');
+    });
+
+    it('throws TranscriptChunkingError on empty response', async () => {
+      mockAiService.callChat.mockResolvedValue(null);
+
+      await expect(
+        service.synthesizeSummaries(
+          ['summary'],
+          mockStructure,
+          transcriptionId,
+          jobId,
+        ),
+      ).rejects.toThrow(TranscriptChunkingError);
+    });
+  });
+
+  describe('processTranscript', () => {
+    const shortText = 'This is a short transcript.';
+
+    beforeEach(() => {
+      mockAiService.callChat.mockReset();
+    });
+
+    describe('full-context mode', () => {
+      beforeEach(() => {
+        mockConfigService.getProcessingModeForChannel.mockReturnValue('full-context');
+      });
+
+      it('processes transcript without chunking in full-context mode', async () => {
+        mockAiService.callChat.mockResolvedValue('Full context summary');
+
+        const result = await service.processTranscript(
+          shortText,
+          transcriptionId,
+          jobId,
+          channelId,
+        );
+
+        expect(result).toBe('Full context summary');
+        expect(mockAiService.callChat).toHaveBeenCalledTimes(1);
+      });
+
+      it('applies custom prompt in full-context mode', async () => {
+        mockAiService.callChat.mockResolvedValue('Summary');
+
+        await service.processTranscript(
+          shortText,
+          transcriptionId,
+          jobId,
+          channelId,
+          'Custom instructions',
+        );
+
+        const prompt = mockAiService.callChat.mock.calls[0][0];
+        expect(prompt).toContain('Additional instructions: Custom instructions');
+      });
+
+      it('throws TranscriptChunkingError on empty response', async () => {
+        mockAiService.callChat.mockResolvedValue(null);
+
+        await expect(
+          service.processTranscript(shortText, transcriptionId, jobId, channelId),
+        ).rejects.toThrow(TranscriptChunkingError);
+      });
+    });
+
+    describe('chunked mode', () => {
+      const validStructureJson = JSON.stringify({
+        sections: [
+          { title: 'Section 1', startPhrase: 'Start' },
+        ],
+        keyThemes: ['theme1'],
+        crossReferences: [],
+      });
+
+      beforeEach(() => {
+        mockConfigService.getProcessingModeForChannel.mockReturnValue('chunked');
+        mockConfigService.getYoutubeTranscriptionsChunkingConfig.mockReturnValue({
+          maxTranscriptionTokens: 100,
+          transcriptionChunkSize: 100,
+          transcriptionChunkOverlap: 10,
+        });
+      });
+
+      it('extracts structure and processes chunks', async () => {
+        const longText = 'This is sentence one. This is sentence two. This is sentence three. This is sentence four.';
+        mockAiService.callChat
+          .mockResolvedValueOnce(validStructureJson)
+          .mockResolvedValueOnce('Chunk 1 summary')
+          .mockResolvedValueOnce('Final synthesized summary');
+
+        const result = await service.processTranscript(
+          longText,
+          transcriptionId,
+          jobId,
+          channelId,
+        );
+
+        expect(result).toBe('Final synthesized summary');
+        expect(mockAiService.callChat).toHaveBeenCalledTimes(3);
+      });
+
+      it('applies custom prompt to chunk summaries', async () => {
+        const longText = 'This is sentence one. This is sentence two. This is sentence three.';
+        mockAiService.callChat
+          .mockResolvedValueOnce(validStructureJson)
+          .mockResolvedValueOnce('Chunk summary')
+          .mockResolvedValueOnce('Final summary');
+
+        await service.processTranscript(
+          longText,
+          transcriptionId,
+          jobId,
+          channelId,
+          'Focus on key points',
+        );
+
+        const chunkPrompt = mockAiService.callChat.mock.calls[1][0];
+        expect(chunkPrompt).toContain('Additional instructions: Focus on key points');
+      });
+
+      it('stores partial results on chunk failure', async () => {
+        const longText = 'This is sentence one. This is sentence two. This is sentence three.';
+        mockAiService.callChat
+          .mockResolvedValueOnce(validStructureJson)
+          .mockResolvedValueOnce('Chunk 1 summary')
+          .mockResolvedValueOnce(null);
+
+        await expect(
+          service.processTranscript(longText, transcriptionId, jobId, channelId),
+        ).rejects.toThrow(TranscriptChunkingError);
+
+        expect(mockRedisClient.setex).toHaveBeenCalled();
+      });
+
+      it('falls back to simple chunking on structure extraction failure', async () => {
+        const longText = 'This is sentence one. This is sentence two. This is sentence three.';
+        mockAiService.callChat
+          .mockRejectedValueOnce(new Error('Structure extraction failed'))
+          .mockResolvedValueOnce('Chunk summary')
+          .mockResolvedValueOnce('Final summary');
+
+        const result = await service.processTranscript(
+          longText,
+          transcriptionId,
+          jobId,
+          channelId,
+        );
+
+        expect(result).toBe('Final summary');
+      });
+    });
+  });
+});

--- a/src/youtube-transcriptions/services/transcript-chunking.service.ts
+++ b/src/youtube-transcriptions/services/transcript-chunking.service.ts
@@ -1,0 +1,551 @@
+import { RedisService } from '@libs/redis';
+import { Injectable } from '@nestjs/common';
+import { AiService } from '../../ai/ai.service';
+import { ProcessingMode } from '../../config/config.entity';
+import { ConfigService } from '../../config/config.service';
+import {
+  chunkSummaryPrompt,
+  chunkSummaryWithStructurePrompt,
+  structureExtractionPrompt,
+  synthesisWithStructurePrompt,
+  transcriptionSummaryPrompt,
+} from '../../config/prompts';
+import { buildFinalPrompt } from '../../shared/helpers/build-final-prompt';
+import { estimateChatTokens } from '../../shared/helpers/token-estimation';
+import {
+  StructureExtractionError,
+  TranscriptChunkingError,
+} from '../errors/transcript-chunking.errors';
+
+export type VideoStructure = {
+  sections: Array<{
+    title: string;
+    startPhrase: string;
+  }>;
+  keyThemes: string[];
+  crossReferences: Array<{
+    from: number;
+    to: number;
+    description: string;
+  }>;
+};
+
+export type TranscriptChunk = {
+  text: string;
+  tokenCount: number;
+  startIndex: number;
+};
+
+const REDIS_KEY_PREFIX = 'transcript:chunk';
+const REDIS_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+@Injectable()
+export class TranscriptChunkingService {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly aiService: AiService,
+    private readonly redisService: RedisService,
+  ) { }
+
+  needsChunking(transcriptText: string): boolean {
+    const config = this.configService.getYoutubeTranscriptionsChunkingConfig();
+    const tokenCount = estimateChatTokens(transcriptText);
+    return tokenCount > config.maxTranscriptionTokens;
+  }
+
+  getProcessingMode(channelId: string): ProcessingMode {
+    return this.configService.getProcessingModeForChannel(channelId);
+  }
+
+  async extractStructure(
+    transcriptText: string,
+    transcriptionId: string,
+  ): Promise<VideoStructure> {
+    // Truncate for structure extraction to avoid API limits
+    // Structure extraction only needs themes and section markers, not full content
+    const truncatedText = this.truncateIfNeeded(transcriptText, 50000);
+
+    const prompt = structureExtractionPrompt.replace(
+      '{article_content}',
+      truncatedText,
+    );
+
+    const response = await this.aiService.callChat(prompt);
+
+    if (!response) {
+      throw new StructureExtractionError(
+        'Structure extraction returned empty response',
+        transcriptionId,
+      );
+    }
+
+    try {
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        throw new StructureExtractionError(
+          'No JSON object found in response',
+          transcriptionId,
+          response,
+        );
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]) as VideoStructure;
+
+      if (!parsed.sections || !Array.isArray(parsed.sections)) {
+        throw new StructureExtractionError(
+          'Invalid structure: missing or invalid sections array',
+          transcriptionId,
+          response,
+        );
+      }
+
+      return {
+        sections: parsed.sections || [],
+        keyThemes: parsed.keyThemes || [],
+        crossReferences: parsed.crossReferences || [],
+      };
+    } catch (error) {
+      if (error instanceof StructureExtractionError) {
+        throw error;
+      }
+      throw new StructureExtractionError(
+        `Failed to parse structure JSON: ${error instanceof Error ? error.message : String(error)}`,
+        transcriptionId,
+        response,
+      );
+    }
+  }
+
+  splitIntoChunks(transcriptText: string): TranscriptChunk[] {
+    const config = this.configService.getYoutubeTranscriptionsChunkingConfig();
+    const chunkSize = config.transcriptionChunkSize;
+    const overlap = config.transcriptionChunkOverlap;
+
+    const normalizedText = transcriptText.trim().replace(/\s+/g, ' ');
+    if (!normalizedText) {
+      return [];
+    }
+
+    const totalTokens = estimateChatTokens(normalizedText);
+    if (totalTokens <= chunkSize) {
+      return [
+        {
+          text: normalizedText,
+          tokenCount: totalTokens,
+          startIndex: 0,
+        },
+      ];
+    }
+
+    const sentences = normalizedText.split(/(?<=[.!?])\s+/);
+    const chunks: TranscriptChunk[] = [];
+    let currentChunk = '';
+    let currentTokens = 0;
+    let startIndex = 0;
+
+    for (const sentence of sentences) {
+      const sentenceTokens = estimateChatTokens(sentence);
+      const candidate = currentChunk ? `${currentChunk} ${sentence}` : sentence;
+      const candidateTokens = estimateChatTokens(candidate);
+
+      if (candidateTokens <= chunkSize) {
+        currentChunk = candidate;
+        currentTokens = candidateTokens;
+        continue;
+      }
+
+      if (currentChunk) {
+        chunks.push({
+          text: currentChunk,
+          tokenCount: currentTokens,
+          startIndex,
+        });
+
+        // Add overlap from the end of the previous chunk
+        const overlapText = this.getOverlapText(currentChunk, overlap);
+        currentChunk = overlapText ? `${overlapText} ${sentence}` : sentence;
+        currentTokens = estimateChatTokens(currentChunk);
+        startIndex = chunks.length;
+      } else {
+        // Single sentence exceeds chunk size, use it anyway
+        currentChunk = sentence;
+        currentTokens = sentenceTokens;
+        startIndex = chunks.length;
+      }
+    }
+
+    if (currentChunk) {
+      chunks.push({
+        text: currentChunk,
+        tokenCount: currentTokens,
+        startIndex,
+      });
+    }
+
+    return chunks;
+  }
+
+  private getOverlapText(text: string, overlapTokens: number): string {
+    const tokens = estimateChatTokens(text);
+    if (tokens <= overlapTokens) {
+      return text;
+    }
+
+    // Approximate character position for overlap
+    const charsPerToken = text.length / tokens;
+    const overlapChars = Math.floor(overlapTokens * charsPerToken);
+
+    // Find sentence boundary near the overlap point
+    const startPos = Math.max(0, text.length - overlapChars);
+    const substring = text.substring(startPos);
+    const sentenceStart = substring.indexOf('. ');
+
+    if (sentenceStart !== -1) {
+      return substring.substring(sentenceStart + 2);
+    }
+
+    return substring;
+  }
+
+  private getRedisKey(transcriptionId: string, jobId: string): string {
+    return `${REDIS_KEY_PREFIX}:${transcriptionId}:${jobId}`;
+  }
+
+  async storeChunkSummaries(
+    transcriptionId: string,
+    jobId: string,
+    summaries: string[],
+  ): Promise<void> {
+    const key = this.getRedisKey(transcriptionId, jobId);
+    const client = this.redisService.getClient();
+    await client.setex(key, REDIS_TTL_SECONDS, JSON.stringify(summaries));
+  }
+
+  async getStoredChunkSummaries(
+    transcriptionId: string,
+    jobId: string,
+  ): Promise<string[] | null> {
+    const key = this.getRedisKey(transcriptionId, jobId);
+    const client = this.redisService.getClient();
+    const data = await client.get(key);
+
+    if (!data) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(data) as string[];
+    } catch {
+      return null;
+    }
+  }
+
+  async clearChunkSummaries(
+    transcriptionId: string,
+    jobId: string,
+  ): Promise<void> {
+    const key = this.getRedisKey(transcriptionId, jobId);
+    const client = this.redisService.getClient();
+    await client.del(key);
+  }
+
+  async synthesizeSummaries(
+    summaries: string[],
+    structure: VideoStructure,
+    transcriptionId: string,
+    jobId: string,
+    customPrompt?: string | null,
+  ): Promise<string> {
+    const sectionsOverview = structure.sections
+      .map((s, i) => `${i + 1}. ${s.title}`)
+      .join('\n');
+
+    const videoStructure = `Key Themes: ${structure.keyThemes.join(', ')}\nSections:\n${sectionsOverview}`;
+
+    const chunkSummaries = summaries
+      .map((s, i) => `## Section ${i + 1}\n${s}`)
+      .join('\n\n');
+
+    const basePrompt = synthesisWithStructurePrompt
+      .replace('{video_structure}', videoStructure)
+      .replace('{chunk_summaries}', chunkSummaries);
+
+    const prompt = buildFinalPrompt(basePrompt, customPrompt);
+
+    const result = await this.aiService.callChat(prompt);
+
+    if (!result) {
+      throw new TranscriptChunkingError(
+        'Synthesis returned empty response',
+        transcriptionId,
+        jobId,
+      );
+    }
+
+    return result;
+  }
+
+  private truncateIfNeeded(
+    transcriptText: string,
+    maxTokens: number,
+  ): string {
+    const tokens = estimateChatTokens(transcriptText);
+    if (tokens <= maxTokens) {
+      return transcriptText;
+    }
+
+    // Approximate character position
+    const charsPerToken = transcriptText.length / tokens;
+    const targetChars = Math.floor(maxTokens * charsPerToken);
+
+    // Find sentence boundary near the target
+    const truncated = transcriptText.substring(0, targetChars);
+    const lastSentenceEnd = Math.max(
+      truncated.lastIndexOf('. '),
+      truncated.lastIndexOf('! '),
+      truncated.lastIndexOf('? '),
+    );
+
+    if (lastSentenceEnd > targetChars * 0.8) {
+      return truncated.substring(0, lastSentenceEnd + 1);
+    }
+
+    return truncated;
+  }
+
+  async processTranscript(
+    transcriptText: string,
+    transcriptionId: string,
+    jobId: string,
+    channelId: string,
+    customPrompt?: string | null,
+  ): Promise<string> {
+    const processingMode = this.getProcessingMode(channelId);
+
+    if (processingMode === 'full-context') {
+      console.log(
+        JSON.stringify({
+          event: 'transcript_full_context_start',
+          transcriptionId,
+          processingMode,
+        }),
+      );
+
+      const truncatedText = this.truncateIfNeeded(transcriptText, 120000);
+      const basePrompt = transcriptionSummaryPrompt.replace(
+        '{article_content}',
+        truncatedText,
+      );
+      const prompt = buildFinalPrompt(basePrompt, customPrompt);
+
+      const result = await this.aiService.callChat(prompt);
+
+      if (!result) {
+        throw new TranscriptChunkingError(
+          'Full-context processing returned empty response',
+          transcriptionId,
+          jobId,
+        );
+      }
+
+      return result;
+    }
+
+    // Chunked mode with structure extraction
+    console.log(
+      JSON.stringify({
+        event: 'transcript_chunking_start',
+        transcriptionId,
+        processingMode,
+        estimatedTokens: estimateChatTokens(transcriptText),
+      }),
+    );
+
+    try {
+      // Step 1: Extract structure
+      const structure = await this.extractStructure(
+        transcriptText,
+        transcriptionId,
+      );
+
+      console.log(
+        JSON.stringify({
+          event: 'transcript_structure_extracted',
+          transcriptionId,
+          sectionsCount: structure.sections.length,
+          keyThemesCount: structure.keyThemes.length,
+        }),
+      );
+
+      // Step 2: Split into chunks
+      const chunks = this.splitIntoChunks(transcriptText);
+      const summaries: string[] = [];
+
+      console.log(
+        JSON.stringify({
+          event: 'transcript_chunks_created',
+          transcriptionId,
+          chunkCount: chunks.length,
+          chunkSizes: chunks.map((c) => c.tokenCount),
+        }),
+      );
+
+      // Step 3: Summarize each chunk WITH structure context
+      for (let i = 0; i < chunks.length; i++) {
+        const startTime = Date.now();
+        const chunk = chunks[i];
+
+        const sectionsOverview = structure.sections
+          .map((s, idx) => `${idx + 1}. ${s.title}`)
+          .join('\n');
+
+        const relevantCrossRefs = structure.crossReferences
+          .filter(
+            (cr) =>
+              cr.from === i ||
+              cr.to === i ||
+              (cr.from <= i && cr.to >= i),
+          )
+          .map((cr) => cr.description)
+          .join('\n');
+
+        const baseChunkPrompt = chunkSummaryWithStructurePrompt
+          .replace('{section_number}', String(i + 1))
+          .replace('{total_sections}', String(chunks.length))
+          .replace('{key_themes}', structure.keyThemes.join(', '))
+          .replace('{sections_overview}', sectionsOverview)
+          .replace('{cross_references}', relevantCrossRefs || 'None')
+          .replace('{chunk_content}', chunk.text);
+
+        const prompt = buildFinalPrompt(baseChunkPrompt, customPrompt);
+
+        const summary = await this.aiService.callChat(prompt);
+
+        if (!summary) {
+          // Store partial results for retry
+          await this.storeChunkSummaries(transcriptionId, jobId, summaries);
+          throw new TranscriptChunkingError(
+            `Chunk ${i + 1} processing failed`,
+            transcriptionId,
+            jobId,
+          );
+        }
+
+        summaries.push(summary);
+
+        console.log(
+          JSON.stringify({
+            event: 'transcript_chunk_processed',
+            transcriptionId,
+            chunkIndex: i,
+            chunkTokens: chunk.tokenCount,
+            processingTimeMs: Date.now() - startTime,
+          }),
+        );
+      }
+
+      // Store summaries before synthesis
+      await this.storeChunkSummaries(transcriptionId, jobId, summaries);
+
+      // Step 4: Synthesize with structure awareness
+      const finalSummary = await this.synthesizeSummaries(
+        summaries,
+        structure,
+        transcriptionId,
+        jobId,
+        customPrompt,
+      );
+
+      // Clear intermediate storage
+      await this.clearChunkSummaries(transcriptionId, jobId);
+
+      console.log(
+        JSON.stringify({
+          event: 'transcript_chunking_complete',
+          transcriptionId,
+          chunkCount: chunks.length,
+        }),
+      );
+
+      return finalSummary;
+    } catch (error) {
+      if (error instanceof TranscriptChunkingError) {
+        throw error;
+      }
+
+      // Fallback to simple chunking without structure extraction
+      console.error(
+        'Structure-aware chunking failed, falling back to simple chunking:',
+        error,
+      );
+      return this.processSimpleChunked(
+        transcriptText,
+        transcriptionId,
+        jobId,
+        customPrompt,
+      );
+    }
+  }
+
+  private async processSimpleChunked(
+    transcriptText: string,
+    transcriptionId: string,
+    jobId: string,
+    customPrompt?: string | null,
+  ): Promise<string> {
+    const chunks = this.splitIntoChunks(transcriptText);
+    const summaries: string[] = [];
+
+    console.log(
+      JSON.stringify({
+        event: 'transcript_simple_chunking_start',
+        transcriptionId,
+        chunkCount: chunks.length,
+      }),
+    );
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      const baseChunkPrompt = chunkSummaryPrompt.replace('{chunk_content}', chunk.text);
+      const prompt = buildFinalPrompt(baseChunkPrompt, customPrompt);
+
+      const summary = await this.aiService.callChat(prompt);
+
+      if (!summary) {
+        // Store partial results for retry
+        await this.storeChunkSummaries(transcriptionId, jobId, summaries);
+        throw new TranscriptChunkingError(
+          `Simple chunk ${i + 1} processing failed`,
+          transcriptionId,
+          jobId,
+        );
+      }
+
+      summaries.push(summary);
+
+      console.log(
+        JSON.stringify({
+          event: 'transcript_simple_chunk_processed',
+          transcriptionId,
+          chunkIndex: i,
+        }),
+      );
+    }
+
+    const result = await this.synthesizeSummaries(
+      summaries,
+      {
+        sections: [],
+        keyThemes: [],
+        crossReferences: [],
+      },
+      transcriptionId,
+      jobId,
+      customPrompt,
+    );
+
+    await this.clearChunkSummaries(transcriptionId, jobId);
+
+    return result;
+  }
+}

--- a/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
+++ b/src/youtube-transcriptions/services/youtube-transcriptions.service.ts
@@ -416,9 +416,10 @@ export class YoutubeTranscriptionsService {
       );
       await this.queueService.addTranscriptionSummaryJob(
         transcriptionId,
-        transcriptText.substring(0, 8000), // Limit text length
+        transcriptText,
         videoWithTranscript.title,
         generateAudio,
+        channelId,
       );
 
       console.log(
@@ -620,9 +621,10 @@ export class YoutubeTranscriptionsService {
       );
       await this.queueService.addTranscriptionSummaryJob(
         insertedId,
-        videoData.transcriptText.substring(0, 8000), // Limit text length
+        videoData.transcriptText,
         videoData.title,
         generateAudio,
+        videoData.channel.id,
       );
 
       console.log(

--- a/src/youtube-transcriptions/youtube-transcriptions.module.ts
+++ b/src/youtube-transcriptions/youtube-transcriptions.module.ts
@@ -17,6 +17,7 @@ import { GetYoutubeTranscriptionByIdQuery } from './queries/get-youtube-transcri
 import { ListAllYoutubeTranscriptionsQuery } from './queries/list-all-youtube-transcriptions.query';
 import { ListYoutubeTranscriptionsQuery } from './queries/list-youtube-transcriptions.query';
 import { StorageService } from './services/storage.service';
+import { TranscriptChunkingService } from './services/transcript-chunking.service';
 import { TranscriptService } from './services/transcript.service';
 import { YoutubeTranscriptionsAlternativeService } from './services/youtube-transcriptions-alternative.service';
 import { YoutubeTranscriptionsService } from './services/youtube-transcriptions.service';
@@ -48,6 +49,7 @@ import { ProcessTranscriptionFilesUseCase } from './usecases/process-transcripti
     StorageService,
     AiService,
     ConfigService,
+    TranscriptChunkingService,
     ListYoutubeTranscriptionsQuery,
     ListAllYoutubeTranscriptionsQuery,
     GetYoutubeTranscriptionByIdQuery,


### PR DESCRIPTION
Implements a hybrid processing strategy to handle YouTube transcripts that exceed DeepSeek's 128K context window. Uses structure-aware chunking that extracts video structure before splitting, summarizes each chunk with context, then synthesizes a final unified summary. Includes Redis-based intermediate storage for partial failure recovery. Configuration options added for chunking thresholds, processing modes, and premium channel settings.

Closes https://linear.app/anas-org/issue/TASK-287