### PR TITLE
feat: extract article source from uploaded markdown via AI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,10 @@ _Avoid_: audio briefing, audio file, TTS file
 A piece of written content ingested into the platform. Sources include RSS feeds, website URLs (scraped), and uploaded markdown files (for non-public or unscrappable sites). YouTube transcriptions are not Articles.
 _Avoid_: content item, post (unless quoting a source)
 
+**Article Source**:
+The publication or author attribution stored on an Article. For RSS-ingested articles it is the feed name (e.g. `"Will Larson"`, `"TechCrunch"`). For manually scraped URLs it is `"Manual"`. For uploaded markdown articles it is extracted from the document content via AI; falls back to `"Unknown"` when no author can be identified. `"Unknown"` is a meaningful sentinel — it means extraction was attempted and failed, distinct from legacy `"S3 Upload"` records created before this feature existed.
+_Avoid_: author (too narrow — covers publications, not just people), feed_source (implementation column name)
+
 **Bookmark**:
 An article saved by the user to read later. Not a saved briefing.
 _Avoid_: saved article, favourite, starred

--- a/docs/adr/0003-ai-source-extraction-for-uploaded-articles.md
+++ b/docs/adr/0003-ai-source-extraction-for-uploaded-articles.md
@@ -1,0 +1,31 @@
+# ADR-0003: AI-Based Article Source Extraction for Uploaded Markdown Articles
+
+## Status
+Accepted
+
+## Context
+When a markdown article is uploaded, `feed_source` was hardcoded to `'S3 Upload'`. RSS articles carry a meaningful source name (e.g. `"Will Larson"`, `"TechCrunch"`) from the feed config. Uploaded articles lacked equivalent attribution, making them opaque in listings and briefings.
+
+Uploaded markdown files often contain the author or publication in the body — patterns like `**Author:** João Silva` or `By João Silva` — but the format varies and is not guaranteed.
+
+## Decision
+Before saving an uploaded article to the database, run a dedicated AI call to extract the Article Source from the markdown content. If extraction succeeds, use the result as `feed_source`. If the AI cannot identify a source, fall back to `'Unknown'`.
+
+This extraction is scoped to the markdown upload pipeline only (`MarkdownArticleProcessor`). RSS and manual scrape ingestion paths are unaffected.
+
+## Alternatives considered
+
+**Regex extraction in `parseMarkdownArticle`**
+Deterministic and free. Rejected because the format of author/byline fields varies enough across real uploaded documents that a regex approach would need continual maintenance and would still miss edge cases.
+
+**Piggyback on the existing summary prompt (b1)**
+One fewer AI call. Rejected because the summary prompt is already complex, profile-specific, and structured with strict output sections. Adding a second extraction job risks breaking response parsing and makes the prompt harder to reason about.
+
+**Use `'S3 Upload'` as fallback**
+Consistent with historical data. Rejected because it conflates "no author found" with "feature didn't exist yet", making it impossible to distinguish old records from new ones where extraction failed.
+
+## Consequences
+- Uploaded articles gain meaningful Article Source attribution when present in the content.
+- `'Unknown'` is a new sentinel value for `feed_source`. Legacy records with `'S3 Upload'` remain unchanged and queryable as pre-feature uploads.
+- One extra AI call per markdown upload (small cost, upload path is low-frequency).
+- No schema migration required — `feed_source` is already a free-text `NOT NULL` column.

--- a/src/articles/processors/markdown-article.processor.spec.ts
+++ b/src/articles/processors/markdown-article.processor.spec.ts
@@ -3,6 +3,7 @@ import { RedisService } from '@libs/redis';
 import { S3Service } from '@libs/s3';
 import { Job, Worker } from 'bullmq';
 import { mock } from 'jest-mock-extended';
+import { AiService } from '../../ai/ai.service';
 import { ProcessorService } from '../../processor/processor.service';
 import { FeedProfile } from '../../shared/types/feed';
 import { ArticlesService } from '../articles.service';
@@ -16,6 +17,7 @@ describe('MarkdownArticleProcessor', () => {
   const mockS3Service = mock<S3Service>();
   const mockArticlesService = mock<ArticlesService>();
   const mockProcessorService = mock<ProcessorService>();
+  const mockAiService = mock<AiService>();
   const mockWorker = mock<Worker>();
 
   beforeEach(() => {
@@ -26,6 +28,7 @@ describe('MarkdownArticleProcessor', () => {
       mockS3Service,
       mockArticlesService,
       mockProcessorService,
+      mockAiService,
     );
   });
 
@@ -65,10 +68,11 @@ describe('MarkdownArticleProcessor', () => {
       data: mockJobData,
     } as Job<ProcessMarkdownArticleJobData>;
 
-    it('should successfully process markdown article', async () => {
+    it('should successfully process markdown article using Unknown when AI finds no author', async () => {
       const markdownContent = '# Test Title\n\nTest content.';
       const articleId = 'article-123';
 
+      mockAiService.callChat.mockResolvedValueOnce(null);
       mockS3Service.downloadMarkdownFile.mockResolvedValueOnce(markdownContent);
       mockArticlesService.addArticle.mockResolvedValueOnce(articleId);
       mockProcessorService.processArticles.mockResolvedValueOnce({
@@ -106,7 +110,7 @@ describe('MarkdownArticleProcessor', () => {
         's3://test-bucket/test-file.md',
         'Test Title',
         expect.any(Date),
-        'S3 Upload',
+        'Unknown',
         markdownContent,
         FeedProfile.DEFAULT,
         undefined,
@@ -133,6 +137,104 @@ describe('MarkdownArticleProcessor', () => {
         success: true,
         message: expect.stringContaining('test-file.md'),
       });
+    });
+
+    it('should use AI-extracted author as article source', async () => {
+      const markdownContent =
+        '# My Article\n\n**Author:** João Silva\n\nTest content.';
+      const articleId = 'article-456';
+
+      mockAiService.callChat.mockResolvedValueOnce('João Silva');
+      mockS3Service.downloadMarkdownFile.mockResolvedValueOnce(markdownContent);
+      mockArticlesService.addArticle.mockResolvedValueOnce(articleId);
+      mockProcessorService.processArticles.mockResolvedValueOnce({
+        feedProfile: FeedProfile.DEFAULT,
+        articlesProcessed: 1,
+        articlesRated: 0,
+        articlesCategorized: 0,
+        errors: 0,
+        startTime: new Date(),
+      });
+      mockProcessorService.rateArticles.mockResolvedValueOnce({
+        feedProfile: FeedProfile.DEFAULT,
+        articlesProcessed: 0,
+        articlesRated: 1,
+        articlesCategorized: 0,
+        errors: 0,
+        startTime: new Date(),
+      });
+      mockProcessorService.categorizeArticles.mockResolvedValueOnce({
+        feedProfile: FeedProfile.DEFAULT,
+        articlesProcessed: 0,
+        articlesRated: 0,
+        articlesCategorized: 1,
+        errors: 0,
+        startTime: new Date(),
+      });
+
+      await processor.processMarkdownArticle({
+        ...mockJob,
+        data: { ...mockJobData },
+      } as Job<ProcessMarkdownArticleJobData>);
+
+      expect(mockArticlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        'My Article',
+        expect.any(Date),
+        'João Silva',
+        markdownContent,
+        FeedProfile.DEFAULT,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should use Unknown as article source when AI returns empty string', async () => {
+      const markdownContent = '# Test Title\n\nTest content.';
+      const articleId = 'article-123';
+
+      mockAiService.callChat.mockResolvedValueOnce('');
+      mockS3Service.downloadMarkdownFile.mockResolvedValueOnce(markdownContent);
+      mockArticlesService.addArticle.mockResolvedValueOnce(articleId);
+      mockProcessorService.processArticles.mockResolvedValueOnce({
+        feedProfile: FeedProfile.DEFAULT,
+        articlesProcessed: 1,
+        articlesRated: 0,
+        articlesCategorized: 0,
+        errors: 0,
+        startTime: new Date(),
+      });
+      mockProcessorService.rateArticles.mockResolvedValueOnce({
+        feedProfile: FeedProfile.DEFAULT,
+        articlesProcessed: 0,
+        articlesRated: 1,
+        articlesCategorized: 0,
+        errors: 0,
+        startTime: new Date(),
+      });
+      mockProcessorService.categorizeArticles.mockResolvedValueOnce({
+        feedProfile: FeedProfile.DEFAULT,
+        articlesProcessed: 0,
+        articlesRated: 0,
+        articlesCategorized: 1,
+        errors: 0,
+        startTime: new Date(),
+      });
+
+      await processor.processMarkdownArticle(mockJob);
+
+      expect(mockArticlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        'Test Title',
+        expect.any(Date),
+        'Unknown',
+        markdownContent,
+        FeedProfile.DEFAULT,
+        undefined,
+        undefined,
+        undefined,
+      );
     });
 
     it('should handle S3 download failure', async () => {

--- a/src/articles/processors/markdown-article.processor.ts
+++ b/src/articles/processors/markdown-article.processor.ts
@@ -6,6 +6,8 @@ import { RedisService } from '@libs/redis';
 import { S3Service } from '@libs/s3';
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { Job, Worker } from 'bullmq';
+import { articleSourceExtractionPrompt } from '../../config/prompts';
+import { AiService } from '../../ai/ai.service';
 import { ProcessorService } from '../../processor/processor.service';
 import { ArticlesService } from '../articles.service';
 import { parseMarkdownArticle } from '../helpers/parse-markdown';
@@ -19,6 +21,7 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
     private readonly s3Service: S3Service,
     private readonly articlesService: ArticlesService,
     private readonly processorService: ProcessorService,
+    private readonly aiService: AiService,
   ) {}
 
   onModuleInit() {
@@ -77,12 +80,15 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
       console.log(`Step 2: Parsing markdown...`);
       const parsedArticle = parseMarkdownArticle(markdownContent);
 
+      console.log(`Step 2.5: Extracting article source...`);
+      const articleSource = await this.extractArticleSource(markdownContent);
+
       console.log(`Step 3: Creating article in database...`);
       const articleId = await this.articlesService.addArticle(
         `s3://${s3Bucket}/${s3Key}`,
         parsedArticle.title,
         parsedArticle.publishedDate,
-        'S3 Upload',
+        articleSource,
         parsedArticle.content,
         feedProfile,
         undefined,
@@ -154,6 +160,13 @@ export class MarkdownArticleProcessor implements OnModuleInit, OnModuleDestroy {
         `Markdown article processing failed for ${s3Key}: ${errorMessage}`,
       );
     }
+  }
+
+  private async extractArticleSource(content: string): Promise<string> {
+    const result = await this.aiService.callChat(
+      articleSourceExtractionPrompt + content.substring(0, 2000),
+    );
+    return result?.trim() || 'Unknown';
   }
 
   async onModuleDestroy() {

--- a/src/config/prompts/article-source-extraction.prompt.ts
+++ b/src/config/prompts/article-source-extraction.prompt.ts
@@ -1,0 +1,6 @@
+export const articleSourceExtractionPrompt = `Extract the author or publication name from the article below.
+Return ONLY the name with no additional text, punctuation, or explanation.
+If no author or publication is identifiable, return nothing.
+
+Article:
+`;

--- a/src/config/prompts/index.ts
+++ b/src/config/prompts/index.ts
@@ -1,3 +1,4 @@
+export { articleSourceExtractionPrompt } from './article-source-extraction.prompt';
 export { articleSummaryPrompt } from './article-summary.prompt';
 export { briefSynthesisPrompt } from './brief-synthesis.prompt';
 export { categoryClassificationPrompt } from './category-classification.prompt';


### PR DESCRIPTION
## Summary

- Replaces hardcoded `'S3 Upload'` feed_source on markdown-uploaded articles with an AI-extracted author/publication name
- Falls back to `'Unknown'` when no source is identifiable — distinguishable from legacy `'S3 Upload'` records created before this feature
- Dedicated AI call (Step 2.5) runs between markdown parse and `addArticle`, scoped to the upload pipeline only

## Design decisions

- **Separate AI call** over piggybacking on the summary prompt — keeps the structured summary prompt clean and testable independently
- **`'Unknown'` fallback** over `'S3 Upload'` — makes it possible to query uploads where extraction failed vs. pre-feature records
- **Prompt lives in `src/config/prompts/`** — consistent with every other prompt in the codebase
- ADR-0003 documents the trade-offs in full

## Test plan

- [ ] All 15 processor tests pass (3 new: extracted author, null fallback, empty-string fallback)
- [ ] Full suite green (471 tests)
- [ ] Upload a markdown with `**Author:** Name` and verify feed_source is populated
- [ ] Upload a markdown with no author and verify feed_source is `'Unknown'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)