### PR TITLE
feat(briefings): phase 4 test coverage and customPrompts endpoint

### DIFF
--- a/src/briefings/briefings.controller.spec.ts
+++ b/src/briefings/briefings.controller.spec.ts
@@ -5,11 +5,13 @@ import { FeedProfile } from '../shared/types/feed';
 import { BriefingsController } from './briefings.controller';
 import { BriefingsService } from './briefings.service';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
+import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
 
 describe('BriefingsController', () => {
   let controller: BriefingsController;
   const mockBriefingsService = mock<BriefingsService>();
   const mockListBriefingsQuery = mock<ListBriefingsQuery>();
+  const mockGenerateBriefUseCase = mock<GenerateBriefUseCase>();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -17,6 +19,7 @@ describe('BriefingsController', () => {
       providers: [
         { provide: BriefingsService, useValue: mockBriefingsService },
         { provide: ListBriefingsQuery, useValue: mockListBriefingsQuery },
+        { provide: GenerateBriefUseCase, useValue: mockGenerateBriefUseCase },
       ],
     }).compile();
 
@@ -115,6 +118,34 @@ describe('BriefingsController', () => {
       await expect(
         controller.getBriefing('00000000-0000-0000-0000-000000000000'),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('generateBriefing', () => {
+    it('delegates to GenerateBriefUseCase and returns result', async () => {
+      const expected = { success: true, briefingId: 'brief-uuid' };
+      mockGenerateBriefUseCase.execute.mockResolvedValue(expected);
+
+      const result = await controller.generateBriefing({
+        feedProfile: FeedProfile.DEFAULT,
+      });
+
+      expect(mockGenerateBriefUseCase.execute).toHaveBeenCalledWith({
+        feedProfile: FeedProfile.DEFAULT,
+      });
+      expect(result).toBe(expected);
+    });
+
+    it('forwards customPrompts to use case', async () => {
+      mockGenerateBriefUseCase.execute.mockResolvedValue({ success: true });
+      const input = {
+        feedProfile: FeedProfile.DEFAULT,
+        customPrompts: { briefSynthesis: 'Custom prompt' },
+      };
+
+      await controller.generateBriefing(input);
+
+      expect(mockGenerateBriefUseCase.execute).toHaveBeenCalledWith(input);
     });
   });
 });

--- a/src/briefings/briefings.controller.ts
+++ b/src/briefings/briefings.controller.ts
@@ -1,20 +1,25 @@
 import {
+  Body,
   Controller,
   Get,
   NotFoundException,
   Param,
   ParseUUIDPipe,
+  Post,
   Query,
 } from '@nestjs/common';
 import type { FeedProfile } from '../shared/types/feed';
 import { BriefingsService } from './briefings.service';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
+import { GenerateBriefInputDto } from './usecases/dto/generate-brief.dto';
+import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
 
 @Controller('api/briefings')
 export class BriefingsController {
   constructor(
     private readonly briefingsService: BriefingsService,
     private readonly listBriefingsQuery: ListBriefingsQuery,
+    private readonly generateBriefUseCase: GenerateBriefUseCase,
   ) {}
 
   private static readonly MAX_LIMIT = 100;
@@ -39,5 +44,10 @@ export class BriefingsController {
       throw new NotFoundException('Briefing not found');
     }
     return briefing;
+  }
+
+  @Post('generate')
+  async generateBriefing(@Body() input: GenerateBriefInputDto) {
+    return this.generateBriefUseCase.execute(input);
   }
 }

--- a/src/briefings/usecases/categorize-articles.usecase.spec.ts
+++ b/src/briefings/usecases/categorize-articles.usecase.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ProcessorService } from '../../processor/processor.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { ProcessingStats } from '../../shared/types/ai';
+import { CategorizeArticlesUseCase } from './categorize-articles.usecase';
+
+const baseStats: ProcessingStats = {
+  feedProfile: FeedProfile.DEFAULT,
+  articlesProcessed: 0,
+  articlesRated: 0,
+  articlesCategorized: 0,
+  errors: 0,
+  startTime: new Date(),
+};
+
+describe('CategorizeArticlesUseCase', () => {
+  let useCase: CategorizeArticlesUseCase;
+  const mockProcessorService = mock<ProcessorService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategorizeArticlesUseCase,
+        { provide: ProcessorService, useValue: mockProcessorService },
+      ],
+    }).compile();
+
+    useCase = module.get<CategorizeArticlesUseCase>(CategorizeArticlesUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates to processorService and maps stats', async () => {
+    const stats: ProcessingStats = { ...baseStats, articlesCategorized: 8, errors: 0 };
+    mockProcessorService.categorizeArticles.mockResolvedValue(stats);
+
+    const result = await useCase.execute({ feedProfile: FeedProfile.DEFAULT });
+
+    expect(mockProcessorService.categorizeArticles).toHaveBeenCalledWith(FeedProfile.DEFAULT);
+    expect(result).toEqual({ articlesCategorized: 8, errors: 0 });
+  });
+
+  it('propagates service errors', async () => {
+    mockProcessorService.categorizeArticles.mockRejectedValue(new Error('categorization failed'));
+
+    await expect(
+      useCase.execute({ feedProfile: FeedProfile.DEFAULT }),
+    ).rejects.toThrow('categorization failed');
+  });
+});

--- a/src/briefings/usecases/dto/generate-brief.dto.ts
+++ b/src/briefings/usecases/dto/generate-brief.dto.ts
@@ -1,5 +1,16 @@
-import { IsBoolean, IsEnum, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsBoolean, IsEnum, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { FeedProfile } from '../../../shared/types/feed';
+
+export class CustomPromptsDto {
+  @IsOptional()
+  @IsString()
+  clusterAnalysis?: string;
+
+  @IsOptional()
+  @IsString()
+  briefSynthesis?: string;
+}
 
 export class GenerateBriefInputDto {
   @IsEnum(FeedProfile)
@@ -8,6 +19,11 @@ export class GenerateBriefInputDto {
   @IsOptional()
   @IsBoolean()
   simple?: boolean;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CustomPromptsDto)
+  customPrompts?: CustomPromptsDto;
 }
 
 export interface GenerateBriefOutputDto {

--- a/src/briefings/usecases/generate-brief.usecase.spec.ts
+++ b/src/briefings/usecases/generate-brief.usecase.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ConfigService } from '../../config/config.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { BriefingGenerationService } from '../services/briefing-generation.service';
+import { GenerateBriefInputDto } from './dto/generate-brief.dto';
+import { GenerateBriefUseCase } from './generate-brief.usecase';
+
+describe('GenerateBriefUseCase', () => {
+  let useCase: GenerateBriefUseCase;
+  const mockBriefingGenerationService = mock<BriefingGenerationService>();
+  const mockConfigService = mock<ConfigService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GenerateBriefUseCase,
+        { provide: BriefingGenerationService, useValue: mockBriefingGenerationService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    useCase = module.get<GenerateBriefUseCase>(GenerateBriefUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const input: GenerateBriefInputDto = { feedProfile: FeedProfile.DEFAULT };
+
+  it('returns disabled error when feature flag off', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(false);
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('disabled');
+    expect(mockBriefingGenerationService.generateBrief).not.toHaveBeenCalled();
+  });
+
+  it('returns success with briefingId and stats on success path', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockBriefingGenerationService.generateBrief.mockResolvedValue({
+      success: true,
+      briefingId: 'brief-123',
+      stats: { articlesAnalyzed: 10, clustersGenerated: 3, clustersUsed: 2 },
+    });
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(true);
+    expect(result.briefingId).toBe('brief-123');
+    expect(result.stats?.articlesAnalyzed).toBe(10);
+    expect(result.stats?.clustersUsed).toBe(2);
+  });
+
+  it('propagates error from service', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockBriefingGenerationService.generateBrief.mockResolvedValue({
+      success: false,
+      error: 'Not enough articles',
+    });
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Not enough articles');
+  });
+
+  it('forwards customPrompts to generateBrief', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockBriefingGenerationService.generateBrief.mockResolvedValue({
+      success: true,
+      briefingId: 'brief-456',
+    });
+    const inputWithPrompts: GenerateBriefInputDto = {
+      feedProfile: FeedProfile.DEFAULT,
+      customPrompts: { briefSynthesis: 'Custom synthesis prompt' },
+    };
+
+    await useCase.execute(inputWithPrompts);
+
+    expect(mockBriefingGenerationService.generateBrief).toHaveBeenCalledWith(
+      FeedProfile.DEFAULT,
+      { customPrompts: { briefSynthesis: 'Custom synthesis prompt' } },
+    );
+  });
+
+  it('passes undefined customPrompts when not provided', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockBriefingGenerationService.generateBrief.mockResolvedValue({ success: true });
+
+    await useCase.execute(input);
+
+    expect(mockBriefingGenerationService.generateBrief).toHaveBeenCalledWith(
+      FeedProfile.DEFAULT,
+      { customPrompts: undefined },
+    );
+  });
+});

--- a/src/briefings/usecases/generate-brief.usecase.ts
+++ b/src/briefings/usecases/generate-brief.usecase.ts
@@ -24,7 +24,9 @@ export class GenerateBriefUseCase {
       };
     }
 
-    const result = await this.briefingGenerationService.generateBrief(input.feedProfile);
+    const result = await this.briefingGenerationService.generateBrief(input.feedProfile, {
+      customPrompts: input.customPrompts,
+    });
 
     return {
       success: result.success,

--- a/src/briefings/usecases/generate-simple-brief.usecase.spec.ts
+++ b/src/briefings/usecases/generate-simple-brief.usecase.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ConfigService } from '../../config/config.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { BriefingGenerationService } from '../services/briefing-generation.service';
+import { GenerateBriefInputDto } from './dto/generate-brief.dto';
+import { GenerateSimpleBriefUseCase } from './generate-simple-brief.usecase';
+
+describe('GenerateSimpleBriefUseCase', () => {
+  let useCase: GenerateSimpleBriefUseCase;
+  const mockBriefingGenerationService = mock<BriefingGenerationService>();
+  const mockConfigService = mock<ConfigService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GenerateSimpleBriefUseCase,
+        { provide: BriefingGenerationService, useValue: mockBriefingGenerationService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    useCase = module.get<GenerateSimpleBriefUseCase>(GenerateSimpleBriefUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const input: GenerateBriefInputDto = { feedProfile: FeedProfile.DEFAULT };
+
+  it('returns disabled error when feature flag off', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(false);
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('disabled');
+    expect(mockBriefingGenerationService.generateSimpleBrief).not.toHaveBeenCalled();
+  });
+
+  it('returns success with briefingId on success path', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockBriefingGenerationService.generateSimpleBrief.mockResolvedValue({
+      success: true,
+      briefingId: 'simple-brief-uuid',
+    });
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(true);
+    expect(result.briefingId).toBe('simple-brief-uuid');
+    expect(mockBriefingGenerationService.generateSimpleBrief).toHaveBeenCalledWith(
+      FeedProfile.DEFAULT,
+    );
+  });
+
+  it('propagates error from service', async () => {
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockBriefingGenerationService.generateSimpleBrief.mockResolvedValue({
+      success: false,
+      error: 'No articles found for briefing',
+    });
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No articles found for briefing');
+  });
+});

--- a/src/briefings/usecases/process-articles.usecase.spec.ts
+++ b/src/briefings/usecases/process-articles.usecase.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ProcessorService } from '../../processor/processor.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { ProcessingStats } from '../../shared/types/ai';
+import { ProcessArticlesUseCase } from './process-articles.usecase';
+
+const baseStats: ProcessingStats = {
+  feedProfile: FeedProfile.DEFAULT,
+  articlesProcessed: 0,
+  articlesRated: 0,
+  articlesCategorized: 0,
+  errors: 0,
+  startTime: new Date(),
+};
+
+describe('ProcessArticlesUseCase', () => {
+  let useCase: ProcessArticlesUseCase;
+  const mockProcessorService = mock<ProcessorService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProcessArticlesUseCase,
+        { provide: ProcessorService, useValue: mockProcessorService },
+      ],
+    }).compile();
+
+    useCase = module.get<ProcessArticlesUseCase>(ProcessArticlesUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates to processorService and maps stats', async () => {
+    const stats: ProcessingStats = { ...baseStats, articlesProcessed: 4, errors: 0 };
+    mockProcessorService.processArticles.mockResolvedValue(stats);
+
+    const result = await useCase.execute({ feedProfile: FeedProfile.DEFAULT });
+
+    expect(mockProcessorService.processArticles).toHaveBeenCalledWith(
+      FeedProfile.DEFAULT,
+      1000,
+      undefined,
+      undefined,
+    );
+    expect(result).toEqual({ articlesProcessed: 4, errors: 0 });
+  });
+
+  it('propagates service errors', async () => {
+    mockProcessorService.processArticles.mockRejectedValue(new Error('processor error'));
+
+    await expect(
+      useCase.execute({ feedProfile: FeedProfile.DEFAULT }),
+    ).rejects.toThrow('processor error');
+  });
+});

--- a/src/briefings/usecases/rate-articles.usecase.spec.ts
+++ b/src/briefings/usecases/rate-articles.usecase.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ProcessorService } from '../../processor/processor.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { ProcessingStats } from '../../shared/types/ai';
+import { RateArticlesUseCase } from './rate-articles.usecase';
+
+const baseStats: ProcessingStats = {
+  feedProfile: FeedProfile.DEFAULT,
+  articlesProcessed: 0,
+  articlesRated: 0,
+  articlesCategorized: 0,
+  errors: 0,
+  startTime: new Date(),
+};
+
+describe('RateArticlesUseCase', () => {
+  let useCase: RateArticlesUseCase;
+  const mockProcessorService = mock<ProcessorService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateArticlesUseCase,
+        { provide: ProcessorService, useValue: mockProcessorService },
+      ],
+    }).compile();
+
+    useCase = module.get<RateArticlesUseCase>(RateArticlesUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates to processorService and maps stats', async () => {
+    const stats: ProcessingStats = { ...baseStats, articlesRated: 6, errors: 0 };
+    mockProcessorService.rateArticles.mockResolvedValue(stats);
+
+    const result = await useCase.execute({ feedProfile: FeedProfile.DEFAULT });
+
+    expect(mockProcessorService.rateArticles).toHaveBeenCalledWith(FeedProfile.DEFAULT);
+    expect(result).toEqual({ articlesRated: 6, errors: 0 });
+  });
+
+  it('propagates service errors', async () => {
+    mockProcessorService.rateArticles.mockRejectedValue(new Error('rating failed'));
+
+    await expect(
+      useCase.execute({ feedProfile: FeedProfile.DEFAULT }),
+    ).rejects.toThrow('rating failed');
+  });
+});

--- a/src/briefings/usecases/run-briefing.usecase.spec.ts
+++ b/src/briefings/usecases/run-briefing.usecase.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ConfigService } from '../../config/config.service';
+import { ProfilesService } from '../../profiles/profiles.service';
+import { FeedProfile, RSSFeed } from '../../shared/types/feed';
+import { CategorizeArticlesUseCase } from './categorize-articles.usecase';
+import { RunBriefingInputDto } from './dto/run-briefing.dto';
+import { GenerateBriefUseCase } from './generate-brief.usecase';
+import { ProcessArticlesUseCase } from './process-articles.usecase';
+import { RateArticlesUseCase } from './rate-articles.usecase';
+import { RunBriefingUseCase } from './run-briefing.usecase';
+import { ScrapeArticlesUseCase } from './scrape-articles.usecase';
+
+const enabledFeed: RSSFeed = { url: 'https://example.com/feed', name: 'Example' };
+
+describe('RunBriefingUseCase', () => {
+  let useCase: RunBriefingUseCase;
+  const mockScrapeArticlesUseCase = mock<ScrapeArticlesUseCase>();
+  const mockProcessArticlesUseCase = mock<ProcessArticlesUseCase>();
+  const mockRateArticlesUseCase = mock<RateArticlesUseCase>();
+  const mockCategorizeArticlesUseCase = mock<CategorizeArticlesUseCase>();
+  const mockGenerateBriefUseCase = mock<GenerateBriefUseCase>();
+  const mockProfilesService = mock<ProfilesService>();
+  const mockConfigService = mock<ConfigService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RunBriefingUseCase,
+        { provide: ScrapeArticlesUseCase, useValue: mockScrapeArticlesUseCase },
+        { provide: ProcessArticlesUseCase, useValue: mockProcessArticlesUseCase },
+        { provide: RateArticlesUseCase, useValue: mockRateArticlesUseCase },
+        { provide: CategorizeArticlesUseCase, useValue: mockCategorizeArticlesUseCase },
+        { provide: GenerateBriefUseCase, useValue: mockGenerateBriefUseCase },
+        { provide: ProfilesService, useValue: mockProfilesService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    useCase = module.get<RunBriefingUseCase>(RunBriefingUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const input: RunBriefingInputDto = { feedProfile: FeedProfile.DEFAULT };
+
+  it('returns error immediately when no enabled feeds', async () => {
+    mockProfilesService.getEnabledFeedsForProfile.mockReturnValue([]);
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No enabled feeds found for profile 'default'");
+    expect(mockScrapeArticlesUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('runs all stages and returns success when generation enabled', async () => {
+    mockProfilesService.getEnabledFeedsForProfile.mockReturnValue([enabledFeed]);
+    mockScrapeArticlesUseCase.execute.mockResolvedValue({ newArticles: 5, errors: 0 });
+    mockProcessArticlesUseCase.execute.mockResolvedValue({ articlesProcessed: 5, errors: 0 });
+    mockRateArticlesUseCase.execute.mockResolvedValue({ articlesRated: 5, errors: 0 });
+    mockCategorizeArticlesUseCase.execute.mockResolvedValue({ articlesCategorized: 5, errors: 0 });
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(true);
+    mockGenerateBriefUseCase.execute.mockResolvedValue({
+      success: true,
+      briefingId: 'brief-uuid',
+      stats: { articlesAnalyzed: 5, clustersUsed: 2 },
+    });
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(true);
+    expect(result.stages?.scraping.newArticles).toBe(5);
+    expect(result.stages?.processing.articlesProcessed).toBe(5);
+    expect(result.stages?.rating.articlesRated).toBe(5);
+    expect(result.stages?.categorization.articlesCategorized).toBe(5);
+    expect(result.stages?.briefGeneration.briefingId).toBe('brief-uuid');
+  });
+
+  it('skips brief generation when feature flag disabled', async () => {
+    mockProfilesService.getEnabledFeedsForProfile.mockReturnValue([enabledFeed]);
+    mockScrapeArticlesUseCase.execute.mockResolvedValue({ newArticles: 0, errors: 0 });
+    mockProcessArticlesUseCase.execute.mockResolvedValue({ articlesProcessed: 0, errors: 0 });
+    mockRateArticlesUseCase.execute.mockResolvedValue({ articlesRated: 0, errors: 0 });
+    mockCategorizeArticlesUseCase.execute.mockResolvedValue({ articlesCategorized: 0, errors: 0 });
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(false);
+
+    const result = await useCase.execute(input);
+
+    expect(result.success).toBe(false);
+    expect(mockGenerateBriefUseCase.execute).not.toHaveBeenCalled();
+    expect(result.stages?.briefGeneration.error).toContain('disabled');
+  });
+
+  it('propagates stage failure', async () => {
+    mockProfilesService.getEnabledFeedsForProfile.mockReturnValue([enabledFeed]);
+    mockScrapeArticlesUseCase.execute.mockRejectedValue(new Error('scraper down'));
+
+    await expect(useCase.execute(input)).rejects.toThrow('scraper down');
+  });
+
+  it('passes feed urls from enabled feeds to scrape use case', async () => {
+    const feeds: RSSFeed[] = [
+      { url: 'https://a.com/feed', name: 'A' },
+      { url: 'https://b.com/feed', name: 'B' },
+    ];
+    mockProfilesService.getEnabledFeedsForProfile.mockReturnValue(feeds);
+    mockScrapeArticlesUseCase.execute.mockResolvedValue({ newArticles: 0, errors: 0 });
+    mockProcessArticlesUseCase.execute.mockResolvedValue({ articlesProcessed: 0, errors: 0 });
+    mockRateArticlesUseCase.execute.mockResolvedValue({ articlesRated: 0, errors: 0 });
+    mockCategorizeArticlesUseCase.execute.mockResolvedValue({ articlesCategorized: 0, errors: 0 });
+    mockConfigService.isBriefingsGenerationEnabled.mockReturnValue(false);
+
+    await useCase.execute(input);
+
+    expect(mockScrapeArticlesUseCase.execute).toHaveBeenCalledWith({
+      feedProfile: FeedProfile.DEFAULT,
+      feedUrls: ['https://a.com/feed', 'https://b.com/feed'],
+    });
+  });
+});

--- a/src/briefings/usecases/scrape-articles.usecase.spec.ts
+++ b/src/briefings/usecases/scrape-articles.usecase.spec.ts
@@ -1,0 +1,59 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { ProfilesService } from '../../profiles/profiles.service';
+import { ScraperService } from '../../scraper/scraper.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { ScrapingStats } from '../../scraper/scrapper.entity';
+import { ScrapeArticlesUseCase } from './scrape-articles.usecase';
+
+describe('ScrapeArticlesUseCase', () => {
+  let useCase: ScrapeArticlesUseCase;
+  const mockScraperService = mock<ScraperService>();
+  const mockProfilesService = mock<ProfilesService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScrapeArticlesUseCase,
+        { provide: ScraperService, useValue: mockScraperService },
+        { provide: ProfilesService, useValue: mockProfilesService },
+      ],
+    }).compile();
+
+    useCase = module.get<ScrapeArticlesUseCase>(ScrapeArticlesUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('delegates to scraperService and maps stats', async () => {
+    const stats: ScrapingStats = {
+      feedProfile: FeedProfile.DEFAULT,
+      totalFeeds: 2,
+      newArticles: 7,
+      errors: 1,
+      startTime: new Date(),
+    };
+    mockScraperService.scrapeArticles.mockResolvedValue(stats);
+
+    const result = await useCase.execute({
+      feedProfile: FeedProfile.DEFAULT,
+      feedUrls: ['https://a.com/feed', 'https://b.com/feed'],
+    });
+
+    expect(mockScraperService.scrapeArticles).toHaveBeenCalledWith(FeedProfile.DEFAULT, [
+      'https://a.com/feed',
+      'https://b.com/feed',
+    ]);
+    expect(result).toEqual({ newArticles: 7, errors: 1 });
+  });
+
+  it('propagates service errors', async () => {
+    mockScraperService.scrapeArticles.mockRejectedValue(new Error('feed timeout'));
+
+    await expect(
+      useCase.execute({ feedProfile: FeedProfile.DEFAULT, feedUrls: [] }),
+    ).rejects.toThrow('feed timeout');
+  });
+});


### PR DESCRIPTION
## Problem

Phase 4 of the Briefings Module Remediation plan was unimplemented: 7 use case classes had no test coverage, and `customPrompts` was not exposed through the HTTP layer despite the generation service already supporting it. Plan: `docs/features/plans/Implementation Plan - Briefings Module Remediation.md`

## Solution

- Added unit tests for all 7 previously untested use cases: `RunBriefingUseCase`, `GenerateBriefUseCase`, `GenerateSimpleBriefUseCase`, `ScrapeArticlesUseCase`, `ProcessArticlesUseCase`, `RateArticlesUseCase`, `CategorizeArticlesUseCase`
- Added `CustomPromptsDto` with `@IsOptional()` / `@IsString()` / `@ValidateNested()` to `GenerateBriefInputDto`
- `GenerateBriefUseCase` now forwards `customPrompts` to `generateBrief` as second arg options
- Added `POST /api/briefings/generate` endpoint on `BriefingsController`, wired to `GenerateBriefUseCase`
- Updated `briefings.controller.spec.ts` to cover the new endpoint (2 new tests)

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Chore

## Test Plan

- [x] Unit tests pass (`pnpm test`)
- [ ] e2e tests pass (`pnpm test:e2e`)
- Manual steps:
  1. `POST /api/briefings/generate` with `{ "feedProfile": "default" }` triggers brief generation
  2. `POST /api/briefings/generate` with `customPrompts.briefSynthesis` overrides default synthesis prompt

## DB Changes

- [x] No schema changes

## Checklist

- [x] No `console.log` left in
- [x] No hardcoded secrets or env values
- [x] Public API contracts unchanged (or breaking change flagged)