### PR TITLE
feat: custom briefing generation with article picker

### DIFF
--- a/libs/queue/constants/queue.constants.ts
+++ b/libs/queue/constants/queue.constants.ts
@@ -9,3 +9,6 @@ export const PROCESS_TRANSCRIPTION_SUMMARY_JOB = 'process-transcription-summary'
 
 export const AUDIO_GENERATION_QUEUE = 'audio-generation';
 export const GENERATE_AUDIO_JOB = 'generate-audio';
+
+export const CUSTOM_BRIEFING_GENERATION_QUEUE = 'custom-briefing-generation';
+export const GENERATE_CUSTOM_BRIEFING_JOB = 'generate-custom-briefing';

--- a/libs/queue/interfaces/custom-briefing-job.interface.ts
+++ b/libs/queue/interfaces/custom-briefing-job.interface.ts
@@ -1,5 +1,7 @@
+import type { FeedProfile } from '../../../src/shared/types/feed';
+
 export interface CustomBriefingJobData {
   articleIds: string[];
-  feedProfile: string;
+  feedProfile: FeedProfile;
   customPrompt?: string;
 }

--- a/libs/queue/interfaces/custom-briefing-job.interface.ts
+++ b/libs/queue/interfaces/custom-briefing-job.interface.ts
@@ -1,0 +1,5 @@
+export interface CustomBriefingJobData {
+  articleIds: string[];
+  feedProfile: string;
+  customPrompt?: string;
+}

--- a/libs/queue/queue.module.ts
+++ b/libs/queue/queue.module.ts
@@ -9,6 +9,7 @@ import { ConfigModule } from '../../src/config/config.module';
 import { ProcessorModule } from '../../src/processor/processor.module';
 import {
   ARTICLE_PROCESSING_QUEUE,
+  CUSTOM_BRIEFING_GENERATION_QUEUE,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE
 } from './constants/queue.constants';
@@ -54,6 +55,15 @@ import { QueueService } from './queue.service';
       },
       inject: [RedisService],
     },
+    {
+      provide: CUSTOM_BRIEFING_GENERATION_QUEUE,
+      useFactory: (redisService: RedisService) => {
+        return new Queue(CUSTOM_BRIEFING_GENERATION_QUEUE, {
+          connection: redisService.getClient(),
+        });
+      },
+      inject: [RedisService],
+    },
     ArticleProcessor,
     AudioGenerationProcessor,
     QueueService,
@@ -62,6 +72,7 @@ import { QueueService } from './queue.service';
     ARTICLE_PROCESSING_QUEUE,
     MARKDOWN_ARTICLE_PROCESSING_QUEUE,
     YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
+    CUSTOM_BRIEFING_GENERATION_QUEUE,
     QueueService,
   ],
 })

--- a/libs/queue/queue.service.spec.ts
+++ b/libs/queue/queue.service.spec.ts
@@ -5,6 +5,7 @@ import { Job, Queue } from 'bullmq';
 import Redis from 'ioredis';
 import { mock, mockReset } from 'jest-mock-extended';
 import { ConfigService } from '../../src/config/config.service';
+import { FeedProfile } from '../../src/shared/types/feed';
 import {
   ARTICLE_PROCESSING_QUEUE,
   AUDIO_GENERATION_QUEUE,
@@ -88,6 +89,40 @@ describe('QueueService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('addCustomBriefingJob', () => {
+    it('adds retry options from custom briefing queue config', async () => {
+      mockConfigService.getCustomBriefingQueueConfig.mockReturnValue({
+        concurrency: 2,
+        attempts: 4,
+        backoffDelayMs: 7000,
+      });
+      mockCustomBriefingQueue.add.mockResolvedValue({ id: 'job-123' } as Job);
+
+      const result = await service.addCustomBriefingJob({
+        articleIds: ['article-1', 'article-2'],
+        feedProfile: FeedProfile.DEFAULT,
+        customPrompt: 'Focus on risks',
+      });
+
+      expect(mockCustomBriefingQueue.add).toHaveBeenCalledWith(
+        'generate-custom-briefing',
+        {
+          articleIds: ['article-1', 'article-2'],
+          feedProfile: FeedProfile.DEFAULT,
+          customPrompt: 'Focus on risks',
+        },
+        {
+          attempts: 4,
+          backoff: {
+            type: 'exponential',
+            delay: 7000,
+          },
+        },
+      );
+      expect(result).toEqual({ jobId: 'job-123' });
+    });
   });
 
   describe('handleAudioGenerationFailure', () => {

--- a/libs/queue/queue.service.spec.ts
+++ b/libs/queue/queue.service.spec.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '../../src/config/config.service';
 import {
   ARTICLE_PROCESSING_QUEUE,
   AUDIO_GENERATION_QUEUE,
+  CUSTOM_BRIEFING_GENERATION_QUEUE,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   YOUTUBE_TRANSCRIPTION_SUMMARY_QUEUE,
 } from './constants/queue.constants';
@@ -21,6 +22,7 @@ describe('QueueService', () => {
   const mockMarkdownArticleQueue = mock<Queue>();
   const mockTranscriptionSummaryQueue = mock<Queue>();
   const mockAudioQueue = mock<Queue>();
+  const mockCustomBriefingQueue = mock<Queue>();
   const mockConfigService = mock<ConfigService>();
   const mockEmailService = mock<EmailService>();
   const mockRedisService = mock<RedisService>();
@@ -31,6 +33,7 @@ describe('QueueService', () => {
     mockReset(mockMarkdownArticleQueue);
     mockReset(mockTranscriptionSummaryQueue);
     mockReset(mockAudioQueue);
+    mockReset(mockCustomBriefingQueue);
     mockReset(mockConfigService);
     mockReset(mockEmailService);
     mockReset(mockRedisService);
@@ -56,6 +59,10 @@ describe('QueueService', () => {
         {
           provide: AUDIO_GENERATION_QUEUE,
           useValue: mockAudioQueue,
+        },
+        {
+          provide: CUSTOM_BRIEFING_GENERATION_QUEUE,
+          useValue: mockCustomBriefingQueue,
         },
         {
           provide: ConfigService,

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -7,6 +7,8 @@ import { FeedProfile } from '../../src/shared/types/feed';
 import {
   ARTICLE_PROCESSING_QUEUE,
   AUDIO_GENERATION_QUEUE,
+  CUSTOM_BRIEFING_GENERATION_QUEUE,
+  GENERATE_CUSTOM_BRIEFING_JOB,
   MARKDOWN_ARTICLE_PROCESSING_QUEUE,
   PROCESS_ARTICLE_JOB,
   PROCESS_MARKDOWN_ARTICLE_JOB,
@@ -15,6 +17,7 @@ import {
 } from './constants/queue.constants';
 import type { ProcessArticleJobData } from './interfaces/article-job.interface';
 import type { GenerateAudioJobData } from './interfaces/audio-job.interface';
+import type { CustomBriefingJobData } from './interfaces/custom-briefing-job.interface';
 import type { ProcessMarkdownArticleJobData } from './interfaces/markdown-article-job.interface';
 import type { ProcessTranscriptionSummaryJobData } from './interfaces/youtube-transcription-job.interface';
 
@@ -51,6 +54,8 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
     private readonly transcriptionSummaryQueue: Queue,
     @Inject(AUDIO_GENERATION_QUEUE)
     private readonly audioQueue: Queue,
+    @Inject(CUSTOM_BRIEFING_GENERATION_QUEUE)
+    private readonly customBriefingQueue: Queue,
     private readonly configService: ConfigService,
     private readonly emailService: EmailService,
     private readonly redisService: RedisService,
@@ -359,6 +364,38 @@ Please investigate the issue.`,
    */
   async getJobStatus(jobId: string): Promise<JobStatus> {
     const job = await this.articleQueue.getJob(jobId);
+
+    if (!job) {
+      throw new NotFoundException('Job not found');
+    }
+
+    const state = await job.getState();
+    const progress = job.progress;
+    const returnValue = job.returnvalue;
+    const failedReason = job.failedReason;
+
+    return {
+      jobId: job.id as string,
+      state,
+      progress,
+      result: returnValue,
+      error: failedReason,
+      data: job.data,
+    };
+  }
+
+  async addCustomBriefingJob(
+    data: CustomBriefingJobData,
+  ): Promise<{ jobId: string }> {
+    const job = await this.customBriefingQueue.add(
+      GENERATE_CUSTOM_BRIEFING_JOB,
+      data,
+    );
+    return { jobId: job.id as string };
+  }
+
+  async getCustomBriefingJobStatus(jobId: string): Promise<JobStatus> {
+    const job = await this.customBriefingQueue.getJob(jobId);
 
     if (!job) {
       throw new NotFoundException('Job not found');

--- a/libs/queue/queue.service.ts
+++ b/libs/queue/queue.service.ts
@@ -387,9 +387,18 @@ Please investigate the issue.`,
   async addCustomBriefingJob(
     data: CustomBriefingJobData,
   ): Promise<{ jobId: string }> {
+    const { attempts, backoffDelayMs } =
+      this.configService.getCustomBriefingQueueConfig();
     const job = await this.customBriefingQueue.add(
       GENERATE_CUSTOM_BRIEFING_JOB,
       data,
+      {
+        attempts,
+        backoff: {
+          type: 'exponential',
+          delay: backoffDelayMs,
+        },
+      },
     );
     return { jobId: job.id as string };
   }

--- a/src/articles/articles.service.spec.ts
+++ b/src/articles/articles.service.spec.ts
@@ -1,0 +1,85 @@
+import { DatabaseService } from '@libs/database';
+import { mock } from 'jest-mock-extended';
+import { FeedProfile } from '../shared/types/feed';
+import { ArticlesService } from './articles.service';
+
+describe('ArticlesService', () => {
+  const mockDatabaseService = mock<DatabaseService>();
+  const mockDb = {
+    all: jest.fn(),
+  };
+  let service: ArticlesService;
+
+  beforeEach(() => {
+    mockDatabaseService.getDbConnection.mockReturnValue(mockDb as never);
+    service = new ArticlesService(mockDatabaseService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getArticlesByIds', () => {
+    it('returns an empty array without querying when ids are empty', async () => {
+      await expect(service.getArticlesByIds([])).resolves.toEqual([]);
+
+      expect(mockDb.all).not.toHaveBeenCalled();
+    });
+
+    it('queries articles with a bound uuid array and maps row fields', async () => {
+      const ids = [
+        '11111111-1111-1111-1111-111111111111',
+        '22222222-2222-2222-2222-222222222222',
+      ];
+      mockDb.all.mockImplementationOnce((query, params, callback) => {
+        callback(null, [
+          {
+            id: ids[0],
+            url: 'https://example.com/one',
+            title: 'First article',
+            published_date: '2026-04-25T12:00:00.000Z',
+            feed_source: 'Feed',
+            content: 'Raw content',
+            processed_content: 'Processed content',
+            impact_rating: 8,
+            feed_profile: FeedProfile.DEFAULT,
+            image_url: null,
+            categories: '["news","research"]',
+            custom_prompt: null,
+            created_at: '2026-04-25T12:30:00.000Z',
+          },
+        ]);
+      });
+
+      const result = await service.getArticlesByIds(ids);
+
+      expect(mockDb.all).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE id = ANY(?::uuid[])'),
+        [ids, ids],
+        expect.any(Function),
+      );
+      expect(mockDb.all.mock.calls[0][0]).toContain(
+        'ORDER BY array_position(?::uuid[], id)',
+      );
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: ids[0],
+          title: 'First article',
+          published_date: new Date('2026-04-25T12:00:00.000Z'),
+          created_at: new Date('2026-04-25T12:30:00.000Z'),
+          categories: ['news', 'research'],
+        }),
+      ]);
+    });
+
+    it('rejects when the database query fails', async () => {
+      mockDb.all.mockImplementationOnce((query, params, callback) => {
+        callback(new Error('database failed'));
+      });
+
+      await expect(
+        service.getArticlesByIds(['11111111-1111-1111-1111-111111111111']),
+      ).rejects.toThrow('database failed');
+    });
+  });
+});

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -266,17 +266,17 @@ export class ArticlesService {
         return;
       }
 
-      const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
       const query = `
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
           raw_content as content, processed_content, impact_rating,
           image_url, categories, custom_prompt, created_at
         FROM articles
-        WHERE id IN (${placeholders})
+        WHERE id = ANY(?::uuid[])
+        ORDER BY array_position(?::uuid[], id)
       `;
 
-      db.all(query, ids, (err, rows: ArticleRow[]) => {
+      db.all(query, [ids, ids], (err, rows: ArticleRow[]) => {
         if (err) {
           reject(err);
           return;

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -257,6 +257,45 @@ export class ArticlesService {
     });
   }
 
+  async getArticlesByIds(ids: string[]): Promise<DBArticle[]> {
+    return new Promise((resolve, reject) => {
+      const db = this.databaseService.getDbConnection();
+
+      if (!ids || ids.length === 0) {
+        resolve([]);
+        return;
+      }
+
+      const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
+      const query = `
+        SELECT
+          id, url, title, published_date, feed_source, feed_profile,
+          raw_content as content, processed_content, impact_rating,
+          image_url, categories, custom_prompt, created_at
+        FROM articles
+        WHERE id IN (${placeholders})
+      `;
+
+      db.all(query, ids, (err, rows: ArticleRow[]) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        const articles: DBArticle[] = rows.map((row) => ({
+          ...row,
+          published_date: new Date(row.published_date),
+          created_at: new Date(row.created_at),
+          categories: row.categories
+            ? (JSON.parse(row.categories) as ArticleCategory[])
+            : undefined,
+        }));
+
+        resolve(articles);
+      });
+    });
+  }
+
   async getArticlesForBriefing(
     lookbackHours: number,
     feedProfile: FeedProfile,

--- a/src/briefings/briefings.controller.spec.ts
+++ b/src/briefings/briefings.controller.spec.ts
@@ -1,3 +1,4 @@
+import { IS_PUBLIC_KEY } from '@libs/auth';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock } from 'jest-mock-extended';
@@ -154,6 +155,65 @@ describe('BriefingsController', () => {
       await controller.generateBriefing(input);
 
       expect(mockGenerateBriefUseCase.execute).toHaveBeenCalledWith(input);
+    });
+  });
+
+  describe('generateCustomBriefing', () => {
+    it('delegates to GenerateCustomBriefUseCase and returns job id', async () => {
+      const expected = { jobId: 'job-123' };
+      const input = {
+        articleIds: ['article-1', 'article-2'],
+        feedProfile: FeedProfile.DEFAULT,
+      };
+      mockGenerateCustomBriefUseCase.execute.mockResolvedValue(expected);
+
+      const result = await controller.generateCustomBriefing(input);
+
+      expect(mockGenerateCustomBriefUseCase.execute).toHaveBeenCalledWith(input);
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('getCustomBriefingJobStatus', () => {
+    it('delegates to QueueService', async () => {
+      const expected = {
+        jobId: 'job-123',
+        state: 'completed',
+        progress: 100,
+        result: { briefingId: 'briefing-uuid' },
+        error: undefined,
+        data: {},
+      };
+      mockQueueService.getCustomBriefingJobStatus.mockResolvedValue(expected);
+
+      const result = await controller.getCustomBriefingJobStatus('job-123');
+
+      expect(mockQueueService.getCustomBriefingJobStatus).toHaveBeenCalledWith(
+        'job-123',
+      );
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('updateBriefTitle', () => {
+    it('is not marked public', () => {
+      const isPublic = Reflect.getMetadata(
+        IS_PUBLIC_KEY,
+        BriefingsController.prototype,
+        'updateBriefTitle',
+      );
+      expect(isPublic).toBeUndefined();
+    });
+
+    it('updates the title through BriefingsService', async () => {
+      await controller.updateBriefTitle('briefing-uuid', {
+        customTitle: 'Updated Title',
+      });
+
+      expect(mockBriefingsService.updateBriefTitle).toHaveBeenCalledWith(
+        'briefing-uuid',
+        'Updated Title',
+      );
     });
   });
 });

--- a/src/briefings/briefings.controller.spec.ts
+++ b/src/briefings/briefings.controller.spec.ts
@@ -1,17 +1,21 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { mock } from 'jest-mock-extended';
+import { QueueService } from '../../libs/queue/queue.service';
 import { FeedProfile } from '../shared/types/feed';
 import { BriefingsController } from './briefings.controller';
 import { BriefingsService } from './briefings.service';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
 import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
+import { GenerateCustomBriefUseCase } from './usecases/generate-custom-brief.usecase';
 
 describe('BriefingsController', () => {
   let controller: BriefingsController;
   const mockBriefingsService = mock<BriefingsService>();
   const mockListBriefingsQuery = mock<ListBriefingsQuery>();
   const mockGenerateBriefUseCase = mock<GenerateBriefUseCase>();
+  const mockGenerateCustomBriefUseCase = mock<GenerateCustomBriefUseCase>();
+  const mockQueueService = mock<QueueService>();
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -20,6 +24,8 @@ describe('BriefingsController', () => {
         { provide: BriefingsService, useValue: mockBriefingsService },
         { provide: ListBriefingsQuery, useValue: mockListBriefingsQuery },
         { provide: GenerateBriefUseCase, useValue: mockGenerateBriefUseCase },
+        { provide: GenerateCustomBriefUseCase, useValue: mockGenerateCustomBriefUseCase },
+        { provide: QueueService, useValue: mockQueueService },
       ],
     }).compile();
 
@@ -104,6 +110,8 @@ describe('BriefingsController', () => {
         brief_markdown: '# Brief',
         generated_at: new Date('2025-01-01'),
         feed_profile: FeedProfile.DEFAULT,
+        isCustom: false,
+        customTitle: null,
       };
       mockBriefingsService.getBriefById.mockResolvedValue(briefing);
 

--- a/src/briefings/briefings.controller.ts
+++ b/src/briefings/briefings.controller.ts
@@ -1,3 +1,4 @@
+import { JwtAuthGuard } from '@libs/auth';
 import {
   Body,
   Controller,
@@ -8,6 +9,7 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { QueueService } from '../../libs/queue/queue.service';
 import type { FeedProfile } from '../shared/types/feed';
@@ -68,6 +70,7 @@ export class BriefingsController {
   }
 
   @Patch(':id/title')
+  @UseGuards(JwtAuthGuard)
   async updateBriefTitle(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() body: { customTitle: string },

--- a/src/briefings/briefings.controller.ts
+++ b/src/briefings/briefings.controller.ts
@@ -5,14 +5,18 @@ import {
   NotFoundException,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
   Query,
 } from '@nestjs/common';
+import { QueueService } from '../../libs/queue/queue.service';
 import type { FeedProfile } from '../shared/types/feed';
 import { BriefingsService } from './briefings.service';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
 import { GenerateBriefInputDto } from './usecases/dto/generate-brief.dto';
+import type { GenerateCustomBriefInputDto } from './usecases/dto/generate-custom-brief.dto';
 import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
+import { GenerateCustomBriefUseCase } from './usecases/generate-custom-brief.usecase';
 
 @Controller('api/briefings')
 export class BriefingsController {
@@ -20,6 +24,8 @@ export class BriefingsController {
     private readonly briefingsService: BriefingsService,
     private readonly listBriefingsQuery: ListBriefingsQuery,
     private readonly generateBriefUseCase: GenerateBriefUseCase,
+    private readonly generateCustomBriefUseCase: GenerateCustomBriefUseCase,
+    private readonly queueService: QueueService,
   ) {}
 
   private static readonly MAX_LIMIT = 100;
@@ -49,5 +55,24 @@ export class BriefingsController {
   @Post('generate')
   async generateBriefing(@Body() input: GenerateBriefInputDto) {
     return this.generateBriefUseCase.execute(input);
+  }
+
+  @Post('custom')
+  async generateCustomBriefing(@Body() input: GenerateCustomBriefInputDto) {
+    return this.generateCustomBriefUseCase.execute(input);
+  }
+
+  @Get('jobs/:jobId')
+  async getCustomBriefingJobStatus(@Param('jobId') jobId: string) {
+    return this.queueService.getCustomBriefingJobStatus(jobId);
+  }
+
+  @Patch(':id/title')
+  async updateBriefTitle(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() body: { customTitle: string },
+  ) {
+    await this.briefingsService.updateBriefTitle(id, body.customTitle);
+    return { success: true };
   }
 }

--- a/src/briefings/briefings.module.ts
+++ b/src/briefings/briefings.module.ts
@@ -1,3 +1,4 @@
+import { RedisModule } from '@libs/redis';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { QueueModule } from '../../libs/queue/queue.module';
@@ -32,6 +33,7 @@ import { ScrapeArticlesUseCase } from './usecases/scrape-articles.usecase';
     ConfigModule,
     AiModule,
     QueueModule,
+    RedisModule,
   ],
   providers: [
     BriefingsService,

--- a/src/briefings/briefings.module.ts
+++ b/src/briefings/briefings.module.ts
@@ -1,5 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { QueueModule } from '../../libs/queue/queue.module';
 import { AiModule } from '../ai/ai.module';
 import { ArticlesModule } from '../articles/articles.module';
 import { ConfigModule } from '../config/config.module';
@@ -10,9 +11,11 @@ import { BriefingsController } from './briefings.controller';
 import { BriefingsService } from './briefings.service';
 import { BriefingEntity } from './entities/briefing.entity';
 import { ListBriefingsQuery } from './queries/list-briefings.query';
+import { CustomBriefingProcessor } from './processors/custom-briefing.processor';
 import { BriefingGenerationService } from './services/briefing-generation.service';
 import { CategorizeArticlesUseCase } from './usecases/categorize-articles.usecase';
 import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
+import { GenerateCustomBriefUseCase } from './usecases/generate-custom-brief.usecase';
 import { GenerateSimpleBriefUseCase } from './usecases/generate-simple-brief.usecase';
 import { ProcessArticlesUseCase } from './usecases/process-articles.usecase';
 import { RateArticlesUseCase } from './usecases/rate-articles.usecase';
@@ -28,13 +31,16 @@ import { ScrapeArticlesUseCase } from './usecases/scrape-articles.usecase';
     ScraperModule,
     ConfigModule,
     AiModule,
+    QueueModule,
   ],
   providers: [
     BriefingsService,
     BriefingGenerationService,
     ListBriefingsQuery,
+    CustomBriefingProcessor,
     CategorizeArticlesUseCase,
     GenerateBriefUseCase,
+    GenerateCustomBriefUseCase,
     GenerateSimpleBriefUseCase,
     ProcessArticlesUseCase,
     RateArticlesUseCase,

--- a/src/briefings/briefings.module.ts
+++ b/src/briefings/briefings.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { QueueModule } from '../../libs/queue/queue.module';
 import { AiModule } from '../ai/ai.module';
@@ -10,8 +10,8 @@ import { ScraperModule } from '../scraper/scraper.module';
 import { BriefingsController } from './briefings.controller';
 import { BriefingsService } from './briefings.service';
 import { BriefingEntity } from './entities/briefing.entity';
-import { ListBriefingsQuery } from './queries/list-briefings.query';
 import { CustomBriefingProcessor } from './processors/custom-briefing.processor';
+import { ListBriefingsQuery } from './queries/list-briefings.query';
 import { BriefingGenerationService } from './services/briefing-generation.service';
 import { CategorizeArticlesUseCase } from './usecases/categorize-articles.usecase';
 import { GenerateBriefUseCase } from './usecases/generate-brief.usecase';
@@ -50,4 +50,4 @@ import { ScrapeArticlesUseCase } from './usecases/scrape-articles.usecase';
   controllers: [BriefingsController],
   exports: [BriefingsService, BriefingGenerationService],
 })
-export class BriefingsModule {}
+export class BriefingsModule { }

--- a/src/briefings/briefings.service.spec.ts
+++ b/src/briefings/briefings.service.spec.ts
@@ -42,6 +42,8 @@ describe('BriefingsService', () => {
         content: 'content',
         articleIds: ['article-1'],
         feedProfile: FeedProfile.DEFAULT,
+        isCustom: false,
+        customTitle: null,
       });
       expect(result).toBe('new-uuid');
     });

--- a/src/briefings/briefings.service.spec.ts
+++ b/src/briefings/briefings.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { mock } from 'jest-mock-extended';
@@ -61,8 +62,20 @@ describe('BriefingsService', () => {
   describe('getAllBriefsMetadata', () => {
     it('returns mapped metadata for all profiles when no filter', async () => {
       const entities: Partial<BriefingEntity>[] = [
-        { id: 'id-1', createdAt: new Date('2025-01-02'), feedProfile: 'default' },
-        { id: 'id-2', createdAt: new Date('2025-01-01'), feedProfile: 'tech' },
+        {
+          id: 'id-1',
+          createdAt: new Date('2025-01-02'),
+          feedProfile: 'default',
+          isCustom: false,
+          customTitle: null,
+        },
+        {
+          id: 'id-2',
+          createdAt: new Date('2025-01-01'),
+          feedProfile: 'tech',
+          isCustom: false,
+          customTitle: null,
+        },
       ];
       mockRepo.find.mockResolvedValue(entities as BriefingEntity[]);
 
@@ -72,8 +85,20 @@ describe('BriefingsService', () => {
         expect.objectContaining({ where: {}, take: 50 }),
       );
       expect(result).toEqual([
-        { id: 'id-1', generated_at: new Date('2025-01-02'), feed_profile: 'default' },
-        { id: 'id-2', generated_at: new Date('2025-01-01'), feed_profile: 'tech' },
+        {
+          id: 'id-1',
+          generated_at: new Date('2025-01-02'),
+          feed_profile: 'default',
+          isCustom: false,
+          customTitle: null,
+        },
+        {
+          id: 'id-2',
+          generated_at: new Date('2025-01-01'),
+          feed_profile: 'tech',
+          isCustom: false,
+          customTitle: null,
+        },
       ]);
     });
 
@@ -98,6 +123,8 @@ describe('BriefingsService', () => {
         content: '# Brief',
         createdAt: new Date('2025-01-01'),
         feedProfile: 'default',
+        isCustom: false,
+        customTitle: null,
       };
       mockRepo.findOne.mockResolvedValue(entity as BriefingEntity);
 
@@ -108,6 +135,8 @@ describe('BriefingsService', () => {
         brief_markdown: '# Brief',
         generated_at: new Date('2025-01-01'),
         feed_profile: 'default',
+        isCustom: false,
+        customTitle: null,
       });
     });
 
@@ -117,6 +146,27 @@ describe('BriefingsService', () => {
       const result = await service.getBriefById('missing-id');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('updateBriefTitle', () => {
+    it('updates only custom briefings', async () => {
+      mockRepo.update.mockResolvedValue({ affected: 1, raw: {}, generatedMaps: [] });
+
+      await service.updateBriefTitle('brief-uuid', 'New Title');
+
+      expect(mockRepo.update).toHaveBeenCalledWith(
+        { id: 'brief-uuid', isCustom: true },
+        { customTitle: 'New Title' },
+      );
+    });
+
+    it('throws NotFoundException when no custom briefing is updated', async () => {
+      mockRepo.update.mockResolvedValue({ affected: 0, raw: {}, generatedMaps: [] });
+
+      await expect(
+        service.updateBriefTitle('brief-uuid', 'New Title'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/briefings/briefings.service.ts
+++ b/src/briefings/briefings.service.ts
@@ -16,11 +16,14 @@ export class BriefingsService {
     content: string,
     articleIds: string[],
     feedProfile: FeedProfile,
+    opts?: { isCustom?: boolean; customTitle?: string },
   ): Promise<string> {
     const entity = this.briefingRepository.create({
       content,
       articleIds,
       feedProfile,
+      isCustom: opts?.isCustom ?? false,
+      customTitle: opts?.customTitle ?? null,
     });
     const saved = await this.briefingRepository.save(entity);
     return saved.id;
@@ -33,7 +36,7 @@ export class BriefingsService {
     const entities = await this.briefingRepository.find({
       where: feedProfile ? { feedProfile } : {},
       order: { createdAt: 'DESC' },
-      select: { id: true, createdAt: true, feedProfile: true },
+      select: { id: true, createdAt: true, feedProfile: true, isCustom: true, customTitle: true },
       take: limit,
     });
 
@@ -41,6 +44,8 @@ export class BriefingsService {
       id: e.id,
       generated_at: e.createdAt,
       feed_profile: e.feedProfile,
+      isCustom: e.isCustom,
+      customTitle: e.customTitle,
     }));
   }
 
@@ -58,6 +63,12 @@ export class BriefingsService {
       brief_markdown: entity.content,
       generated_at: entity.createdAt,
       feed_profile: entity.feedProfile,
+      isCustom: entity.isCustom,
+      customTitle: entity.customTitle,
     };
+  }
+
+  async updateBriefTitle(id: string, customTitle: string): Promise<void> {
+    await this.briefingRepository.update(id, { customTitle });
   }
 }

--- a/src/briefings/briefings.service.ts
+++ b/src/briefings/briefings.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FeedProfile } from '../shared/types/feed';
@@ -69,6 +69,13 @@ export class BriefingsService {
   }
 
   async updateBriefTitle(id: string, customTitle: string): Promise<void> {
-    await this.briefingRepository.update(id, { customTitle });
+    const result = await this.briefingRepository.update(
+      { id, isCustom: true },
+      { customTitle },
+    );
+
+    if (!result.affected) {
+      throw new NotFoundException('Custom briefing not found');
+    }
   }
 }

--- a/src/briefings/entities/briefing.entity.ts
+++ b/src/briefings/entities/briefing.entity.ts
@@ -19,6 +19,12 @@ export class BriefingEntity {
   @Column({ name: 'feed_profile', type: 'text' })
   feedProfile: string;
 
+  @Column({ name: 'is_custom', type: 'boolean', default: false })
+  isCustom: boolean;
+
+  @Column({ name: 'custom_title', type: 'text', nullable: true })
+  customTitle: string | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }

--- a/src/briefings/entities/briefing.types.ts
+++ b/src/briefings/entities/briefing.types.ts
@@ -53,10 +53,14 @@ export interface GetBriefByIdResult {
   brief_markdown: string;
   generated_at: Date;
   feed_profile: string;
+  isCustom: boolean;
+  customTitle: string | null;
 }
 
 export interface BriefsMetadata {
   id: string;
   generated_at: Date;
   feed_profile: string;
+  isCustom: boolean;
+  customTitle: string | null;
 }

--- a/src/briefings/entities/briefing.types.ts
+++ b/src/briefings/entities/briefing.types.ts
@@ -15,6 +15,7 @@ export interface SimpleBriefResult {
   success: boolean;
   briefingId?: string;
   content?: string;
+  customTitle?: string | null;
   error?: string;
 }
 

--- a/src/briefings/processors/custom-briefing.processor.spec.ts
+++ b/src/briefings/processors/custom-briefing.processor.spec.ts
@@ -108,10 +108,11 @@ describe('CustomBriefingProcessor', () => {
   });
 
   describe('processCustomBriefing', () => {
-    it('generates a custom briefing and returns the briefing id', async () => {
+    it('generates a custom briefing and returns the briefing id with custom title', async () => {
       mockBriefingGenerationService.generateCustomBrief.mockResolvedValue({
         success: true,
         briefingId: 'briefing-uuid',
+        customTitle: 'Generated Title',
       });
 
       const result = await processor.processCustomBriefing({
@@ -128,7 +129,30 @@ describe('CustomBriefingProcessor', () => {
         FeedProfile.DEFAULT,
         'Focus on impact',
       );
-      expect(result).toEqual({ briefingId: 'briefing-uuid' });
+      expect(result).toEqual({
+        briefingId: 'briefing-uuid',
+        customTitle: 'Generated Title',
+      });
+    });
+
+    it('returns null custom title when generation did not produce one', async () => {
+      mockBriefingGenerationService.generateCustomBrief.mockResolvedValue({
+        success: true,
+        briefingId: 'briefing-uuid',
+      });
+
+      const result = await processor.processCustomBriefing({
+        id: 'job-123',
+        data: {
+          articleIds: ['article-1', 'article-2'],
+          feedProfile: FeedProfile.DEFAULT,
+        },
+      } as Job);
+
+      expect(result).toEqual({
+        briefingId: 'briefing-uuid',
+        customTitle: null,
+      });
     });
 
     it('throws when custom briefing generation fails', async () => {

--- a/src/briefings/processors/custom-briefing.processor.spec.ts
+++ b/src/briefings/processors/custom-briefing.processor.spec.ts
@@ -1,0 +1,151 @@
+import { RedisService } from '@libs/redis';
+import { Logger } from '@nestjs/common';
+import { Job, Worker } from 'bullmq';
+import { mock } from 'jest-mock-extended';
+import { ConfigService } from '../../config/config.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { BriefingGenerationService } from '../services/briefing-generation.service';
+import { CustomBriefingProcessor } from './custom-briefing.processor';
+
+jest.mock('bullmq');
+
+describe('CustomBriefingProcessor', () => {
+  let processor: CustomBriefingProcessor;
+  const mockRedisService = mock<RedisService>();
+  const mockBriefingGenerationService = mock<BriefingGenerationService>();
+  const mockConfigService = mock<ConfigService>();
+  const mockWorker = mock<Worker>();
+  const redisClient = {};
+
+  beforeEach(() => {
+    (Worker as unknown as jest.Mock).mockImplementation(() => mockWorker);
+    mockRedisService.getClient.mockReturnValue(redisClient as never);
+    mockConfigService.getCustomBriefingQueueConfig.mockReturnValue({
+      concurrency: 4,
+      attempts: 3,
+      backoffDelayMs: 5000,
+    });
+
+    processor = new CustomBriefingProcessor(
+      mockRedisService,
+      mockBriefingGenerationService,
+      mockConfigService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('initializes the worker with configured concurrency', () => {
+      processor.onModuleInit();
+
+      expect(Worker).toHaveBeenCalledWith(
+        'custom-briefing-generation',
+        expect.any(Function),
+        {
+          connection: redisClient,
+          concurrency: 4,
+        },
+      );
+      expect(mockWorker.on).toHaveBeenCalledWith(
+        'completed',
+        expect.any(Function),
+      );
+      expect(mockWorker.on).toHaveBeenCalledWith('failed', expect.any(Function));
+      expect(mockWorker.on).toHaveBeenCalledWith('error', expect.any(Function));
+    });
+
+    it('logs final job failures after retries are exhausted', () => {
+      const loggerErrorSpy = jest
+        .spyOn(Logger.prototype, 'error')
+        .mockImplementation();
+
+      processor.onModuleInit();
+      const failedHandler = mockWorker.on.mock.calls.find(
+        ([event]) => event === 'failed',
+      )?.[1] as (job: Job | undefined, err: Error) => void;
+
+      failedHandler(
+        {
+          id: 'job-123',
+          attemptsMade: 3,
+          opts: { attempts: 3 },
+        } as Job,
+        new Error('generation failed'),
+      );
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Custom briefing job job-123 failed after 3/3 attempts',
+        expect.any(String),
+      );
+    });
+
+    it('logs retryable job failures before attempts are exhausted', () => {
+      const loggerWarnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation();
+
+      processor.onModuleInit();
+      const failedHandler = mockWorker.on.mock.calls.find(
+        ([event]) => event === 'failed',
+      )?.[1] as (job: Job | undefined, err: Error) => void;
+
+      failedHandler(
+        {
+          id: 'job-123',
+          attemptsMade: 1,
+          opts: { attempts: 3 },
+        } as Job,
+        new Error('generation failed'),
+      );
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'Custom briefing job job-123 failed attempt 1/3; retry scheduled: generation failed',
+      );
+    });
+  });
+
+  describe('processCustomBriefing', () => {
+    it('generates a custom briefing and returns the briefing id', async () => {
+      mockBriefingGenerationService.generateCustomBrief.mockResolvedValue({
+        success: true,
+        briefingId: 'briefing-uuid',
+      });
+
+      const result = await processor.processCustomBriefing({
+        id: 'job-123',
+        data: {
+          articleIds: ['article-1', 'article-2'],
+          feedProfile: FeedProfile.DEFAULT,
+          customPrompt: 'Focus on impact',
+        },
+      } as Job);
+
+      expect(mockBriefingGenerationService.generateCustomBrief).toHaveBeenCalledWith(
+        ['article-1', 'article-2'],
+        FeedProfile.DEFAULT,
+        'Focus on impact',
+      );
+      expect(result).toEqual({ briefingId: 'briefing-uuid' });
+    });
+
+    it('throws when custom briefing generation fails', async () => {
+      mockBriefingGenerationService.generateCustomBrief.mockResolvedValue({
+        success: false,
+        error: 'No articles with processed content found',
+      });
+
+      await expect(
+        processor.processCustomBriefing({
+          id: 'job-123',
+          data: {
+            articleIds: ['article-1', 'article-2'],
+            feedProfile: FeedProfile.DEFAULT,
+          },
+        } as Job),
+      ).rejects.toThrow('No articles with processed content found');
+    });
+  });
+});

--- a/src/briefings/processors/custom-briefing.processor.ts
+++ b/src/briefings/processors/custom-briefing.processor.ts
@@ -3,7 +3,6 @@ import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { Job, Worker } from 'bullmq';
 import { CUSTOM_BRIEFING_GENERATION_QUEUE } from '../../../libs/queue/constants/queue.constants';
 import { CustomBriefingJobData } from '../../../libs/queue/interfaces/custom-briefing-job.interface';
-import { FeedProfile } from '../../shared/types/feed';
 import { BriefingGenerationService } from '../services/briefing-generation.service';
 
 @Injectable()
@@ -56,7 +55,7 @@ export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
 
     const result = await this.briefingGenerationService.generateCustomBrief(
       articleIds,
-      feedProfile as FeedProfile,
+      feedProfile,
       customPrompt,
     );
 

--- a/src/briefings/processors/custom-briefing.processor.ts
+++ b/src/briefings/processors/custom-briefing.processor.ts
@@ -1,0 +1,75 @@
+import { RedisService } from '@libs/redis';
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Job, Worker } from 'bullmq';
+import { CUSTOM_BRIEFING_GENERATION_QUEUE } from '../../../libs/queue/constants/queue.constants';
+import { CustomBriefingJobData } from '../../../libs/queue/interfaces/custom-briefing-job.interface';
+import { FeedProfile } from '../../shared/types/feed';
+import { BriefingGenerationService } from '../services/briefing-generation.service';
+
+@Injectable()
+export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
+  private worker: Worker;
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly briefingGenerationService: BriefingGenerationService,
+  ) { }
+
+  onModuleInit() {
+    this.worker = new Worker(
+      CUSTOM_BRIEFING_GENERATION_QUEUE,
+      async (job: Job<CustomBriefingJobData>) => {
+        return await this.processCustomBriefing(job);
+      },
+      {
+        connection: this.redisService.getClient(),
+        concurrency: 1,
+      },
+    );
+
+    this.worker.on('completed', (job) => {
+      console.log(`Custom briefing job ${job.id} completed successfully`);
+    });
+
+    this.worker.on('failed', (job, err) => {
+      console.error(`Custom briefing job ${job?.id} failed with error:`, err);
+    });
+
+    this.worker.on('error', (err: Error) => {
+      if (err.message?.includes('ECONNRESET') || err.message?.includes('closed')) {
+        return;
+      }
+      console.error('Custom briefing processor worker error:', err);
+    });
+
+    console.log('Custom briefing processor worker initialized');
+  }
+
+  async processCustomBriefing(
+    job: Job<CustomBriefingJobData>,
+  ): Promise<{ briefingId: string }> {
+    const { articleIds, feedProfile, customPrompt } = job.data;
+
+    console.log(
+      `\n>>> Processing custom briefing (Job ${job.id}) for profile ${feedProfile} with ${articleIds.length} articles <<<`,
+    );
+
+    const result = await this.briefingGenerationService.generateCustomBrief(
+      articleIds,
+      feedProfile as FeedProfile,
+      customPrompt,
+    );
+
+    if (!result.success || !result.briefingId) {
+      throw new Error(result.error || 'Failed to generate custom briefing');
+    }
+
+    return { briefingId: result.briefingId };
+  }
+
+  async onModuleDestroy() {
+    if (this.worker) {
+      await this.worker.close();
+    }
+  }
+}

--- a/src/briefings/processors/custom-briefing.processor.ts
+++ b/src/briefings/processors/custom-briefing.processor.ts
@@ -74,7 +74,7 @@ export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
 
   async processCustomBriefing(
     job: Job<CustomBriefingJobData>,
-  ): Promise<{ briefingId: string }> {
+  ): Promise<{ briefingId: string; customTitle: string | null }> {
     const { articleIds, feedProfile, customPrompt } = job.data;
 
     this.logger.log(
@@ -91,7 +91,10 @@ export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
       throw new Error(result.error || 'Failed to generate custom briefing');
     }
 
-    return { briefingId: result.briefingId };
+    return {
+      briefingId: result.briefingId,
+      customTitle: result.customTitle ?? null,
+    };
   }
 
   async onModuleDestroy() {

--- a/src/briefings/processors/custom-briefing.processor.ts
+++ b/src/briefings/processors/custom-briefing.processor.ts
@@ -1,20 +1,25 @@
 import { RedisService } from '@libs/redis';
-import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { Job, Worker } from 'bullmq';
 import { CUSTOM_BRIEFING_GENERATION_QUEUE } from '../../../libs/queue/constants/queue.constants';
 import { CustomBriefingJobData } from '../../../libs/queue/interfaces/custom-briefing-job.interface';
+import { ConfigService } from '../../config/config.service';
 import { BriefingGenerationService } from '../services/briefing-generation.service';
 
 @Injectable()
 export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
   private worker: Worker;
+  private readonly logger = new Logger(CustomBriefingProcessor.name);
 
   constructor(
     private readonly redisService: RedisService,
     private readonly briefingGenerationService: BriefingGenerationService,
+    private readonly configService: ConfigService,
   ) { }
 
   onModuleInit() {
+    const { concurrency } = this.configService.getCustomBriefingQueueConfig();
+
     this.worker = new Worker(
       CUSTOM_BRIEFING_GENERATION_QUEUE,
       async (job: Job<CustomBriefingJobData>) => {
@@ -22,26 +27,49 @@ export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
       },
       {
         connection: this.redisService.getClient(),
-        concurrency: 1,
+        concurrency,
       },
     );
 
     this.worker.on('completed', (job) => {
-      console.log(`Custom briefing job ${job.id} completed successfully`);
+      this.logger.log(`Custom briefing job ${job.id} completed successfully`);
     });
 
     this.worker.on('failed', (job, err) => {
-      console.error(`Custom briefing job ${job?.id} failed with error:`, err);
+      this.handleFailedJob(job, err);
     });
 
     this.worker.on('error', (err: Error) => {
       if (err.message?.includes('ECONNRESET') || err.message?.includes('closed')) {
         return;
       }
-      console.error('Custom briefing processor worker error:', err);
+      this.logger.error('Custom briefing processor worker error', err.stack);
     });
 
-    console.log('Custom briefing processor worker initialized');
+    this.logger.log(
+      `Custom briefing processor worker initialized with concurrency ${concurrency}`,
+    );
+  }
+
+  private handleFailedJob(
+    job: Job<CustomBriefingJobData> | undefined,
+    err: Error,
+  ): void {
+    const attemptsMade = job?.attemptsMade ?? 0;
+    const maxAttempts = job?.opts.attempts ?? 1;
+    const jobId = job?.id ?? 'unknown';
+
+    if (attemptsMade >= maxAttempts) {
+      this.logger.error(
+        `Custom briefing job ${jobId} failed after ${attemptsMade}/${maxAttempts} attempts`,
+        err.stack,
+      );
+      return;
+    }
+
+    this.logger.warn(
+      `Custom briefing job ${jobId} failed attempt ${attemptsMade}/${maxAttempts}; retry scheduled: ${err.message}`,
+    );
   }
 
   async processCustomBriefing(
@@ -49,7 +77,7 @@ export class CustomBriefingProcessor implements OnModuleInit, OnModuleDestroy {
   ): Promise<{ briefingId: string }> {
     const { articleIds, feedProfile, customPrompt } = job.data;
 
-    console.log(
+    this.logger.log(
       `\n>>> Processing custom briefing (Job ${job.id}) for profile ${feedProfile} with ${articleIds.length} articles <<<`,
     );
 

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -249,11 +249,41 @@ describe('BriefingGenerationService', () => {
     );
 
     expect(result.success).toBe(true);
+    expect(result.customTitle).toBeNull();
     expect(mockBriefingsService.saveBrief).toHaveBeenCalledWith(
       '# Custom Brief',
       ['article-1', 'article-2'],
       FeedProfile.DEFAULT,
       { isCustom: true, customTitle: undefined },
+    );
+  });
+
+  it('generateCustomBrief returns the generated custom title in the result', async () => {
+    mockArticlesService.getArticlesByIds.mockResolvedValue([
+      createArticle({ id: 'article-1', title: 'First' }),
+      createArticle({ id: 'article-2', title: 'Second' }),
+    ]);
+    mockProfilesService.getPromptsForProfile.mockReturnValue({
+      simpleBriefing: 'Default custom brief prompt',
+    });
+    mockConfigService.getSimpleBriefPrompt.mockReturnValue('brief prompt');
+    mockAiService.callChat
+      .mockResolvedValueOnce('# Custom Brief')
+      .mockResolvedValueOnce('AI Briefing Highlights');
+    mockBriefingsService.saveBrief.mockResolvedValue('brief-uuid');
+
+    const result = await service.generateCustomBrief(
+      ['article-1', 'article-2'],
+      FeedProfile.DEFAULT,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.customTitle).toBe('AI Briefing Highlights');
+    expect(mockBriefingsService.saveBrief).toHaveBeenCalledWith(
+      '# Custom Brief',
+      ['article-1', 'article-2'],
+      FeedProfile.DEFAULT,
+      { isCustom: true, customTitle: 'AI Briefing Highlights' },
     );
   });
 });

--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -228,4 +228,32 @@ describe('BriefingGenerationService', () => {
     expect(mockAiService.callDeepseekChat).not.toHaveBeenCalled();
     expect(mockAiService.callOpenAIChat).not.toHaveBeenCalled();
   });
+
+  it('generateCustomBrief saves the brief when title generation fails', async () => {
+    mockArticlesService.getArticlesByIds.mockResolvedValue([
+      createArticle({ id: 'article-1', title: 'First' }),
+      createArticle({ id: 'article-2', title: 'Second' }),
+    ]);
+    mockProfilesService.getPromptsForProfile.mockReturnValue({
+      simpleBriefing: 'Default custom brief prompt',
+    });
+    mockConfigService.getSimpleBriefPrompt.mockReturnValue('brief prompt');
+    mockAiService.callChat
+      .mockResolvedValueOnce('# Custom Brief')
+      .mockRejectedValueOnce(new Error('title model unavailable'));
+    mockBriefingsService.saveBrief.mockResolvedValue('brief-uuid');
+
+    const result = await service.generateCustomBrief(
+      ['article-1', 'article-2'],
+      FeedProfile.DEFAULT,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockBriefingsService.saveBrief).toHaveBeenCalledWith(
+      '# Custom Brief',
+      ['article-1', 'article-2'],
+      FeedProfile.DEFAULT,
+      { isCustom: true, customTitle: undefined },
+    );
+  });
 });

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -383,8 +383,15 @@ export class BriefingGenerationService {
       return { success: false, error: 'Failed to generate brief content' };
     }
 
-    const titlePrompt = `Give this briefing a short title (max 8 words): \n\n${briefContent.slice(0, 500)}`;
-    const customTitle = await this.aiService.callChat(titlePrompt);
+    let customTitle: string | undefined;
+    try {
+      const titlePrompt = `Give this briefing a short title (max 8 words): \n\n${briefContent.slice(0, 500)}`;
+      customTitle = (await this.aiService.callChat(titlePrompt)) || undefined;
+    } catch (error) {
+      this.logger.warn(
+        `Custom brief title generation failed for [${feedProfile}]: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
 
     try {
       const briefingId = await this.briefingsService.saveBrief(

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -344,4 +344,66 @@ export class BriefingGenerationService {
       };
     }
   }
+
+  async generateCustomBrief(
+    articleIds: string[],
+    feedProfile: FeedProfile,
+    customPrompt?: string,
+  ): Promise<SimpleBriefResult> {
+    this.logger.log(`Generating Custom Brief [${feedProfile}] with ${articleIds.length} articles`);
+
+    const articles = await this.articlesService.getArticlesByIds(articleIds);
+
+    const articlesWithContent = articles.filter(
+      (a) => a.processed_content != null,
+    );
+
+    if (articlesWithContent.length === 0) {
+      return { success: false, error: 'No articles with processed content found' };
+    }
+
+    const summariesText = articlesWithContent
+      .map(
+        (article, index) =>
+          `${index + 1}. **${article.title}** (Impact: ${article.impact_rating || 'N/A'})\n   ${article.processed_content}\n`,
+      )
+      .join('\n');
+
+    const profilePrompts = this.profilesService.getPromptsForProfile(feedProfile);
+    const promptToUse = customPrompt || profilePrompts.simpleBriefing;
+    const briefPrompt = this.configService.getSimpleBriefPrompt(
+      feedProfile,
+      summariesText,
+      promptToUse,
+    );
+
+    const briefContent = await this.aiService.callChat(briefPrompt);
+
+    if (!briefContent) {
+      return { success: false, error: 'Failed to generate brief content' };
+    }
+
+    const titlePrompt = `Give this briefing a short title (max 8 words): \n\n${briefContent.slice(0, 500)}`;
+    const customTitle = await this.aiService.callChat(titlePrompt);
+
+    try {
+      const briefingId = await this.briefingsService.saveBrief(
+        briefContent,
+        articleIds,
+        feedProfile,
+        { isCustom: true, customTitle: customTitle || undefined },
+      );
+
+      return {
+        success: true,
+        briefingId,
+        content: briefContent,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to save brief',
+      };
+    }
+  }
 }

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -405,6 +405,7 @@ export class BriefingGenerationService {
         success: true,
         briefingId,
         content: briefContent,
+        customTitle: customTitle ?? null,
       };
     } catch (error) {
       return {

--- a/src/briefings/usecases/dto/generate-custom-brief.dto.ts
+++ b/src/briefings/usecases/dto/generate-custom-brief.dto.ts
@@ -1,0 +1,5 @@
+export interface GenerateCustomBriefInputDto {
+  articleIds: string[];
+  feedProfile: string;
+  customPrompt?: string;
+}

--- a/src/briefings/usecases/dto/generate-custom-brief.dto.ts
+++ b/src/briefings/usecases/dto/generate-custom-brief.dto.ts
@@ -1,5 +1,7 @@
+import type { FeedProfile } from '../../../shared/types/feed';
+
 export interface GenerateCustomBriefInputDto {
   articleIds: string[];
-  feedProfile: string;
+  feedProfile: FeedProfile;
   customPrompt?: string;
 }

--- a/src/briefings/usecases/generate-custom-brief.usecase.spec.ts
+++ b/src/briefings/usecases/generate-custom-brief.usecase.spec.ts
@@ -1,0 +1,72 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { mock } from 'jest-mock-extended';
+import { QueueService } from '../../../libs/queue/queue.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { GenerateCustomBriefUseCase } from './generate-custom-brief.usecase';
+
+describe('GenerateCustomBriefUseCase', () => {
+  let useCase: GenerateCustomBriefUseCase;
+  const mockQueueService = mock<QueueService>();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GenerateCustomBriefUseCase,
+        { provide: QueueService, useValue: mockQueueService },
+      ],
+    }).compile();
+
+    useCase = module.get<GenerateCustomBriefUseCase>(GenerateCustomBriefUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queues a custom briefing job for valid input', async () => {
+    mockQueueService.addCustomBriefingJob.mockResolvedValue({ jobId: 'job-123' });
+
+    const result = await useCase.execute({
+      articleIds: ['article-1', 'article-2'],
+      feedProfile: FeedProfile.DEFAULT,
+      customPrompt: 'Focus on risks',
+    });
+
+    expect(mockQueueService.addCustomBriefingJob).toHaveBeenCalledWith({
+      articleIds: ['article-1', 'article-2'],
+      feedProfile: FeedProfile.DEFAULT,
+      customPrompt: 'Focus on risks',
+    });
+    expect(result).toEqual({ jobId: 'job-123' });
+  });
+
+  it('rejects invalid feed profiles', async () => {
+    await expect(
+      useCase.execute({
+        articleIds: ['article-1', 'article-2'],
+        feedProfile: 'invalid-profile' as FeedProfile,
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(mockQueueService.addCustomBriefingJob).not.toHaveBeenCalled();
+  });
+
+  it('requires at least two articles', async () => {
+    await expect(
+      useCase.execute({
+        articleIds: ['article-1'],
+        feedProfile: FeedProfile.DEFAULT,
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('allows no more than ten articles', async () => {
+    await expect(
+      useCase.execute({
+        articleIds: Array.from({ length: 11 }, (_, index) => `article-${index}`),
+        feedProfile: FeedProfile.DEFAULT,
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/src/briefings/usecases/generate-custom-brief.usecase.ts
+++ b/src/briefings/usecases/generate-custom-brief.usecase.ts
@@ -1,0 +1,25 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { QueueService } from '../../../libs/queue/queue.service';
+import { GenerateCustomBriefInputDto } from './dto/generate-custom-brief.dto';
+
+@Injectable()
+export class GenerateCustomBriefUseCase {
+  constructor(private readonly queueService: QueueService) {}
+
+  async execute(input: GenerateCustomBriefInputDto): Promise<{ jobId: string }> {
+    if (!input.articleIds || input.articleIds.length < 2) {
+      throw new BadRequestException('At least 2 articles must be selected');
+    }
+    if (input.articleIds.length > 10) {
+      throw new BadRequestException('Maximum 10 articles can be selected');
+    }
+
+    const { jobId } = await this.queueService.addCustomBriefingJob({
+      articleIds: input.articleIds,
+      feedProfile: input.feedProfile,
+      customPrompt: input.customPrompt,
+    });
+
+    return { jobId };
+  }
+}

--- a/src/briefings/usecases/generate-custom-brief.usecase.ts
+++ b/src/briefings/usecases/generate-custom-brief.usecase.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { QueueService } from '../../../libs/queue/queue.service';
+import { FeedProfile } from '../../shared/types/feed';
 import { GenerateCustomBriefInputDto } from './dto/generate-custom-brief.dto';
 
 @Injectable()
@@ -12,6 +13,9 @@ export class GenerateCustomBriefUseCase {
     }
     if (input.articleIds.length > 10) {
       throw new BadRequestException('Maximum 10 articles can be selected');
+    }
+    if (!Object.values(FeedProfile).includes(input.feedProfile)) {
+      throw new BadRequestException('Invalid feed profile');
     }
 
     const { jobId } = await this.queueService.addCustomBriefingJob({

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -238,6 +238,46 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('getCustomBriefingQueueConfig', () => {
+    afterEach(() => {
+      delete process.env.CUSTOM_BRIEFING_WORKER_CONCURRENCY;
+      delete process.env.CUSTOM_BRIEFING_JOB_ATTEMPTS;
+      delete process.env.CUSTOM_BRIEFING_JOB_BACKOFF_DELAY_MS;
+    });
+
+    it('returns defaults when custom briefing env vars are not set', () => {
+      expect(service.getCustomBriefingQueueConfig()).toEqual({
+        concurrency: 1,
+        attempts: 3,
+        backoffDelayMs: 5000,
+      });
+    });
+
+    it('returns positive integer env values when set', () => {
+      process.env.CUSTOM_BRIEFING_WORKER_CONCURRENCY = '4';
+      process.env.CUSTOM_BRIEFING_JOB_ATTEMPTS = '5';
+      process.env.CUSTOM_BRIEFING_JOB_BACKOFF_DELAY_MS = '10000';
+
+      expect(service.getCustomBriefingQueueConfig()).toEqual({
+        concurrency: 4,
+        attempts: 5,
+        backoffDelayMs: 10000,
+      });
+    });
+
+    it('falls back to defaults for invalid env values', () => {
+      process.env.CUSTOM_BRIEFING_WORKER_CONCURRENCY = 'invalid';
+      process.env.CUSTOM_BRIEFING_JOB_ATTEMPTS = '0';
+      process.env.CUSTOM_BRIEFING_JOB_BACKOFF_DELAY_MS = '-1';
+
+      expect(service.getCustomBriefingQueueConfig()).toEqual({
+        concurrency: 1,
+        attempts: 3,
+        backoffDelayMs: 5000,
+      });
+    });
+  });
+
   describe('getEnabledChatModel', () => {
     it('should return environment variable value when ENABLED_CHAT_MODEL is set', () => {
       process.env.ENABLED_CHAT_MODEL = 'deepseek';

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -276,6 +276,35 @@ export class ConfigService {
     };
   }
 
+  getCustomBriefingQueueConfig() {
+    return {
+      concurrency: this.getPositiveInteger(
+        process.env.CUSTOM_BRIEFING_WORKER_CONCURRENCY,
+        1,
+      ),
+      attempts: this.getPositiveInteger(
+        process.env.CUSTOM_BRIEFING_JOB_ATTEMPTS,
+        3,
+      ),
+      backoffDelayMs: this.getPositiveInteger(
+        process.env.CUSTOM_BRIEFING_JOB_BACKOFF_DELAY_MS,
+        5000,
+      ),
+    };
+  }
+
+  private getPositiveInteger(
+    value: string | undefined,
+    defaultValue: number,
+  ): number {
+    if (value === undefined || value === '') {
+      return defaultValue;
+    }
+
+    const parsed = parseInt(value, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
+  }
+
   getArticleEmailsNotifications(): ArticleEmailsNotifications {
     return {
       failureNotificationEmail:

--- a/src/database/migrations/1777129577067-AddCustomBriefingFields.ts
+++ b/src/database/migrations/1777129577067-AddCustomBriefingFields.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCustomBriefingFields1777129577067 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE briefings ADD COLUMN is_custom BOOLEAN DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE briefings ADD COLUMN custom_title TEXT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE briefings DROP COLUMN custom_title`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE briefings DROP COLUMN is_custom`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the "Custom Briefing" feature, allowing users to hand-pick specific articles and generate a focused intelligence summary from them.

### Backend Changes

- **Database**: Added `is_custom` (boolean, default false) and `custom_title` (text, nullable) columns to the `briefings` table via TypeORM migration `1777129577067-AddCustomBriefingFields`.
- **Queue**: Added `CUSTOM_BRIEFING_GENERATION_QUEUE` with `generate-custom-briefing` job type, `CustomBriefingJobData` interface, and `QueueService` methods `addCustomBriefingJob()` and `getCustomBriefingJobStatus()`.
- **Processor**: Created `CustomBriefingProcessor` (placed in `src/briefings/processors/` to avoid `QueueModule` ↔ `BriefingsModule` circular dependency) that processes jobs via `BriefingGenerationService.generateCustomBrief()`.
- **ArticlesService**: Added `getArticlesByIds()` using dynamic SQL placeholders (`$N`).
- **BriefingGenerationService**: Added `generateCustomBrief()` which:
  - Fetches articles by ID
  - Filters to articles with `processed_content`
  - Formats summaries and calls LLM for briefing content
  - Calls LLM again with a title prompt (max 8 words) for `custom_title`
  - Saves briefing with `isCustom: true`
- **UseCase**: Added `GenerateCustomBriefUseCase` validating `articleIds.length` is 2–10.
- **Controller**: Added three new endpoints:
  - `POST /api/briefings/custom` — queues generation, returns `{ jobId }`
  - `GET /api/briefings/jobs/:jobId` — polls job status
  - `PATCH /api/briefings/:id/title` — renames custom briefing title

### Testing
- All 44 test suites pass (448 tests).