### PR TITLE
fix(briefings): phase 1 correctness fixes

### DIFF
--- a/src/briefings/briefings.controller.spec.ts
+++ b/src/briefings/briefings.controller.spec.ts
@@ -1,0 +1,83 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { FeedProfile } from '../shared/types/feed';
+import { BriefingsController } from './briefings.controller';
+import { BriefingsService } from './briefings.service';
+import { ListBriefingsQuery } from './queries/list-briefings.query';
+
+describe('BriefingsController', () => {
+  let controller: BriefingsController;
+  const mockBriefingsService = mock<BriefingsService>();
+  const mockListBriefingsQuery = mock<ListBriefingsQuery>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BriefingsController],
+      providers: [
+        { provide: BriefingsService, useValue: mockBriefingsService },
+        { provide: ListBriefingsQuery, useValue: mockListBriefingsQuery },
+      ],
+    }).compile();
+
+    controller = module.get<BriefingsController>(BriefingsController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('listBriefings', () => {
+    it('delegates to ListBriefingsQuery', async () => {
+      const expected = {
+        briefings: [],
+        current_feed_profile: undefined,
+        available_profiles: [],
+      };
+      mockListBriefingsQuery.execute.mockResolvedValue(expected);
+
+      const result = await controller.listBriefings();
+
+      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(undefined);
+      expect(result).toBe(expected);
+    });
+
+    it('passes feedProfile to query', async () => {
+      mockListBriefingsQuery.execute.mockResolvedValue({
+        briefings: [],
+        current_feed_profile: FeedProfile.DEFAULT,
+        available_profiles: [],
+      });
+
+      await controller.listBriefings(FeedProfile.DEFAULT);
+
+      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(
+        FeedProfile.DEFAULT,
+      );
+    });
+  });
+
+  describe('getBriefing', () => {
+    it('returns briefing when found', async () => {
+      const briefing = {
+        id: 'uuid-1',
+        brief_markdown: '# Brief',
+        generated_at: new Date('2025-01-01'),
+        feed_profile: FeedProfile.DEFAULT,
+      };
+      mockBriefingsService.getBriefById.mockResolvedValue(briefing);
+
+      const result = await controller.getBriefing('uuid-1');
+
+      expect(result).toBe(briefing);
+    });
+
+    it('throws NotFoundException for unknown id', async () => {
+      mockBriefingsService.getBriefById.mockResolvedValue(null);
+
+      await expect(
+        controller.getBriefing('00000000-0000-0000-0000-000000000000'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/briefings/briefings.controller.ts
+++ b/src/briefings/briefings.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, ParseUUIDPipe, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
 import type { FeedProfile } from '../shared/types/feed';
 import { BriefingsService } from './briefings.service';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
@@ -12,10 +19,6 @@ export class BriefingsController {
 
   @Get()
   async listBriefings(@Query('feedProfile') feedProfile?: FeedProfile) {
-    // const briefings =
-    //   await this.briefingsService.getAllBriefsMetadata(feedProfile);
-    // return briefings;
-
     return this.listBriefingsQuery.execute(feedProfile);
   }
 
@@ -23,7 +26,7 @@ export class BriefingsController {
   async getBriefing(@Param('id', ParseUUIDPipe) id: string) {
     const briefing = await this.briefingsService.getBriefById(id);
     if (!briefing) {
-      return { error: 'Briefing not found' };
+      throw new NotFoundException('Briefing not found');
     }
     return briefing;
   }

--- a/src/briefings/briefings.service.ts
+++ b/src/briefings/briefings.service.ts
@@ -1,4 +1,4 @@
-import { DatabaseService } from '@libs/database';
+import { DatabaseService, RunCallbackContext } from '@libs/database';
 import { Injectable } from '@nestjs/common';
 import { BriefsMetadata, GetBriefByIdResult } from './entities/briefing.entity';
 import { FeedProfile } from '../shared/types/feed';
@@ -29,7 +29,7 @@ export class BriefingsService {
 
       stmt.run(
         [content, JSON.stringify(articleIds), feedProfile],
-        function (this: { lastID?: string }, err: Error | null) {
+        function (this: RunCallbackContext, err: Error | null) {
           if (err) {
             reject(err);
           } else if (!this.lastID) {

--- a/src/briefings/briefings.service.ts
+++ b/src/briefings/briefings.service.ts
@@ -1,10 +1,6 @@
 import { DatabaseService } from '@libs/database';
 import { Injectable } from '@nestjs/common';
-import {
-  BriefsMetadata,
-  GetBriefByIdResult,
-  ProcessingStatsResult,
-} from './entities/briefing.entity';
+import { BriefsMetadata, GetBriefByIdResult } from './entities/briefing.entity';
 import { FeedProfile } from '../shared/types/feed';
 
 interface BriefingRow {
@@ -12,14 +8,6 @@ interface BriefingRow {
   generated_at: string;
   feed_profile: string;
   brief_markdown?: string;
-}
-
-interface CountRow {
-  count: number;
-}
-
-interface AvgRow {
-  avg: number | null;
 }
 
 @Injectable()
@@ -44,8 +32,10 @@ export class BriefingsService {
         function (this: { lastID?: string }, err: Error | null) {
           if (err) {
             reject(err);
+          } else if (!this.lastID) {
+            reject(new Error('saveBrief: insert succeeded but no lastID returned'));
           } else {
-            resolve(this.lastID ?? '');
+            resolve(this.lastID);
           }
           stmt.finalize();
         },
@@ -111,81 +101,4 @@ export class BriefingsService {
     });
   }
 
-  async getStats(feedProfile: FeedProfile): Promise<ProcessingStatsResult> {
-    return new Promise((resolve, reject) => {
-      const db = this.databaseService.getDbConnection();
-
-      const queries = [
-        'SELECT COUNT(*) as count FROM articles WHERE feed_profile = ?',
-        'SELECT COUNT(*) as count FROM articles WHERE feed_profile = ? AND processed_content IS NOT NULL',
-        'SELECT COUNT(*) as count FROM articles WHERE feed_profile = ? AND impact_rating IS NOT NULL',
-        'SELECT AVG(impact_rating) as avg FROM articles WHERE feed_profile = ? AND impact_rating IS NOT NULL',
-      ];
-
-      const results: (CountRow | AvgRow)[] = [];
-      let completed = 0;
-
-      queries.forEach((query, index) => {
-        if (index === 3) {
-          db.get(query, [feedProfile], (err, row: AvgRow | undefined) => {
-            if (err) {
-              reject(err);
-              return;
-            }
-
-            results[index] = row || { avg: null };
-            completed++;
-
-            if (completed === queries.length) {
-              const total = (results[0] as CountRow).count;
-              const processed = (results[1] as CountRow).count;
-              const rated = (results[2] as CountRow).count;
-              const averageRating = (results[3] as AvgRow).avg;
-
-              const stats: ProcessingStatsResult = {
-                total,
-                processed,
-                rated,
-                unprocessed: total - processed,
-                unrated: processed - rated,
-                averageRating: averageRating
-                  ? Math.round(averageRating * 100) / 100
-                  : undefined,
-              };
-              resolve(stats);
-            }
-          });
-        } else {
-          db.get(query, [feedProfile], (err, row: CountRow | undefined) => {
-            if (err) {
-              reject(err);
-              return;
-            }
-
-            results[index] = row || { count: 0 };
-            completed++;
-
-            if (completed === queries.length) {
-              const total = (results[0] as CountRow).count;
-              const processed = (results[1] as CountRow).count;
-              const rated = (results[2] as CountRow).count;
-              const averageRating = (results[3] as AvgRow).avg;
-
-              const stats: ProcessingStatsResult = {
-                total,
-                processed,
-                rated,
-                unprocessed: total - processed,
-                unrated: processed - rated,
-                averageRating: averageRating
-                  ? Math.round(averageRating * 100) / 100
-                  : undefined,
-              };
-              resolve(stats);
-            }
-          });
-        }
-      });
-    });
-  }
 }

--- a/src/briefings/entities/briefing.entity.ts
+++ b/src/briefings/entities/briefing.entity.ts
@@ -65,15 +65,6 @@ export interface GetBriefByIdResult {
   feed_profile: string;
 }
 
-export interface ProcessingStatsResult {
-  total: number;
-  processed: number;
-  rated: number;
-  unprocessed: number;
-  unrated: number;
-  averageRating?: number;
-}
-
 export interface BriefsMetadata {
   id: string;
   generated_at: Date;

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -99,6 +99,61 @@ describe('BriefingGenerationService', () => {
     expect(mockAiService.callOpenAIChat).not.toHaveBeenCalled();
   });
 
+  it('analyzeCluster filters articles with null processed_content before building prompt', async () => {
+    const embedding = (x: number, y: number) =>
+      JSON.stringify([x, y, x + 0.1, y + 0.1]);
+
+    const validArticle = (id: string, x: number, y: number) =>
+      createArticle({
+        id,
+        processed_content: `content-${id}`,
+        embedding: embedding(x, y),
+      });
+
+    const articles = [
+      validArticle('a1', 0.1, 0.2),
+      validArticle('a2', 0.3, 0.4),
+      createArticle({ id: 'a3', processed_content: null, embedding: embedding(0.5, 0.6) }),
+      createArticle({ id: 'a4', processed_content: undefined, embedding: embedding(0.7, 0.8) }),
+    ];
+
+    mockConfigService.getBriefingConfig.mockReturnValue({
+      feedProfile: FeedProfile.DEFAULT,
+      lookbackHours: 24,
+      minArticles: 2,
+      clustersQtd: 2,
+      articlesPerPage: 15,
+      customPrompts: undefined,
+    });
+    mockArticlesService.getArticlesForBriefing.mockResolvedValue(articles);
+    mockProfilesService.getPromptsForProfile.mockReturnValue({
+      clusterAnalysis: null,
+      briefSynthesis: null,
+    });
+    mockConfigService.getPrompt.mockReturnValue('{cluster_summaries_text}');
+    mockConfigService.formatPrompt.mockImplementation((template, vars) =>
+      template.replace(
+        '{cluster_summaries_text}',
+        (vars as Record<string, string>).cluster_summaries_text ?? '',
+      ).replace(
+        '{cluster_analyses_text}',
+        (vars as Record<string, string>).cluster_analyses_text ?? '',
+      ).replace('{feed_profile}', ''),
+    );
+    mockAiService.callChat.mockResolvedValue('cluster-analysis-text');
+    mockBriefingsService.saveBrief.mockResolvedValue('brief-uuid');
+
+    await service.generateBrief(FeedProfile.DEFAULT);
+
+    const clusterAnalysisCalls = mockAiService.callChat.mock.calls.filter(
+      ([prompt]) => !prompt.includes('cluster-analysis-text'),
+    );
+    for (const [prompt] of clusterAnalysisCalls) {
+      expect(prompt).not.toContain('- null');
+      expect(prompt).not.toContain('- undefined');
+    }
+  });
+
   it('generateSimpleBrief returns error when callChat returns null', async () => {
     mockConfigService.getProcessingConfig.mockReturnValue({
       briefingArticleLookbackHours: 24,

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -154,6 +154,33 @@ describe('BriefingGenerationService', () => {
     }
   });
 
+  it('analyzeCluster returns null without calling AI when all articles have null processed_content', async () => {
+    const embedding = (x: number, y: number) =>
+      JSON.stringify([x, y, x + 0.1, y + 0.1]);
+
+    const articles = [
+      createArticle({ id: 'a1', processed_content: null, embedding: embedding(0.1, 0.2) }),
+      createArticle({ id: 'a2', processed_content: null, embedding: embedding(0.3, 0.4) }),
+      createArticle({ id: 'a3', processed_content: undefined, embedding: embedding(0.5, 0.6) }),
+      createArticle({ id: 'a4', processed_content: undefined, embedding: embedding(0.7, 0.8) }),
+    ];
+
+    mockConfigService.getBriefingConfig.mockReturnValue({
+      feedProfile: FeedProfile.DEFAULT,
+      lookbackHours: 24,
+      minArticles: 2,
+      clustersQtd: 2,
+      articlesPerPage: 15,
+      customPrompts: undefined,
+    });
+    mockArticlesService.getArticlesForBriefing.mockResolvedValue(articles);
+
+    const result = await service.generateBrief(FeedProfile.DEFAULT);
+
+    expect(result.success).toBe(false);
+    expect(mockAiService.callChat).not.toHaveBeenCalled();
+  });
+
   it('generateSimpleBrief returns error when callChat returns null', async () => {
     mockConfigService.getProcessingConfig.mockReturnValue({
       briefingArticleLookbackHours: 24,

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -56,6 +56,25 @@ describe('BriefingGenerationService', () => {
     expect(service).toBeDefined();
   });
 
+  it('generateSimpleBrief returns error when all articles have null processed_content', async () => {
+    mockConfigService.getProcessingConfig.mockReturnValue({
+      briefingArticleLookbackHours: 24,
+      minArticlesForBriefing: 5,
+      articlesPerPage: 15,
+      clustersQtd: 10,
+    });
+    mockArticlesService.getArticlesForBriefing.mockResolvedValue([
+      createArticle({ id: 'a1', processed_content: null }),
+      createArticle({ id: 'a2', processed_content: undefined }),
+    ]);
+
+    const result = await service.generateSimpleBrief(FeedProfile.DEFAULT);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No articles with processed content found');
+    expect(mockAiService.callChat).not.toHaveBeenCalled();
+  });
+
   it('generateSimpleBrief returns error when no articles', async () => {
     mockConfigService.getProcessingConfig.mockReturnValue({
       briefingArticleLookbackHours: 24,

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -291,7 +291,15 @@ export class BriefingGenerationService {
       .sort((a, b) => (b.impact_rating || 0) - (a.impact_rating || 0))
       .slice(0, maxArticles);
 
-    const summariesText = selectedArticles
+    const articlesWithContent = selectedArticles.filter(
+      (a) => a.processed_content != null,
+    );
+
+    if (articlesWithContent.length === 0) {
+      return { success: false, error: 'No articles with processed content found' };
+    }
+
+    const summariesText = articlesWithContent
       .map(
         (article, index) =>
           `${index + 1}. **${article.title}** (Impact: ${article.impact_rating || 'N/A'})\n   ${article.processed_content}\n`,

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -67,6 +67,7 @@ export class BriefingGenerationService {
     const selectedArticles = clusterArticles.slice(0, maxSummariesPerCluster);
 
     const clusterSummariesText = selectedArticles
+      .filter((article) => article.processed_content != null)
       .map((article) => `- ${article.processed_content}`)
       .join('\n\n');
 

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -71,6 +71,10 @@ export class BriefingGenerationService {
       .map((article) => `- ${article.processed_content}`)
       .join('\n\n');
 
+    if (!clusterSummariesText) {
+      return null;
+    }
+
     const profilePrompts =
       this.profilesService.getPromptsForProfile(feedProfile);
     const promptToUse =


### PR DESCRIPTION
## Summary

- Replace inline `{ error: 'Briefing not found' }` response with proper `NotFoundException` in `getBriefing`
- Guard `null`/`undefined` `processed_content` in both `analyzeCluster` and `generateSimpleBrief` before building AI prompts — prevents literal `"null"`/`"undefined"` strings reaching the model
- Reject `saveBrief` promise when `lastID` is missing post-insert instead of resolving with empty string
- Fix `this` type annotation in `saveBrief` to use `RunCallbackContext` from `@libs/database`
- Delete `getStats` dead code and `ProcessingStatsResult` interface

## Test plan

- [x] `BriefingsController` unit tests (new) — `listBriefings` delegation, `getBriefing` 404 path
- [x] `BriefingGenerationService` — null `processed_content` filter in `analyzeCluster` (2 new tests) and `generateSimpleBrief` (1 new test)
- [x] `pnpm test src/briefings` — 11/11 pass