### PR TITLE
fix: rename simpleBriefing → customBriefing across active custom brief path (issue #94)

### DIFF
--- a/src/briefings/services/briefing-generation.service.spec.ts
+++ b/src/briefings/services/briefing-generation.service.spec.ts
@@ -108,7 +108,7 @@ describe('BriefingGenerationService', () => {
     });
     mockArticlesService.getArticlesForBriefing.mockResolvedValue([article]);
     mockProfilesService.getPromptsForProfile.mockReturnValue({});
-    mockConfigService.getSimpleBriefPrompt.mockReturnValue(
+    mockConfigService.getCustomBriefPrompt.mockReturnValue(
       "Create a concise briefing for the 'default' profile based on these recent articles:\n\n1. **Headline Alpha**",
     );
     mockAiService.callChat.mockResolvedValue('# Brief\n\nExecutive summary.');
@@ -155,7 +155,7 @@ describe('BriefingGenerationService', () => {
     mockProfilesService.getPromptsForProfile.mockReturnValue({
       clusterAnalysis: undefined,
       briefSynthesis: undefined,
-      simpleBriefing: undefined,
+      customBriefing: undefined,
     });
     mockConfigService.getPrompt.mockReturnValue('{cluster_summaries_text}');
     mockConfigService.formatPrompt.mockImplementation((template, vars) =>
@@ -236,9 +236,9 @@ describe('BriefingGenerationService', () => {
       createArticle({ id: 'article-2', title: 'Second' }),
     ]);
     mockProfilesService.getPromptsForProfile.mockReturnValue({
-      simpleBriefing: 'Default custom brief prompt',
+      customBriefing: 'Default custom brief prompt',
     });
-    mockConfigService.getSimpleBriefPrompt.mockReturnValue('brief prompt');
+    mockConfigService.getCustomBriefPrompt.mockReturnValue('brief prompt');
     mockAiService.callChat
       .mockResolvedValueOnce('# Custom Brief')
       .mockRejectedValueOnce(new Error('title model unavailable'));
@@ -265,9 +265,9 @@ describe('BriefingGenerationService', () => {
       createArticle({ id: 'article-2', title: 'Second' }),
     ]);
     mockProfilesService.getPromptsForProfile.mockReturnValue({
-      simpleBriefing: 'Default custom brief prompt',
+      customBriefing: 'Default custom brief prompt',
     });
-    mockConfigService.getSimpleBriefPrompt.mockReturnValue('brief prompt');
+    mockConfigService.getCustomBriefPrompt.mockReturnValue('brief prompt');
     mockAiService.callChat
       .mockResolvedValueOnce('# Custom Brief')
       .mockResolvedValueOnce('AI Briefing Highlights');

--- a/src/briefings/services/briefing-generation.service.ts
+++ b/src/briefings/services/briefing-generation.service.ts
@@ -313,10 +313,10 @@ export class BriefingGenerationService {
       .join('\n');
 
     const profilePrompts = this.profilesService.getPromptsForProfile(feedProfile);
-    const briefPrompt = this.configService.getSimpleBriefPrompt(
+    const briefPrompt = this.configService.getCustomBriefPrompt(
       feedProfile,
       summariesText,
-      profilePrompts.simpleBriefing,
+      profilePrompts.customBriefing,
     );
 
     const briefContent = await this.aiService.callChat(briefPrompt);
@@ -370,8 +370,8 @@ export class BriefingGenerationService {
       .join('\n');
 
     const profilePrompts = this.profilesService.getPromptsForProfile(feedProfile);
-    const promptToUse = customPrompt || profilePrompts.simpleBriefing;
-    const briefPrompt = this.configService.getSimpleBriefPrompt(
+    const promptToUse = customPrompt || profilePrompts.customBriefing;
+    const briefPrompt = this.configService.getCustomBriefPrompt(
       feedProfile,
       summariesText,
       promptToUse,

--- a/src/config/config.entity.ts
+++ b/src/config/config.entity.ts
@@ -36,7 +36,7 @@ export type Config = {
     categoryClassification: string;
     clusterAnalysis: string;
     briefSynthesis: string;
-    simpleBriefing: string;
+    customBriefing: string;
     transcriptionSummary: string;
     transcriptionAnalysis: string;
     transcriptionClassification: string;

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -20,7 +20,7 @@ import {
   categoryClassificationPrompt,
   clusterAnalysisPrompt,
   impactRatingPrompt,
-  simpleBriefingPrompt,
+  customBriefingPrompt,
   transcriptionAnalysisPrompt,
   transcriptionClassificationPrompt,
   transcriptionSummaryPrompt,
@@ -39,7 +39,7 @@ export class ConfigService {
       categoryClassification: categoryClassificationPrompt,
       clusterAnalysis: clusterAnalysisPrompt,
       briefSynthesis: briefSynthesisPrompt,
-      simpleBriefing: simpleBriefingPrompt,
+      customBriefing: customBriefingPrompt,
       transcriptionSummary: transcriptionSummaryPrompt,
       transcriptionClassification: transcriptionClassificationPrompt,
       transcriptionAnalysis: transcriptionAnalysisPrompt,
@@ -145,12 +145,12 @@ export class ConfigService {
     });
   }
 
-  getSimpleBriefPrompt(
+  getCustomBriefPrompt(
     feedProfile: FeedProfile,
     summariesText: string,
     customPrompt?: string,
   ): string {
-    const template = customPrompt || this.CONFIGS.prompts.simpleBriefing;
+    const template = customPrompt || this.CONFIGS.prompts.customBriefing;
     return this.formatPrompt(template, {
       feed_profile: feedProfile,
       summaries_text: summariesText,

--- a/src/config/prompts/custom-briefing.prompt.ts
+++ b/src/config/prompts/custom-briefing.prompt.ts
@@ -1,0 +1,10 @@
+export const customBriefingPrompt = `Create a concise briefing for the '{feed_profile}' profile based on these recent articles:
+
+{summaries_text}
+
+Format as a professional briefing with:
+1. Executive Summary (2-3 key themes)
+2. Key Developments (bullet points)
+3. Analysis and Implications
+
+Use Markdown formatting.`;

--- a/src/config/prompts/index.ts
+++ b/src/config/prompts/index.ts
@@ -4,7 +4,7 @@ export { categoryClassificationPrompt } from './category-classification.prompt';
 export { chunkSummaryPrompt, chunkSummaryWithStructurePrompt, structureExtractionPrompt, synthesisWithStructurePrompt } from './transcription-summary.prompt';
 export { clusterAnalysisPrompt } from './cluster-analysis.prompt';
 export { impactRatingPrompt } from './impact-rating.prompt';
-export { simpleBriefingPrompt } from './simple-briefing.prompt';
+export { customBriefingPrompt } from './custom-briefing.prompt';
 export { transcriptionAnalysisPrompt } from './transcription-analysis.prompt';
 export { transcriptionClassificationPrompt } from './transcription-classification.prompt';
 export { transcriptionSummaryPrompt } from './transcription-summary.prompt';

--- a/src/shared/types/feed.ts
+++ b/src/shared/types/feed.ts
@@ -25,7 +25,7 @@ export interface FeedConfiguration {
     impactRating?: string;
     clusterAnalysis?: string;
     briefSynthesis?: string;
-    simpleBriefing?: string;
+    customBriefing?: string;
   };
   settings?: {
     priority?: number;


### PR DESCRIPTION
## Summary

- Renames `simpleBriefing` → `customBriefing` consistently across the active custom brief code path
- Adds `custom-briefing.prompt.ts` with the `customBriefingPrompt` export; `simple-briefing.prompt.ts` left for a follow-up cleanup
- Updates entity type, service method name, feed config interface, and all related test mocks

## Changes

- `src/config/config.entity.ts` — `Config.prompts.simpleBriefing` → `customBriefing`
- `src/config/config.service.ts` — `getSimpleBriefPrompt()` → `getCustomBriefPrompt()`, import updated
- `src/config/prompts/custom-briefing.prompt.ts` — new file with `customBriefingPrompt`
- `src/config/prompts/index.ts` — re-export updated
- `src/shared/types/feed.ts` — `FeedConfiguration.prompts.simpleBriefing` → `customBriefing`
- `src/briefings/services/briefing-generation.service.ts` — call sites updated
- `src/briefings/services/briefing-generation.service.spec.ts` — mock keys and method calls updated

## Test plan

- [ ] Run `pnpm run test` — briefing-generation.service.spec.ts passes
- [ ] Run `pnpm run build` — no TypeScript errors
- [ ] Verify no remaining references to `simpleBriefing` or `getSimpleBriefPrompt` in the active path (old prompt file excluded)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)