### PR TITLE
feat(news-digest): NewsDigestService — BullMQ orchestrator with retry and daily cron

### DIFF
--- a/libs/queue/constants/queue.constants.ts
+++ b/libs/queue/constants/queue.constants.ts
@@ -12,3 +12,6 @@ export const GENERATE_AUDIO_JOB = 'generate-audio';
 
 export const CUSTOM_BRIEFING_GENERATION_QUEUE = 'custom-briefing-generation';
 export const GENERATE_CUSTOM_BRIEFING_JOB = 'generate-custom-briefing';
+
+export const NEWS_DIGEST_QUEUE = 'news-digest';
+export const NEWS_DIGEST_JOB = 'news-digest-job';

--- a/src/news-digest/news-digest.module.ts
+++ b/src/news-digest/news-digest.module.ts
@@ -1,13 +1,15 @@
+import { EmailModule } from '@libs/email';
+import { RedisModule } from '@libs/redis';
 import { Logger, Module, OnModuleInit } from '@nestjs/common';
 import { ArticlesModule } from '../articles/articles.module';
 import { ConfigService } from '../config/config.service';
-import { EmailModule } from '../email/email.module';
 import { DigestArticleSelectorService } from './digest-article-selector.service';
 import { DigestEmailComposerService } from './digest-email-composer.service';
+import { NewsDigestService } from './news-digest.service';
 
 @Module({
-  imports: [ArticlesModule, EmailModule],
-  providers: [DigestArticleSelectorService, DigestEmailComposerService],
+  imports: [ArticlesModule, EmailModule.forRoot(), RedisModule],
+  providers: [DigestArticleSelectorService, DigestEmailComposerService, NewsDigestService],
 })
 export class NewsDigestModule implements OnModuleInit {
   private readonly logger = new Logger(NewsDigestModule.name);

--- a/src/news-digest/news-digest.service.spec.ts
+++ b/src/news-digest/news-digest.service.spec.ts
@@ -97,6 +97,20 @@ describe('NewsDigestService', () => {
       );
     });
 
+    it('logs error when seed fails', async () => {
+      const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+      mockQueue.add.mockRejectedValueOnce(new Error('Redis unavailable'));
+
+      service.onModuleInit();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Failed to seed news digest repeatable job',
+        expect.anything(),
+      );
+    });
+
     it('logs error when retries are exhausted', () => {
       const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
 

--- a/src/news-digest/news-digest.service.spec.ts
+++ b/src/news-digest/news-digest.service.spec.ts
@@ -1,0 +1,225 @@
+import { EmailService } from '@libs/email';
+import { RedisService } from '@libs/redis';
+import { Logger } from '@nestjs/common';
+import { Job, Queue, Worker } from 'bullmq';
+import { mock } from 'jest-mock-extended';
+import { ArticlesService } from '../articles/articles.service';
+import { ConfigService } from '../config/config.service';
+import { DBArticle } from '../articles/article.entity';
+import { DigestArticleSelectorService } from './digest-article-selector.service';
+import { DigestEmailComposerService } from './digest-email-composer.service';
+import { NewsDigestService } from './news-digest.service';
+
+jest.mock('bullmq');
+
+function makeArticle(overrides: Partial<DBArticle> = {}): DBArticle {
+  return {
+    id: 'test-id',
+    url: 'https://example.com',
+    title: 'Test Article',
+    published_date: new Date('2026-05-15'),
+    feed_source: 'Test Source',
+    raw_content: 'Raw content',
+    feed_profile: 'technology',
+    created_at: new Date(),
+    ...overrides,
+  } as DBArticle;
+}
+
+describe('NewsDigestService', () => {
+  let service: NewsDigestService;
+  let mockRedisService: ReturnType<typeof mock<RedisService>>;
+  let mockArticlesService: ReturnType<typeof mock<ArticlesService>>;
+  let mockSelectorService: ReturnType<typeof mock<DigestArticleSelectorService>>;
+  let mockComposerService: ReturnType<typeof mock<DigestEmailComposerService>>;
+  let mockEmailService: ReturnType<typeof mock<EmailService>>;
+  let mockConfigService: ReturnType<typeof mock<ConfigService>>;
+  let mockQueue: ReturnType<typeof mock<Queue>>;
+  let mockWorker: ReturnType<typeof mock<Worker>>;
+  const redisClient = {};
+
+  beforeEach(() => {
+    mockRedisService = mock<RedisService>();
+    mockArticlesService = mock<ArticlesService>();
+    mockSelectorService = mock<DigestArticleSelectorService>();
+    mockComposerService = mock<DigestEmailComposerService>();
+    mockEmailService = mock<EmailService>();
+    mockConfigService = mock<ConfigService>();
+    mockQueue = mock<Queue>();
+    mockWorker = mock<Worker>();
+
+    (Queue as unknown as jest.Mock).mockImplementation(() => mockQueue);
+    (Worker as unknown as jest.Mock).mockImplementation(() => mockWorker);
+
+    mockRedisService.getClient.mockReturnValue(redisClient as never);
+    mockConfigService.getNewsDigestFromEmail.mockReturnValue('digest@example.com');
+    mockConfigService.getNewsDigestToEmail.mockReturnValue('user@example.com');
+
+    service = new NewsDigestService(
+      mockRedisService,
+      mockArticlesService,
+      mockSelectorService,
+      mockComposerService,
+      mockEmailService,
+      mockConfigService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('creates queue and worker with the redis connection', () => {
+      service.onModuleInit();
+
+      expect(Queue).toHaveBeenCalledWith('news-digest', { connection: redisClient });
+      expect(Worker).toHaveBeenCalledWith(
+        'news-digest',
+        expect.any(Function),
+        { connection: redisClient },
+      );
+    });
+
+    it('seeds a daily repeatable job at 10:00 UTC with retry config', async () => {
+      service.onModuleInit();
+
+      await Promise.resolve();
+
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'news-digest-job',
+        {},
+        {
+          repeat: { pattern: '0 10 * * *' },
+          attempts: 2,
+          backoff: { type: 'fixed', delay: 600_000 },
+        },
+      );
+    });
+
+    it('logs error when retries are exhausted', () => {
+      const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      service.onModuleInit();
+
+      const failedHandler = mockWorker.on.mock.calls.find(
+        ([event]) => event === 'failed',
+      )?.[1] as (job: Job | undefined, err: Error) => void;
+
+      failedHandler(
+        { id: 'job-1', attemptsMade: 2, opts: { attempts: 2 } } as Job,
+        new Error('AI failed'),
+      );
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'News digest job job-1 failed after 2/2 attempts',
+        expect.anything(),
+      );
+    });
+
+    it('logs warning for retryable failures', () => {
+      const loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+      service.onModuleInit();
+
+      const failedHandler = mockWorker.on.mock.calls.find(
+        ([event]) => event === 'failed',
+      )?.[1] as (job: Job | undefined, err: Error) => void;
+
+      failedHandler(
+        { id: 'job-1', attemptsMade: 1, opts: { attempts: 2 } } as Job,
+        new Error('AI failed'),
+      );
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'News digest job job-1 failed attempt 1/2; retry scheduled: AI failed',
+      );
+    });
+  });
+
+  describe('runDigest', () => {
+    it('fetches articles, selects top 10, composes body, and sends email', async () => {
+      const articles = [makeArticle({ id: 'a1' }), makeArticle({ id: 'a2' })];
+      mockArticlesService.getYesterdayArticlesByProfile.mockResolvedValue(articles);
+      mockSelectorService.selectTopArticles.mockResolvedValue(articles);
+      mockComposerService.compose.mockReturnValue('Digest body');
+      mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+      await service.runDigest();
+
+      expect(mockArticlesService.getYesterdayArticlesByProfile).toHaveBeenCalled();
+      expect(mockSelectorService.selectTopArticles).toHaveBeenCalledWith(articles);
+      expect(mockComposerService.compose).toHaveBeenCalledWith(articles);
+      expect(mockEmailService.sendEmail).toHaveBeenCalledWith({
+        from: 'digest@example.com',
+        to: 'user@example.com',
+        subject: 'Daily News Digest',
+        text: 'Digest body',
+      });
+    });
+
+    it('skips email when no articles are selected', async () => {
+      mockArticlesService.getYesterdayArticlesByProfile.mockResolvedValue([makeArticle()]);
+      mockSelectorService.selectTopArticles.mockResolvedValue([]);
+
+      await service.runDigest();
+
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+      expect(mockComposerService.compose).not.toHaveBeenCalled();
+    });
+
+    it('throws when selectTopArticles fails, allowing BullMQ to retry', async () => {
+      mockArticlesService.getYesterdayArticlesByProfile.mockResolvedValue([makeArticle()]);
+      mockSelectorService.selectTopArticles.mockRejectedValue(new Error('AI service error'));
+
+      await expect(service.runDigest()).rejects.toThrow('AI service error');
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('succeeds on second call after AI failure, simulating BullMQ retry', async () => {
+      const articles = [makeArticle({ id: 'a1' })];
+      mockArticlesService.getYesterdayArticlesByProfile.mockResolvedValue(articles);
+      mockSelectorService.selectTopArticles
+        .mockRejectedValueOnce(new Error('AI service error'))
+        .mockResolvedValueOnce(articles);
+      mockComposerService.compose.mockReturnValue('Digest body');
+      mockEmailService.sendEmail.mockResolvedValue({ success: true });
+
+      await expect(service.runDigest()).rejects.toThrow('AI service error');
+      await expect(service.runDigest()).resolves.toBeUndefined();
+
+      expect(mockEmailService.sendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when sendEmail fails, allowing BullMQ to retry', async () => {
+      const articles = [makeArticle({ id: 'a1' })];
+      mockArticlesService.getYesterdayArticlesByProfile.mockResolvedValue(articles);
+      mockSelectorService.selectTopArticles.mockResolvedValue(articles);
+      mockComposerService.compose.mockReturnValue('Digest body');
+      mockEmailService.sendEmail.mockRejectedValue(new Error('Mailgun error'));
+
+      await expect(service.runDigest()).rejects.toThrow('Mailgun error');
+    });
+
+    it('propagates failure after exhausted retries (total failure scenario)', async () => {
+      const articles = [makeArticle({ id: 'a1' })];
+      mockArticlesService.getYesterdayArticlesByProfile.mockResolvedValue(articles);
+      mockSelectorService.selectTopArticles.mockRejectedValue(new Error('AI permanently down'));
+
+      await expect(service.runDigest()).rejects.toThrow('AI permanently down');
+      await expect(service.runDigest()).rejects.toThrow('AI permanently down');
+
+      expect(mockEmailService.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('closes worker and queue on destroy', async () => {
+      service.onModuleInit();
+      await service.onModuleDestroy();
+
+      expect(mockWorker.close).toHaveBeenCalled();
+      expect(mockQueue.close).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/news-digest/news-digest.service.ts
+++ b/src/news-digest/news-digest.service.ts
@@ -28,15 +28,11 @@ export class NewsDigestService implements OnModuleInit, OnModuleDestroy {
 
     this.queue = new Queue(NEWS_DIGEST_QUEUE, { connection });
 
-    void this.seedRepeatableJob();
+    this.seedRepeatableJob().catch((err: Error) => {
+      this.logger.error('Failed to seed news digest repeatable job', err.stack);
+    });
 
-    this.worker = new Worker(
-      NEWS_DIGEST_QUEUE,
-      async () => {
-        await this.runDigest();
-      },
-      { connection },
-    );
+    this.worker = new Worker(NEWS_DIGEST_QUEUE, () => this.runDigest(), { connection });
 
     this.worker.on('completed', (job) => {
       this.logger.log(`News digest job ${job.id} completed successfully`);
@@ -48,6 +44,7 @@ export class NewsDigestService implements OnModuleInit, OnModuleDestroy {
 
     this.worker.on('error', (err: Error) => {
       if (err.message?.includes('ECONNRESET') || err.message?.includes('closed')) {
+        this.logger.debug(`News digest worker connection error: ${err.message}`);
         return;
       }
       this.logger.error('News digest worker error', err.stack);

--- a/src/news-digest/news-digest.service.ts
+++ b/src/news-digest/news-digest.service.ts
@@ -1,0 +1,114 @@
+import { EmailService } from '@libs/email';
+import { RedisService } from '@libs/redis';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { Job, Queue, Worker } from 'bullmq';
+import { NEWS_DIGEST_JOB, NEWS_DIGEST_QUEUE } from '@libs/queue/constants/queue.constants';
+import { ArticlesService } from '../articles/articles.service';
+import { ConfigService } from '../config/config.service';
+import { DigestArticleSelectorService } from './digest-article-selector.service';
+import { DigestEmailComposerService } from './digest-email-composer.service';
+
+@Injectable()
+export class NewsDigestService implements OnModuleInit, OnModuleDestroy {
+  private queue: Queue;
+  private worker: Worker;
+  private readonly logger = new Logger(NewsDigestService.name);
+
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly articlesService: ArticlesService,
+    private readonly digestArticleSelectorService: DigestArticleSelectorService,
+    private readonly digestEmailComposerService: DigestEmailComposerService,
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  onModuleInit() {
+    const connection = this.redisService.getClient();
+
+    this.queue = new Queue(NEWS_DIGEST_QUEUE, { connection });
+
+    void this.seedRepeatableJob();
+
+    this.worker = new Worker(
+      NEWS_DIGEST_QUEUE,
+      async () => {
+        await this.runDigest();
+      },
+      { connection },
+    );
+
+    this.worker.on('completed', (job) => {
+      this.logger.log(`News digest job ${job.id} completed successfully`);
+    });
+
+    this.worker.on('failed', (job, err) => {
+      this.handleFailedJob(job, err);
+    });
+
+    this.worker.on('error', (err: Error) => {
+      if (err.message?.includes('ECONNRESET') || err.message?.includes('closed')) {
+        return;
+      }
+      this.logger.error('News digest worker error', err.stack);
+    });
+
+    this.logger.log('News digest worker initialized');
+  }
+
+  private async seedRepeatableJob(): Promise<void> {
+    await this.queue.add(
+      NEWS_DIGEST_JOB,
+      {},
+      {
+        repeat: { pattern: '0 10 * * *' },
+        attempts: 2,
+        backoff: { type: 'fixed', delay: 600_000 },
+      },
+    );
+    this.logger.log('News digest repeatable job seeded at 10:00 UTC daily');
+  }
+
+  private handleFailedJob(job: Job | undefined, err: Error): void {
+    const attemptsMade = job?.attemptsMade ?? 0;
+    const maxAttempts = job?.opts.attempts ?? 1;
+    const jobId = job?.id ?? 'unknown';
+
+    if (attemptsMade >= maxAttempts) {
+      this.logger.error(
+        `News digest job ${jobId} failed after ${attemptsMade}/${maxAttempts} attempts`,
+        err.stack,
+      );
+      return;
+    }
+
+    this.logger.warn(
+      `News digest job ${jobId} failed attempt ${attemptsMade}/${maxAttempts}; retry scheduled: ${err.message}`,
+    );
+  }
+
+  async runDigest(): Promise<void> {
+    const articles = await this.articlesService.getYesterdayArticlesByProfile();
+    const selected = await this.digestArticleSelectorService.selectTopArticles(articles);
+
+    if (selected.length === 0) {
+      this.logger.log('No articles selected; skipping digest email');
+      return;
+    }
+
+    const body = this.digestEmailComposerService.compose(selected);
+    await this.emailService.sendEmail({
+      from: this.configService.getNewsDigestFromEmail(),
+      to: this.configService.getNewsDigestToEmail(),
+      subject: 'Daily News Digest',
+      text: body,
+    });
+
+    this.logger.log(`Digest email sent to ${this.configService.getNewsDigestToEmail()}`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.worker?.close();
+    await this.queue?.close();
+  }
+}


### PR DESCRIPTION
Closes #104

## Summary

- Adds `NEWS_DIGEST_QUEUE` / `NEWS_DIGEST_JOB` constants to `libs/queue/constants/queue.constants.ts`
- Creates `NewsDigestService` (`OnModuleInit`/`OnModuleDestroy`): seeds a BullMQ repeatable job at `0 10 * * *` (10:00 UTC) with `attempts: 2` and `backoff: { type: 'fixed', delay: 600_000 }`; a Worker runs the pipeline on each fire
- Pipeline: `getYesterdayArticlesByProfile` → `DigestArticleSelectorService.selectTopArticles` → `DigestEmailComposerService.compose` → `EmailService.sendEmail`; skips email when selector returns zero articles
- Updates `NewsDigestModule` to import `RedisModule`, `EmailModule.forRoot()`, and provide `NewsDigestService`
- No `Briefing` entity created or modified

## Test plan

- [x] All 513 existing tests pass (`pnpm test`)
- [x] `news-digest.service.spec.ts` covers: successful send, zero articles (no email), AI failure (throws → BullMQ retries), AI failure then success on retry, email failure (throws), total failure after 2 exhausted attempts
- [x] Worker initialization and repeatable job seeding verified via mocked BullMQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)