### PR TITLE
feat: improve tech article summary prompt (TASK-289)

### DIFF
--- a/src/articles/articles.controller.spec.ts
+++ b/src/articles/articles.controller.spec.ts
@@ -1,5 +1,6 @@
 import { AUDIO_GENERATION_SUCCESS_MESSAGE } from '@libs/audio';
 import { IS_PUBLIC_KEY } from '@libs/auth';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { mock } from 'jest-mock-extended';
 import { ArticlesController } from './articles.controller';
 import { GenerateArticleAudioCommand } from './commands/generate-article-audio.command';
@@ -54,7 +55,6 @@ describe('ArticlesController', () => {
     });
 
     it('should propagate NotFoundException from command', async () => {
-      const { NotFoundException } = await import('@nestjs/common');
       mockGenerateArticleAudioCommand.execute.mockRejectedValue(
         new NotFoundException('Article not found'),
       );
@@ -76,7 +76,6 @@ describe('ArticlesController', () => {
     });
 
     it('should propagate ConflictException from command', async () => {
-      const { ConflictException } = await import('@nestjs/common');
       mockGenerateArticleAudioCommand.execute.mockRejectedValue(
         new ConflictException('Audio already exists for this resource.'),
       );

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -26,6 +26,40 @@ describe('ConfigService', () => {
     expect(service).toBeDefined();
   });
 
+  describe('formatPrompt', () => {
+    it('should replace both {article_content} and {article_title} placeholders', () => {
+      const template = '## Title\n- {article_title}\n\nContent:\n{article_content}';
+      const result = service.formatPrompt(template, {
+        article_content: 'Some article text',
+        article_title: 'My Article Title',
+      });
+
+      expect(result).toBe('## Title\n- My Article Title\n\nContent:\nSome article text');
+      expect(result).not.toContain('{article_title}');
+      expect(result).not.toContain('{article_content}');
+    });
+
+    it('should replace {article_title} with empty string when value is explicitly undefined', () => {
+      const template = '## Title\n- {article_title}\n\nContent:\n{article_content}';
+      const result = service.formatPrompt(template, {
+        article_content: 'Some text',
+        article_title: undefined,
+      });
+
+      expect(result).toContain('## Title\n- \n');
+    });
+
+    it('should handle templates without {article_title} placeholder', () => {
+      const template = 'Content:\n{article_content}';
+      const result = service.formatPrompt(template, {
+        article_content: 'Some text',
+        article_title: 'Title',
+      });
+
+      expect(result).toBe('Content:\nSome text');
+    });
+  });
+
   describe('getArticleEmailsNotifications', () => {
     it('should return email from environment variable when set', () => {
       process.env.ARTICLE_FAILURE_NOTIFICATION_EMAIL = 'test@example.com';

--- a/src/processor/processor.service.spec.ts
+++ b/src/processor/processor.service.spec.ts
@@ -64,6 +64,74 @@ describe('ProcessorService', () => {
     jest.clearAllMocks();
   });
 
+  describe('processArticles - article_title placeholder', () => {
+    it('passes article title to formatPrompt when profile has articleSummary', async () => {
+      mockProfilesService.getPromptsForProfile.mockReturnValue({
+        articleSummary: 'Summarize {article_title}: {article_content}',
+        impactRating: undefined,
+      });
+      mockConfigService.formatPrompt.mockReturnValue('formatted prompt');
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockConfigService.formatPrompt).toHaveBeenCalledWith(
+        'Summarize {article_title}: {article_content}',
+        {
+          article_content: 'Test content',
+          article_title: 'Test Article',
+        },
+      );
+    });
+
+    it('uses feed_source as fallback when article title is empty', async () => {
+      const articleNoTitle: DBArticle = {
+        ...mockArticle,
+        title: '',
+        feed_source: 'test-feed',
+      };
+      mockArticlesService.getUnprocessedArticles.mockResolvedValue([articleNoTitle]);
+      mockProfilesService.getPromptsForProfile.mockReturnValue({
+        articleSummary: '{article_title}: {article_content}',
+        impactRating: undefined,
+      });
+      mockConfigService.formatPrompt.mockReturnValue('formatted prompt');
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockConfigService.formatPrompt).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ article_title: 'test-feed' }),
+      );
+    });
+
+    it('uses "Untitled" when both title and feed_source are empty', async () => {
+      const articleNoTitleNoFeed: DBArticle = {
+        ...mockArticle,
+        title: '',
+        feed_source: '',
+      };
+      mockArticlesService.getUnprocessedArticles.mockResolvedValue([articleNoTitleNoFeed]);
+      mockProfilesService.getPromptsForProfile.mockReturnValue({
+        articleSummary: '{article_title}: {article_content}',
+        impactRating: undefined,
+      });
+      mockConfigService.formatPrompt.mockReturnValue('formatted prompt');
+      mockAiService.callChat.mockResolvedValue('Article summary');
+      mockAiService.getEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+
+      await service.processArticles(FeedProfile.DEFAULT, 10);
+
+      expect(mockConfigService.formatPrompt).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ article_title: 'Untitled' }),
+      );
+    });
+  });
+
   describe('processArticles - backward compatibility (custom prompt)', () => {
     it('sends base prompt to AI when article has no custom_prompt', async () => {
       const articleWithoutCustomPrompt: DBArticle = {

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -68,14 +68,18 @@ export class ProcessorService {
 
       try {
         const articleTitle = article.title || article.feed_source || 'Untitled';
-        const baseSummaryPrompt = profilePrompts.articleSummary
-          ? this.configService.formatPrompt(profilePrompts.articleSummary, {
-            article_content: article.raw_content.substring(0, 4000),
+        let baseSummaryPrompt: string;
+
+        if (profilePrompts.articleSummary) {
+          baseSummaryPrompt = this.configService.formatPrompt(profilePrompts.articleSummary, {
+            article_content: article.raw_content,
             article_title: articleTitle,
-          })
-          : this.configService.getArticleSummaryPrompt(
-            article.raw_content.substring(0, 4000),
+          });
+        } else {
+          baseSummaryPrompt = this.configService.getArticleSummaryPrompt(
+            article.raw_content,
           );
+        }
 
         const summaryPrompt = buildFinalPrompt(
           baseSummaryPrompt,

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -67,9 +67,11 @@ export class ProcessorService {
       console.log(`Processing article ID: ${article.id} - ${article.title}...`);
 
       try {
+        const articleTitle = article.title || article.feed_source || 'Untitled';
         const baseSummaryPrompt = profilePrompts.articleSummary
           ? this.configService.formatPrompt(profilePrompts.articleSummary, {
             article_content: article.raw_content.substring(0, 4000),
+            article_title: articleTitle,
           })
           : this.configService.getArticleSummaryPrompt(
             article.raw_content.substring(0, 4000),

--- a/src/processor/processor.service.ts
+++ b/src/processor/processor.service.ts
@@ -72,12 +72,12 @@ export class ProcessorService {
 
         if (profilePrompts.articleSummary) {
           baseSummaryPrompt = this.configService.formatPrompt(profilePrompts.articleSummary, {
-            article_content: article.raw_content,
+            article_content: article.raw_content.substring(0, 4000),
             article_title: articleTitle,
           });
         } else {
           baseSummaryPrompt = this.configService.getArticleSummaryPrompt(
-            article.raw_content,
+            article.raw_content.substring(0, 4000),
           );
         }
 

--- a/src/shared/feeds/tech.ts
+++ b/src/shared/feeds/tech.ts
@@ -132,16 +132,48 @@ export const techRSSFeeds: RSSFeed[] = [
 
 export const techPrompts = {
   articleSummary: `
-You are an expert in summarization and critical analysis. I will provide you with an article, either news or technical in nature. Your task is to generate a comprehensive, well-structured summary that includes the following components:
-1. **Brief overview:** A clear 1-2 sentence summary in plain English that captures the main topic or purpose of the article.
-2. **Detailed technical summary:** A 4-6 sentence paragraph that explains the core ideas, arguments, and technical points of the article using precise and formal language suitable for an informed audience.
-3. **Key takeaways:** Concise bullet points or short sections highlighting the most important findings, conclusions, or implications discussed in the article.
-4. **Notable data and quotes:** Clear presentation of any significant data, trends, statistics, or memorable quotes, emphasizing their relevance.
-5. **Critical critique:** A brief evaluation addressing potential biases, outdated information, gaps in coverage, missing context, or other limitations within the article.
+You are a senior technology analyst.
 
-Ensure the output is organized, easy to scan, and uses logical structure and clear language throughout.
+Task: Summarize the article content below with high factual precision.
 
-  Transcription:
+Rules:
+- Use ONLY information present in the source.
+- Do NOT invent quotes, numbers, dates, organizations, or causal claims.
+- If information is missing, write "Not stated in source".
+- If the source appears incomplete or noisy, summarize only what is clear and explicitly note uncertainty.
+- Preserve the original article title exactly as provided (character-for-character).
+- Do not translate, rephrase, normalize punctuation, or alter capitalization of the title.
+
+Output in Markdown with EXACT sections and order:
+
+## Title
+- {article_title}
+
+## Brief overview
+- 1-2 sentences, plain English, <= 60 words.
+
+## Detailed technical summary
+- One paragraph, 4-6 sentences, <= 250 words.
+- Focus on mechanism, claims, and technical implications.
+
+## Key takeaways
+- 4-6 bullet points.
+- Each bullet <= 50 words.
+
+## Notable data and quotes
+- Data: bullet list of concrete stats/figures with context.
+- Quotes: bullet list of verbatim quotes.
+- If absent, write "Not stated in source".
+
+## Critical critique
+- 3-5 bullets covering possible bias, missing context, outdated assumptions, and evidentiary gaps.
+- Keep critique separate from factual summary.
+
+## Confidence
+- Overall confidence: High | Medium | Low
+- Uncertainties: 1-3 bullets explaining what could not be verified from source.
+
+  Article content:
   {article_content}
   `,
 

--- a/src/shared/types/ai.ts
+++ b/src/shared/types/ai.ts
@@ -2,6 +2,7 @@ export type ImpactRating = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 export interface PromptVariables {
   article_content?: string;
+  article_title?: string;
   summary?: string;
   title?: string;
   content?: string;


### PR DESCRIPTION
## Summary

Replaces the tech `articleSummary` prompt with a stronger version that enforces structured Markdown output, anti-hallucination rules, confidence scoring, and token/length boundaries.

## Changes

- **`src/shared/feeds/tech.ts`** - Replaced `techPrompts.articleSummary` with an improved prompt featuring exact Markdown sections (Title, Brief overview, Detailed technical summary, Key takeaways, Notable data and quotes, Critical critique, Confidence), anti-hallucination rules, and length constraints.
- **`src/processor/processor.service.ts`** - Now passes `article_title` to `formatPrompt()` with fallback chain: `article.title` -> `article.feed_source` -> `"Untitled"`.
- **`src/shared/types/ai.ts`** - Added `article_title` to `PromptVariables` interface.
- **`src/processor/processor.service.spec.ts`** - Added 3 tests: title passed correctly, feed_source fallback, and "Untitled" fallback.
- **`src/config/config.service.spec.ts`** - Added 3 tests for `formatPrompt` verifying `{article_title}` replacement, undefined handling, and templates without the placeholder.

Resolves: TASK-289