### PR TITLE
feat(briefings): phase 2 architecture with code review fixes

### DIFF
--- a/docs/features/plans/Implementation Plan - Briefings Module And Config Module.md
+++ b/docs/features/plans/Implementation Plan - Briefings Module And Config Module.md
@@ -1,0 +1,34 @@
+# Implementation Plan - Briefings Module And Config Module
+
+## Fix: ConfigService cross-module coupling (BriefingOptions import)
+
+**Problem:** `config.service.ts:2` imports `BriefingOptions` from `../briefings/entities/briefing.types`. Config module must not depend on Briefings — the dependency arrow is inverted.
+
+**Target state:** `BriefingOptions` lives in `src/shared/types/briefing.ts`. Both `config/` and `briefings/` import from `shared/`.
+
+### Steps
+
+1. **Create `src/shared/types/briefing.ts`**
+   Move `BriefingOptions` from `briefing.types.ts` into this new file. Export it.
+
+2. **Update `briefing.types.ts`**
+   Remove the `BriefingOptions` interface. Re-export it from `shared/types/briefing.ts` if any internal briefings code imports it directly from this path (check with grep).
+
+3. **Update `config.service.ts:2`**
+   Change import from `../briefings/entities/briefing.types` → `../shared/types/briefing`.
+
+4. **Update all other consumers**
+   Run: `grep -rn "BriefingOptions" src --include="*.ts"`
+   Update each import to point to `shared/types/briefing`.
+
+5. **Verify no circular deps**
+   Run `pnpm exec madge --circular src/` (or equivalent) to confirm no new cycles.
+
+6. **Run tests**
+   `pnpm exec jest` — all suites must pass.
+
+### Acceptance criteria
+- `config/` imports nothing from `briefings/`
+- `BriefingOptions` is importable from `shared/types/briefing`
+- All tests pass
+- No circular dependency warnings

--- a/src/briefings/briefings.controller.spec.ts
+++ b/src/briefings/briefings.controller.spec.ts
@@ -38,7 +38,7 @@ describe('BriefingsController', () => {
 
       const result = await controller.listBriefings();
 
-      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(undefined);
+      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(undefined, undefined);
       expect(result).toBe(expected);
     });
 
@@ -53,6 +53,7 @@ describe('BriefingsController', () => {
 
       expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(
         FeedProfile.DEFAULT,
+        undefined,
       );
     });
   });

--- a/src/briefings/briefings.controller.spec.ts
+++ b/src/briefings/briefings.controller.spec.ts
@@ -56,6 +56,42 @@ describe('BriefingsController', () => {
         undefined,
       );
     });
+
+    it('parses numeric limit and caps at 100', async () => {
+      mockListBriefingsQuery.execute.mockResolvedValue({
+        briefings: [],
+        current_feed_profile: undefined,
+        available_profiles: [],
+      });
+
+      await controller.listBriefings(undefined, '200');
+
+      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(undefined, 100);
+    });
+
+    it('passes parsed limit when within max', async () => {
+      mockListBriefingsQuery.execute.mockResolvedValue({
+        briefings: [],
+        current_feed_profile: undefined,
+        available_profiles: [],
+      });
+
+      await controller.listBriefings(undefined, '25');
+
+      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(undefined, 25);
+    });
+
+    it('treats non-numeric limit as undefined', async () => {
+      mockListBriefingsQuery.execute.mockResolvedValue({
+        briefings: [],
+        current_feed_profile: undefined,
+        available_profiles: [],
+      });
+
+      await controller.listBriefings(undefined, 'abc');
+
+      expect(mockListBriefingsQuery.execute).toHaveBeenCalledWith(undefined, undefined);
+    });
   });
 
   describe('getBriefing', () => {

--- a/src/briefings/briefings.controller.ts
+++ b/src/briefings/briefings.controller.ts
@@ -17,12 +17,18 @@ export class BriefingsController {
     private readonly listBriefingsQuery: ListBriefingsQuery,
   ) {}
 
+  private static readonly MAX_LIMIT = 100;
+
   @Get()
   async listBriefings(
     @Query('feedProfile') feedProfile?: FeedProfile,
     @Query('limit') limit?: string,
   ) {
-    const parsedLimit = limit ? parseInt(limit, 10) || undefined : undefined;
+    const parsed = limit !== undefined ? parseInt(limit, 10) : undefined;
+    const parsedLimit =
+      parsed !== undefined && !isNaN(parsed)
+        ? Math.min(parsed, BriefingsController.MAX_LIMIT)
+        : undefined;
     return this.listBriefingsQuery.execute(feedProfile, parsedLimit);
   }
 

--- a/src/briefings/briefings.controller.ts
+++ b/src/briefings/briefings.controller.ts
@@ -18,8 +18,12 @@ export class BriefingsController {
   ) {}
 
   @Get()
-  async listBriefings(@Query('feedProfile') feedProfile?: FeedProfile) {
-    return this.listBriefingsQuery.execute(feedProfile);
+  async listBriefings(
+    @Query('feedProfile') feedProfile?: FeedProfile,
+    @Query('limit') limit?: string,
+  ) {
+    const parsedLimit = limit ? parseInt(limit, 10) || undefined : undefined;
+    return this.listBriefingsQuery.execute(feedProfile, parsedLimit);
   }
 
   @Get(':id')

--- a/src/briefings/briefings.module.ts
+++ b/src/briefings/briefings.module.ts
@@ -1,5 +1,5 @@
-import { DatabaseModule } from '@libs/database';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AiModule } from '../ai/ai.module';
 import { ArticlesModule } from '../articles/articles.module';
 import { ConfigModule } from '../config/config.module';
@@ -8,9 +8,9 @@ import { ProfilesModule } from '../profiles/profiles.module';
 import { ScraperModule } from '../scraper/scraper.module';
 import { BriefingsController } from './briefings.controller';
 import { BriefingsService } from './briefings.service';
+import { BriefingEntity } from './entities/briefing.entity';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
 import { BriefingGenerationService } from './services/briefing-generation.service';
-
 import { CategorizeArticlesUseCase } from './usecases/categorize-articles.usecase';
 import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
 import { GenerateSimpleBriefUseCase } from './usecases/generate-simple-brief.usecase';
@@ -21,7 +21,7 @@ import { ScrapeArticlesUseCase } from './usecases/scrape-articles.usecase';
 
 @Module({
   imports: [
-    DatabaseModule,
+    TypeOrmModule.forFeature([BriefingEntity]),
     ArticlesModule,
     ProcessorModule,
     ProfilesModule,
@@ -42,16 +42,6 @@ import { ScrapeArticlesUseCase } from './usecases/scrape-articles.usecase';
     ScrapeArticlesUseCase,
   ],
   controllers: [BriefingsController],
-  exports: [
-    BriefingsService,
-    BriefingGenerationService,
-    CategorizeArticlesUseCase,
-    GenerateBriefUseCase,
-    GenerateSimpleBriefUseCase,
-    ProcessArticlesUseCase,
-    RateArticlesUseCase,
-    RunBriefingUseCase,
-    ScrapeArticlesUseCase,
-  ],
+  exports: [BriefingsService, BriefingGenerationService],
 })
 export class BriefingsModule {}

--- a/src/briefings/briefings.service.spec.ts
+++ b/src/briefings/briefings.service.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { mock } from 'jest-mock-extended';
+import { Repository } from 'typeorm';
+import { FeedProfile } from '../shared/types/feed';
+import { BriefingsService } from './briefings.service';
+import { BriefingEntity } from './entities/briefing.entity';
+
+const mockRepo = mock<Repository<BriefingEntity>>();
+
+describe('BriefingsService', () => {
+  let service: BriefingsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BriefingsService,
+        { provide: getRepositoryToken(BriefingEntity), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<BriefingsService>(BriefingsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveBrief', () => {
+    it('returns the saved entity id', async () => {
+      const entity = { id: 'new-uuid' } as BriefingEntity;
+      mockRepo.create.mockReturnValue(entity);
+      mockRepo.save.mockResolvedValue(entity);
+
+      const result = await service.saveBrief(
+        'content',
+        ['article-1'],
+        FeedProfile.DEFAULT,
+      );
+
+      expect(mockRepo.create).toHaveBeenCalledWith({
+        content: 'content',
+        articleIds: ['article-1'],
+        feedProfile: FeedProfile.DEFAULT,
+      });
+      expect(result).toBe('new-uuid');
+    });
+
+    it('propagates repository save errors', async () => {
+      mockRepo.create.mockReturnValue({} as BriefingEntity);
+      mockRepo.save.mockRejectedValue(new Error('DB error'));
+
+      await expect(
+        service.saveBrief('content', [], FeedProfile.DEFAULT),
+      ).rejects.toThrow('DB error');
+    });
+  });
+
+  describe('getAllBriefsMetadata', () => {
+    it('returns mapped metadata for all profiles when no filter', async () => {
+      const entities: Partial<BriefingEntity>[] = [
+        { id: 'id-1', createdAt: new Date('2025-01-02'), feedProfile: 'default' },
+        { id: 'id-2', createdAt: new Date('2025-01-01'), feedProfile: 'tech' },
+      ];
+      mockRepo.find.mockResolvedValue(entities as BriefingEntity[]);
+
+      const result = await service.getAllBriefsMetadata();
+
+      expect(mockRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} }),
+      );
+      expect(result).toEqual([
+        { id: 'id-1', generated_at: new Date('2025-01-02'), feed_profile: 'default' },
+        { id: 'id-2', generated_at: new Date('2025-01-01'), feed_profile: 'tech' },
+      ]);
+    });
+
+    it('filters by feedProfile when provided', async () => {
+      mockRepo.find.mockResolvedValue([]);
+
+      await service.getAllBriefsMetadata(FeedProfile.DEFAULT);
+
+      expect(mockRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { feedProfile: FeedProfile.DEFAULT },
+        }),
+      );
+    });
+  });
+
+  describe('getBriefById', () => {
+    it('returns mapped result when entity found', async () => {
+      const entity: Partial<BriefingEntity> = {
+        id: 'brief-uuid',
+        content: '# Brief',
+        createdAt: new Date('2025-01-01'),
+        feedProfile: 'default',
+      };
+      mockRepo.findOne.mockResolvedValue(entity as BriefingEntity);
+
+      const result = await service.getBriefById('brief-uuid');
+
+      expect(result).toEqual({
+        id: 'brief-uuid',
+        brief_markdown: '# Brief',
+        generated_at: new Date('2025-01-01'),
+        feed_profile: 'default',
+      });
+    });
+
+    it('returns null when entity not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getBriefById('missing-id');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/briefings/briefings.service.spec.ts
+++ b/src/briefings/briefings.service.spec.ts
@@ -67,7 +67,7 @@ describe('BriefingsService', () => {
       const result = await service.getAllBriefsMetadata();
 
       expect(mockRepo.find).toHaveBeenCalledWith(
-        expect.objectContaining({ where: {} }),
+        expect.objectContaining({ where: {}, take: 50 }),
       );
       expect(result).toEqual([
         { id: 'id-1', generated_at: new Date('2025-01-02'), feed_profile: 'default' },
@@ -83,6 +83,7 @@ describe('BriefingsService', () => {
       expect(mockRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { feedProfile: FeedProfile.DEFAULT },
+          take: 50,
         }),
       );
     });

--- a/src/briefings/briefings.service.ts
+++ b/src/briefings/briefings.service.ts
@@ -1,104 +1,61 @@
-import { DatabaseService, RunCallbackContext } from '@libs/database';
 import { Injectable } from '@nestjs/common';
-import { BriefsMetadata, GetBriefByIdResult } from './entities/briefing.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { FeedProfile } from '../shared/types/feed';
-
-interface BriefingRow {
-  id: string;
-  generated_at: string;
-  feed_profile: string;
-  brief_markdown?: string;
-}
+import { BriefingEntity } from './entities/briefing.entity';
+import { BriefsMetadata, GetBriefByIdResult } from './entities/briefing.types';
 
 @Injectable()
 export class BriefingsService {
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    @InjectRepository(BriefingEntity)
+    private readonly briefingRepository: Repository<BriefingEntity>,
+  ) {}
 
   async saveBrief(
     content: string,
     articleIds: string[],
     feedProfile: FeedProfile,
   ): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const db = this.databaseService.getDbConnection();
-
-      const stmt = db.prepare(`
-        INSERT INTO briefings (content, article_ids, feed_profile)
-        VALUES (?, ?, ?)
-      `);
-
-      stmt.run(
-        [content, JSON.stringify(articleIds), feedProfile],
-        function (this: RunCallbackContext, err: Error | null) {
-          if (err) {
-            reject(err);
-          } else if (!this.lastID) {
-            reject(new Error('saveBrief: insert succeeded but no lastID returned'));
-          } else {
-            resolve(this.lastID);
-          }
-          stmt.finalize();
-        },
-      );
+    const entity = this.briefingRepository.create({
+      content,
+      articleIds,
+      feedProfile,
     });
+    const saved = await this.briefingRepository.save(entity);
+    return saved.id;
   }
 
   async getAllBriefsMetadata(
     feedProfile?: FeedProfile,
   ): Promise<BriefsMetadata[]> {
-    return new Promise((resolve, reject) => {
-      const db = this.databaseService.getDbConnection();
-
-      let query =
-        'SELECT id, created_at as generated_at, feed_profile FROM briefings';
-      const params: string[] = [];
-
-      if (feedProfile) {
-        query += ' WHERE feed_profile = ?';
-        params.push(feedProfile);
-      }
-
-      query += ' ORDER BY created_at DESC';
-
-      db.all(query, params, (err, rows: BriefingRow[]) => {
-        if (err) {
-          reject(err);
-        } else {
-          const briefings: BriefsMetadata[] = rows.map((row) => ({
-            id: row.id,
-            generated_at: new Date(row.generated_at),
-            feed_profile: row.feed_profile,
-          }));
-          resolve(briefings);
-        }
-      });
+    const entities = await this.briefingRepository.find({
+      where: feedProfile ? { feedProfile } : {},
+      order: { createdAt: 'DESC' },
+      select: { id: true, createdAt: true, feedProfile: true },
     });
+
+    return entities.map((e) => ({
+      id: e.id,
+      generated_at: e.createdAt,
+      feed_profile: e.feedProfile,
+    }));
   }
 
   async getBriefById(briefId: string): Promise<GetBriefByIdResult | null> {
-    return new Promise((resolve, reject) => {
-      const db = this.databaseService.getDbConnection();
-
-      db.get(
-        'SELECT id, content as brief_markdown, created_at as generated_at, feed_profile FROM briefings WHERE id = ?',
-        [briefId],
-        (err, row: BriefingRow | undefined) => {
-          if (err) {
-            reject(err);
-          } else if (!row) {
-            resolve(null);
-          } else {
-            const result: GetBriefByIdResult = {
-              id: row.id,
-              brief_markdown: row.brief_markdown || '',
-              generated_at: new Date(row.generated_at),
-              feed_profile: row.feed_profile,
-            };
-            resolve(result);
-          }
-        },
-      );
+    const entity = await this.briefingRepository.findOne({
+      where: { id: briefId },
     });
-  }
 
+    if (!entity) {
+      return null;
+    }
+
+    return {
+      id: entity.id,
+      brief_markdown: entity.content,
+      generated_at: entity.createdAt,
+      feed_profile: entity.feedProfile,
+    };
+  }
 }

--- a/src/briefings/briefings.service.ts
+++ b/src/briefings/briefings.service.ts
@@ -28,11 +28,13 @@ export class BriefingsService {
 
   async getAllBriefsMetadata(
     feedProfile?: FeedProfile,
+    limit = 50,
   ): Promise<BriefsMetadata[]> {
     const entities = await this.briefingRepository.find({
       where: feedProfile ? { feedProfile } : {},
       order: { createdAt: 'DESC' },
       select: { id: true, createdAt: true, feedProfile: true },
+      take: limit,
     });
 
     return entities.map((e) => ({

--- a/src/briefings/entities/briefing.entity.ts
+++ b/src/briefings/entities/briefing.entity.ts
@@ -1,72 +1,24 @@
-import { FeedProfile } from '../../shared/types/feed';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 
-export interface BriefingOptions {
-  feedProfile?: FeedProfile;
-  lookbackHours?: number;
-  minArticles?: number;
-  customPrompts?: Partial<{
-    clusterAnalysis: string;
-    briefSynthesis: string;
-  }>;
-}
-
-export interface BriefGenerationOptions {
-  feedProfile: FeedProfile;
-  lookbackHours?: number;
-  minArticles?: number;
-  clustersQtd?: number;
-  customPrompts?: {
-    clusterAnalysis?: string;
-    briefSynthesis?: string;
-  };
-}
-
-export interface SimpleBriefResult {
-  success: boolean;
-  briefingId?: string;
-  content?: string;
-  error?: string;
-}
-
-export interface RecentBriefingResult {
+@Entity('briefings')
+export class BriefingEntity {
+  @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @Column('text')
   content: string;
-  articleCount: number;
+
+  @Column('simple-json', { name: 'article_ids' })
+  articleIds: string[];
+
+  @Column({ name: 'feed_profile' })
+  feedProfile: string;
+
+  @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
-}
-
-export interface GetBriefingTrendsResult {
-  totalBriefings: number;
-  avgArticlesPerBrief: number;
-  briefingsPerDay: Array<BriefingsPerDay>;
-}
-
-export interface BriefingsPerDay {
-  date: string;
-  count: number;
-}
-
-export interface GenerateBriefResult {
-  success: boolean;
-  briefingId?: string;
-  content?: string;
-  error?: string;
-  stats?: {
-    articlesAnalyzed: number;
-    clustersGenerated: number;
-    clustersUsed: number;
-  };
-}
-
-export interface GetBriefByIdResult {
-  id: string;
-  brief_markdown: string;
-  generated_at: Date;
-  feed_profile: string;
-}
-
-export interface BriefsMetadata {
-  id: string;
-  generated_at: Date;
-  feed_profile: string;
 }

--- a/src/briefings/entities/briefing.entity.ts
+++ b/src/briefings/entities/briefing.entity.ts
@@ -16,7 +16,7 @@ export class BriefingEntity {
   @Column('simple-json', { name: 'article_ids' })
   articleIds: string[];
 
-  @Column({ name: 'feed_profile' })
+  @Column({ name: 'feed_profile', type: 'text' })
   feedProfile: string;
 
   @CreateDateColumn({ name: 'created_at' })

--- a/src/briefings/entities/briefing.types.ts
+++ b/src/briefings/entities/briefing.types.ts
@@ -1,16 +1,5 @@
 import { FeedProfile } from '../../shared/types/feed';
 
-export interface BriefingOptions {
-  feedProfile?: FeedProfile;
-  lookbackHours?: number;
-  minArticles?: number;
-  customPrompts?: Partial<{
-    clusterAnalysis: string;
-    briefSynthesis: string;
-    simpleBriefing: string;
-  }>;
-}
-
 export interface BriefGenerationOptions {
   feedProfile: FeedProfile;
   lookbackHours?: number;

--- a/src/briefings/entities/briefing.types.ts
+++ b/src/briefings/entities/briefing.types.ts
@@ -7,6 +7,7 @@ export interface BriefingOptions {
   customPrompts?: Partial<{
     clusterAnalysis: string;
     briefSynthesis: string;
+    simpleBriefing: string;
   }>;
 }
 

--- a/src/briefings/entities/briefing.types.ts
+++ b/src/briefings/entities/briefing.types.ts
@@ -1,0 +1,72 @@
+import { FeedProfile } from '../../shared/types/feed';
+
+export interface BriefingOptions {
+  feedProfile?: FeedProfile;
+  lookbackHours?: number;
+  minArticles?: number;
+  customPrompts?: Partial<{
+    clusterAnalysis: string;
+    briefSynthesis: string;
+  }>;
+}
+
+export interface BriefGenerationOptions {
+  feedProfile: FeedProfile;
+  lookbackHours?: number;
+  minArticles?: number;
+  clustersQtd?: number;
+  customPrompts?: {
+    clusterAnalysis?: string;
+    briefSynthesis?: string;
+  };
+}
+
+export interface SimpleBriefResult {
+  success: boolean;
+  briefingId?: string;
+  content?: string;
+  error?: string;
+}
+
+export interface RecentBriefingResult {
+  id: string;
+  content: string;
+  articleCount: number;
+  createdAt: Date;
+}
+
+export interface GetBriefingTrendsResult {
+  totalBriefings: number;
+  avgArticlesPerBrief: number;
+  briefingsPerDay: Array<BriefingsPerDay>;
+}
+
+export interface BriefingsPerDay {
+  date: string;
+  count: number;
+}
+
+export interface GenerateBriefResult {
+  success: boolean;
+  briefingId?: string;
+  content?: string;
+  error?: string;
+  stats?: {
+    articlesAnalyzed: number;
+    clustersGenerated: number;
+    clustersUsed: number;
+  };
+}
+
+export interface GetBriefByIdResult {
+  id: string;
+  brief_markdown: string;
+  generated_at: Date;
+  feed_profile: string;
+}
+
+export interface BriefsMetadata {
+  id: string;
+  generated_at: Date;
+  feed_profile: string;
+}

--- a/src/briefings/queries/list-briefings.query.ts
+++ b/src/briefings/queries/list-briefings.query.ts
@@ -10,12 +10,12 @@ export class ListBriefingsQuery {
     private readonly briefingsService: BriefingsService,
   ) {}
 
-  async execute(feedProfile?: FeedProfile) {
+  async execute(feedProfile?: FeedProfile, limit?: number) {
     const availableProfiles =
       await this.articleService.getDistinctFeedProfiles();
 
     const briefings =
-      await this.briefingsService.getAllBriefsMetadata(feedProfile);
+      await this.briefingsService.getAllBriefsMetadata(feedProfile, limit);
 
     return {
       briefings,

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -104,6 +104,10 @@ describe('BriefingGenerationService', () => {
       processed_content: 'Summary text for the article.',
     });
     mockArticlesService.getArticlesForBriefing.mockResolvedValue([article]);
+    mockProfilesService.getPromptsForProfile.mockReturnValue({});
+    mockConfigService.getSimpleBriefPrompt.mockReturnValue(
+      "Create a concise briefing for the 'default' profile based on these recent articles:\n\n1. **Headline Alpha**",
+    );
     mockAiService.callChat.mockResolvedValue('# Brief\n\nExecutive summary.');
     mockBriefingsService.saveBrief.mockResolvedValue('briefing-uuid');
 

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { kmeans } from 'ml-kmeans';
 import { AiService } from '../../ai/ai.service';
 import { ClusterAnalysis, DBArticle } from '../../articles/article.entity';
@@ -15,6 +15,8 @@ import { BriefingsService } from '../briefings.service';
 
 @Injectable()
 export class BriefingGenerationService {
+  private readonly logger = new Logger(BriefingGenerationService.name);
+
   constructor(
     private readonly articlesService: ArticlesService,
     private readonly briefingsService: BriefingsService,
@@ -44,7 +46,7 @@ export class BriefingGenerationService {
       const result = kmeans(embeddings, effectiveClusters, {});
       return result.clusters;
     } catch (error) {
-      console.error('Error during clustering:', error);
+      this.logger.error('Error during clustering:', error);
       return embeddings.map(() => 0);
     }
   }
@@ -59,7 +61,7 @@ export class BriefingGenerationService {
       return null;
     }
 
-    console.log(
+    this.logger.log(
       `  Analyzing Cluster ${clusterIndex} (${clusterArticles.length} articles)`,
     );
 
@@ -112,7 +114,7 @@ export class BriefingGenerationService {
     feedProfile: FeedProfile,
     options: Partial<BriefGenerationOptions> = {},
   ): Promise<GenerateBriefResult> {
-    console.log(`\n--- Starting Brief Generation [${feedProfile}] ---`);
+    this.logger.log(`Starting Brief Generation [${feedProfile}]`);
 
     const briefingConfig = this.configService.getBriefingConfig({
       feedProfile,
@@ -128,24 +130,24 @@ export class BriefingGenerationService {
 
     if (!articles || articles.length < briefingConfig.minArticles) {
       const error = `Not enough recent articles (${articles?.length || 0}) for profile '${feedProfile}'. Min required: ${briefingConfig.minArticles}.`;
-      console.log(error);
+      this.logger.warn(error);
       return { success: false, error };
     }
 
-    console.log(`Generating brief from ${articles.length} articles.`);
+    this.logger.log(`Generating brief from ${articles.length} articles.`);
 
     const articleIds = articles.map((a) => a.id);
     const articlesWithEmbeddings = articles.filter((a) => a.embedding);
 
     if (articlesWithEmbeddings.length !== articles.length) {
-      console.log(
-        `Warning: ${articles.length - articlesWithEmbeddings.length} articles are missing embeddings. Proceeding with available ones.`,
+      this.logger.warn(
+        `${articles.length - articlesWithEmbeddings.length} articles missing embeddings. Proceeding with available ones.`,
       );
     }
 
     if (articlesWithEmbeddings.length < briefingConfig.minArticles) {
       const error = `Not enough articles (${articlesWithEmbeddings.length}) with embeddings to cluster. Min required: ${briefingConfig.minArticles}.`;
-      console.log(error);
+      this.logger.warn(error);
       return { success: false, error };
     }
 
@@ -158,7 +160,7 @@ export class BriefingGenerationService {
     );
 
     if (clustersQtd < 2) {
-      console.log(
+      this.logger.warn(
         'Not enough articles to form meaningful clusters. Skipping clustering.',
       );
       return {
@@ -167,7 +169,7 @@ export class BriefingGenerationService {
       };
     }
 
-    console.log(
+    this.logger.log(
       `Clustering ${embeddings.length} articles into ${clustersQtd} clusters...`,
     );
 
@@ -183,7 +185,7 @@ export class BriefingGenerationService {
       }
     });
 
-    console.log('Analyzing clusters...');
+    this.logger.log('Analyzing clusters...');
     const clusterAnalyses: ClusterAnalysis[] = [];
 
     for (let index = 0; index < clusterGroups.length; index++) {
@@ -207,7 +209,7 @@ export class BriefingGenerationService {
 
     if (clusterAnalyses.length === 0) {
       const error = 'No meaningful clusters found or analyzed.';
-      console.log(error);
+      this.logger.warn(error);
       return { success: false, error };
     }
 
@@ -237,7 +239,7 @@ export class BriefingGenerationService {
 
     if (!finalBriefMarkdown) {
       const error = 'Could not synthesize final brief.';
-      console.log(`--- Brief Generation Failed [${feedProfile}]: ${error} ---`);
+      this.logger.warn(`Brief Generation Failed [${feedProfile}]: ${error}`);
       return { success: false, error };
     }
 
@@ -248,9 +250,7 @@ export class BriefingGenerationService {
         feedProfile,
       );
 
-      console.log(
-        `--- Brief Generation Finished Successfully [${feedProfile}] ---`,
-      );
+      this.logger.log(`Brief Generation Finished Successfully [${feedProfile}]`);
 
       return {
         success: true,
@@ -274,7 +274,7 @@ export class BriefingGenerationService {
     feedProfile: FeedProfile,
     maxArticles: number = 10,
   ): Promise<SimpleBriefResult> {
-    console.log(`\n--- Generating Simple Brief [${feedProfile}] ---`);
+    this.logger.log(`Generating Simple Brief [${feedProfile}]`);
 
     const lookbackHours =
       this.configService.getProcessingConfig().briefingArticleLookbackHours;

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -10,7 +10,7 @@ import {
   BriefGenerationOptions,
   GenerateBriefResult,
   SimpleBriefResult,
-} from '../entities/briefing.entity';
+} from '../entities/briefing.types';
 import { BriefingsService } from '../briefings.service';
 
 @Injectable()
@@ -306,16 +306,12 @@ export class BriefingGenerationService {
       )
       .join('\n');
 
-    const briefPrompt = `Create a concise briefing for the '${feedProfile}' profile based on these recent articles:
-
-${summariesText}
-
-Format as a professional briefing with:
-1. Executive Summary (2-3 key themes)
-2. Key Developments (bullet points)
-3. Analysis and Implications
-
-Use Markdown formatting.`;
+    const profilePrompts = this.profilesService.getPromptsForProfile(feedProfile);
+    const briefPrompt = this.configService.getSimpleBriefPrompt(
+      feedProfile,
+      summariesText,
+      profilePrompts.simpleBriefing,
+    );
 
     const briefContent = await this.aiService.callChat(briefPrompt);
 

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -36,6 +36,7 @@ export type Config = {
     categoryClassification: string;
     clusterAnalysis: string;
     briefSynthesis: string;
+    simpleBriefing: string;
     transcriptionSummary: string;
     transcriptionAnalysis: string;
     transcriptionClassification: string;

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { BriefingOptions } from '../briefings/entities/briefing.types';
+import { BriefingOptions } from '../shared/types/briefing-options';
 import { ImpactRating, PromptVariables } from '../shared/types/ai';
 import { FeedProfile } from '../shared/types/feed';
 import { YoutubeChannelsService } from '../youtube-channels/youtube-channels.service';

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { BriefingOptions } from '../briefings/entities/briefing.entity';
+import { BriefingOptions } from '../briefings/entities/briefing.types';
 import { ImpactRating, PromptVariables } from '../shared/types/ai';
 import { FeedProfile } from '../shared/types/feed';
 import { YoutubeChannelsService } from '../youtube-channels/youtube-channels.service';
@@ -20,6 +20,7 @@ import {
   categoryClassificationPrompt,
   clusterAnalysisPrompt,
   impactRatingPrompt,
+  simpleBriefingPrompt,
   transcriptionAnalysisPrompt,
   transcriptionClassificationPrompt,
   transcriptionSummaryPrompt,
@@ -38,6 +39,7 @@ export class ConfigService {
       categoryClassification: categoryClassificationPrompt,
       clusterAnalysis: clusterAnalysisPrompt,
       briefSynthesis: briefSynthesisPrompt,
+      simpleBriefing: simpleBriefingPrompt,
       transcriptionSummary: transcriptionSummaryPrompt,
       transcriptionClassification: transcriptionClassificationPrompt,
       transcriptionAnalysis: transcriptionAnalysisPrompt,
@@ -139,6 +141,18 @@ export class ConfigService {
     return this.formatPrompt(template, {
       feed_profile: feedProfile,
       cluster_analyses_text: clusterAnalysesText,
+    });
+  }
+
+  getSimpleBriefPrompt(
+    feedProfile: FeedProfile,
+    summariesText: string,
+    customPrompt?: string,
+  ): string {
+    const template = customPrompt || this.CONFIGS.prompts.simpleBriefing;
+    return this.formatPrompt(template, {
+      feed_profile: feedProfile,
+      summaries_text: summariesText,
     });
   }
 

--- a/src/config/prompts/index.ts
+++ b/src/config/prompts/index.ts
@@ -4,6 +4,7 @@ export { categoryClassificationPrompt } from './category-classification.prompt';
 export { chunkSummaryPrompt, chunkSummaryWithStructurePrompt, structureExtractionPrompt, synthesisWithStructurePrompt } from './transcription-summary.prompt';
 export { clusterAnalysisPrompt } from './cluster-analysis.prompt';
 export { impactRatingPrompt } from './impact-rating.prompt';
+export { simpleBriefingPrompt } from './simple-briefing.prompt';
 export { transcriptionAnalysisPrompt } from './transcription-analysis.prompt';
 export { transcriptionClassificationPrompt } from './transcription-classification.prompt';
 export { transcriptionSummaryPrompt } from './transcription-summary.prompt';

--- a/src/config/prompts/simple-briefing.prompt.ts
+++ b/src/config/prompts/simple-briefing.prompt.ts
@@ -1,0 +1,10 @@
+export const simpleBriefingPrompt = `Create a concise briefing for the '{feed_profile}' profile based on these recent articles:
+
+{summaries_text}
+
+Format as a professional briefing with:
+1. Executive Summary (2-3 key themes)
+2. Key Developments (bullet points)
+3. Analysis and Implications
+
+Use Markdown formatting.`;

--- a/src/shared/types/ai.ts
+++ b/src/shared/types/ai.ts
@@ -9,6 +9,7 @@ export interface PromptVariables {
   feed_profile?: string;
   cluster_summaries_text?: string;
   cluster_analyses_text?: string;
+  summaries_text?: string;
 }
 
 export interface EmbeddingResponse {

--- a/src/shared/types/briefing-options.ts
+++ b/src/shared/types/briefing-options.ts
@@ -1,0 +1,11 @@
+import { FeedProfile } from './feed';
+
+export interface BriefingOptions {
+  feedProfile?: FeedProfile;
+  lookbackHours?: number;
+  minArticles?: number;
+  customPrompts?: Partial<{
+    clusterAnalysis: string;
+    briefSynthesis: string;
+  }>;
+}

--- a/src/shared/types/feed.ts
+++ b/src/shared/types/feed.ts
@@ -25,6 +25,7 @@ export interface FeedConfiguration {
     impactRating?: string;
     clusterAnalysis?: string;
     briefSynthesis?: string;
+    simpleBriefing?: string;
   };
   settings?: {
     priority?: number;


### PR DESCRIPTION
## Summary
Implements the Phase 2 architecture for the Briefings module, including TypeORM entity, config-driven prompts, and code review follow-ups.

## Changes
- **TypeORM entity & repository pattern** for briefings persistence
- **Config-driven prompts** via `BriefingOptions` and `BriefGenerationOptions`
- **Trimmed exports** — moved `BriefingOptions` to `shared/types/briefing-options`
- **Added `limit` query parameter** to the list briefings endpoint
- **Replaced `console.log/error` with NestJS `Logger`** in `BriefingGenerationService`

## Commits
- `334cadc` — feat(briefings): phase 2 architecture — TypeORM entity, config prompts, trim exports
- `ba261c2` — fix(briefings): address code review findings from phase 2
- `45034e4` — fix(briefings): additional code review follow-ups for phase 2