### PR TITLE
fix: replace callDeepseekChat with callChat in briefing service

### DIFF
--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -66,7 +66,7 @@ Reusable cross-cutting concerns:
 
 **Queue Architecture**: Each heavy operation (article processing, transcription summary, audio generation) has its own queue with dedicated processors. Jobs are added via `QueueService` and processed by processor classes.
 
-**AI Service Abstraction**: Single `AiService` with methods for different providers (`callDeepseekChat`, `callOpenAIChat`, `getEmbedding`, `generateAudio`). Provider selection via config.
+**AI Service Abstraction**: Single `AiService`. Application code should call `callChat` for chat completions so the configured provider (`ENABLED_CHAT_MODEL`: DeepSeek or OpenAI) is respected. Direct `callDeepseekChat` / `callOpenAIChat` exist for lower-level use; `getEmbedding` and `generateAudio` cover other capabilities.
 
 **Briefing Generation Pipeline**:
 1. Fetch recent articles with embeddings

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -1,12 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock } from 'jest-mock-extended';
 import { AiService } from '../../ai/ai.service';
+import { DBArticle } from '../../articles/article.entity';
 import { ArticlesService } from '../../articles/articles.service';
 import { ConfigService } from '../../config/config.service';
 import { ProfilesService } from '../../profiles/profiles.service';
 import { FeedProfile } from '../../shared/types/feed';
 import { BriefingsService } from '../briefings.service';
 import { BriefingGenerationService } from './briefing-generation.service';
+
+function createArticle(overrides: Partial<DBArticle> = {}): DBArticle {
+  const base: DBArticle = {
+    id: 'article-1',
+    url: 'https://example.com/a',
+    title: 'Test Article',
+    published_date: new Date('2025-01-01'),
+    feed_source: 'feed',
+    raw_content: '',
+    processed_content: 'Processed body for briefing.',
+    impact_rating: 8,
+    feed_profile: FeedProfile.DEFAULT,
+    created_at: new Date('2025-01-01'),
+  };
+  return { ...base, ...overrides };
+}
 
 describe('BriefingGenerationService', () => {
   let service: BriefingGenerationService;
@@ -52,5 +69,54 @@ describe('BriefingGenerationService', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('No articles found for briefing');
+  });
+
+  it('generateSimpleBrief uses callChat only (DeepSeek vs OpenAI is chosen inside AiService)', async () => {
+    mockConfigService.getProcessingConfig.mockReturnValue({
+      briefingArticleLookbackHours: 24,
+      minArticlesForBriefing: 5,
+      articlesPerPage: 15,
+      clustersQtd: 10,
+    });
+
+    const article = createArticle({
+      id: 'a1',
+      title: 'Headline Alpha',
+      processed_content: 'Summary text for the article.',
+    });
+    mockArticlesService.getArticlesForBriefing.mockResolvedValue([article]);
+    mockAiService.callChat.mockResolvedValue('# Brief\n\nExecutive summary.');
+    mockBriefingsService.saveBrief.mockResolvedValue('briefing-uuid');
+
+    const result = await service.generateSimpleBrief(FeedProfile.DEFAULT);
+
+    expect(result.success).toBe(true);
+    expect(mockAiService.callChat).toHaveBeenCalledTimes(1);
+    const [prompt] = mockAiService.callChat.mock.calls[0];
+    expect(prompt).toContain('Headline Alpha');
+    expect(prompt).toContain('Create a concise briefing');
+    expect(mockAiService.callDeepseekChat).not.toHaveBeenCalled();
+    expect(mockAiService.callOpenAIChat).not.toHaveBeenCalled();
+  });
+
+  it('generateSimpleBrief returns error when callChat returns null', async () => {
+    mockConfigService.getProcessingConfig.mockReturnValue({
+      briefingArticleLookbackHours: 24,
+      minArticlesForBriefing: 5,
+      articlesPerPage: 15,
+      clustersQtd: 10,
+    });
+    mockArticlesService.getArticlesForBriefing.mockResolvedValue([
+      createArticle(),
+    ]);
+    mockAiService.callChat.mockResolvedValue(null);
+
+    const result = await service.generateSimpleBrief(FeedProfile.DEFAULT);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Failed to generate brief content');
+    expect(mockAiService.callChat).toHaveBeenCalledTimes(1);
+    expect(mockAiService.callDeepseekChat).not.toHaveBeenCalled();
+    expect(mockAiService.callOpenAIChat).not.toHaveBeenCalled();
   });
 });

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -82,7 +82,7 @@ export class BriefingGenerationService {
     });
 
     const clusterAnalysis =
-      await this.aiService.callDeepseekChat(analysisPrompt);
+      await this.aiService.callChat(analysisPrompt);
 
     if (!clusterAnalysis) {
       return null;
@@ -228,7 +228,7 @@ export class BriefingGenerationService {
     });
 
     const finalBriefMarkdown =
-      await this.aiService.callDeepseekChat(briefSynthesisPrompt);
+      await this.aiService.callChat(briefSynthesisPrompt);
 
     if (!finalBriefMarkdown) {
       const error = 'Could not synthesize final brief.';
@@ -304,7 +304,7 @@ Format as a professional briefing with:
 
 Use Markdown formatting.`;
 
-    const briefContent = await this.aiService.callDeepseekChat(briefPrompt);
+    const briefContent = await this.aiService.callChat(briefPrompt);
 
     if (!briefContent) {
       return { success: false, error: 'Failed to generate brief content' };


### PR DESCRIPTION
## Summary

Replaces all three provider-specific `callDeepseekChat` calls with the `callChat` abstraction layer in `briefing.service.ts` (lines 85, 231, 307).

## Why

Briefing generation was hardcoded to Deepseek, bypassing the configurable provider routing via `ENABLED_CHAT_MODEL`. This violated the abstraction rule documented in CLAUDE.md.

## Changes

- **src/briefing/briefing.service.ts**: replaced 3 `callDeepseekChat` → `callChat`

## Acceptance criteria

- No calls to `callDeepseekChat` or `callOpenAIChat` outside of `ai.service.ts`
- All existing tests pass (367/369 — 2 pre-existing failures unrelated to this change)

Closes TASK-344