### PR TITLE
feat(articles): extract ArticleIngestionModule (#114)

### DIFF
--- a/src/articles/articles.service.spec.ts
+++ b/src/articles/articles.service.spec.ts
@@ -7,6 +7,7 @@ describe('ArticlesService', () => {
   const mockDatabaseService = mock<DatabaseService>();
   const mockDb = {
     all: jest.fn(),
+    get: jest.fn(),
   };
   let service: ArticlesService;
 
@@ -118,6 +119,59 @@ describe('ArticlesService', () => {
       await expect(service.getYesterdayArticlesByProfile()).rejects.toThrow(
         'db error',
       );
+    });
+  });
+
+  describe('getArticleByUrl', () => {
+    it('returns the matching article when found', async () => {
+      const row = {
+        id: 'bbbb-2222',
+        url: 'https://example.com/found',
+        title: 'Found article',
+        published_date: '2026-05-10T08:00:00.000Z',
+        feed_source: 'RSS Feed',
+        content: 'article content',
+        processed_content: null,
+        impact_rating: null,
+        feed_profile: FeedProfile.TECHNOLOGY,
+        image_url: null,
+        categories: '["news"]',
+        custom_prompt: null,
+        created_at: '2026-05-10T08:01:00.000Z',
+      };
+      mockDb.get.mockImplementationOnce((query, params, callback) => {
+        callback(null, row);
+      });
+
+      const result = await service.getArticleByUrl('https://example.com/found');
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          id: 'bbbb-2222',
+          url: 'https://example.com/found',
+          published_date: new Date('2026-05-10T08:00:00.000Z'),
+          created_at: new Date('2026-05-10T08:01:00.000Z'),
+          categories: ['news'],
+        }),
+      );
+    });
+
+    it('returns null when no article matches the URL', async () => {
+      mockDb.get.mockImplementationOnce((query, params, callback) => {
+        callback(null, undefined);
+      });
+
+      const result = await service.getArticleByUrl('https://example.com/missing');
+
+      expect(result).toBeNull();
+    });
+
+    it('rejects when the database query fails', async () => {
+      mockDb.get.mockImplementationOnce((query, params, callback) => {
+        callback(new Error('db error'));
+      });
+
+      await expect(service.getArticleByUrl('https://example.com/error')).rejects.toThrow('db error');
     });
   });
 

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -606,6 +606,41 @@ export class ArticlesService {
     });
   }
 
+  async getArticleByUrl(url: string): Promise<DBArticle | null> {
+    return new Promise((resolve, reject) => {
+      const db = this.databaseService.getDbConnection();
+
+      const query = `
+        SELECT
+          id, url, title, published_date, feed_source, feed_profile,
+          raw_content as content, processed_content, impact_rating,
+          image_url, categories, custom_prompt, created_at
+        FROM articles
+        WHERE url = ?
+      `;
+
+      db.get(query, [url], (err, row: ArticleRow | undefined) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        if (row) {
+          resolve({
+            ...row,
+            published_date: new Date(row.published_date),
+            created_at: new Date(row.created_at),
+            categories: row.categories
+              ? (JSON.parse(row.categories) as ArticleCategory[])
+              : undefined,
+          });
+        } else {
+          resolve(null);
+        }
+      });
+    });
+  }
+
   async getRelatedArticles(
     articleId: string,
     limit: number = 5,

--- a/src/articles/ingestion/article-ingestion.module.ts
+++ b/src/articles/ingestion/article-ingestion.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ArticlesModule } from '../articles.module';
+import { ArticleIngestionService } from './article-ingestion.service';
+
+@Module({
+  imports: [ArticlesModule],
+  providers: [ArticleIngestionService],
+  exports: [ArticleIngestionService],
+})
+export class ArticleIngestionModule {}

--- a/src/articles/ingestion/article-ingestion.service.spec.ts
+++ b/src/articles/ingestion/article-ingestion.service.spec.ts
@@ -1,0 +1,195 @@
+import { mock } from 'jest-mock-extended';
+import { AiService } from '../../ai/ai.service';
+import { FeedProfile } from '../../shared/types/feed';
+import { DBArticle } from '../article.entity';
+import { ArticlesService } from '../articles.service';
+import { ArticleIngestionService, RawArticleInput } from './article-ingestion.service';
+
+const makeArticle = (overrides: Partial<DBArticle> = {}): DBArticle => ({
+  id: 'article-id-1',
+  url: 'https://example.com/article',
+  title: 'Test Article',
+  published_date: new Date('2026-05-17T10:00:00.000Z'),
+  feed_source: 'Test Feed',
+  raw_content: 'article content',
+  feed_profile: FeedProfile.TECHNOLOGY,
+  created_at: new Date('2026-05-17T10:01:00.000Z'),
+  ...overrides,
+});
+
+const makeInput = (overrides: Partial<RawArticleInput> = {}): RawArticleInput => ({
+  url: 'https://example.com/article',
+  title: 'Test Article',
+  content: 'article content',
+  publishedDate: new Date('2026-05-17T10:00:00.000Z'),
+  feedProfile: FeedProfile.TECHNOLOGY,
+  source: { type: 'rss', feedName: 'Test Feed' },
+  ...overrides,
+});
+
+describe('ArticleIngestionService', () => {
+  let service: ArticleIngestionService;
+  let articlesService: ReturnType<typeof mock<ArticlesService>>;
+  let aiService: ReturnType<typeof mock<AiService>>;
+
+  beforeEach(() => {
+    articlesService = mock<ArticlesService>();
+    aiService = mock<AiService>();
+    service = new ArticleIngestionService(articlesService, aiService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deduplication', () => {
+    it('returns existing article and skips persistence when URL already exists', async () => {
+      const existing = makeArticle();
+      articlesService.getArticleByUrl.mockResolvedValue(existing);
+
+      const result = await service.ingest(makeInput());
+
+      expect(result).toBe(existing);
+      expect(articlesService.addArticle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('source attribution', () => {
+    beforeEach(() => {
+      articlesService.getArticleByUrl.mockResolvedValueOnce(null);
+      articlesService.addArticle.mockResolvedValue('article-id-1');
+      articlesService.getArticleById.mockResolvedValue(makeArticle());
+    });
+
+    it('uses feed name for RSS source', async () => {
+      await service.ingest(makeInput({ source: { type: 'rss', feedName: 'Hacker News' } }));
+
+      expect(articlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Date),
+        'Hacker News',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('uses "Manual" for manual scrape source', async () => {
+      await service.ingest(makeInput({ source: { type: 'manual' } }));
+
+      expect(articlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Date),
+        'Manual',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('uses AI-extracted source for markdown when extraction succeeds', async () => {
+      aiService.callChat.mockResolvedValue('  TechCrunch  ');
+
+      await service.ingest(makeInput({ source: { type: 'markdown' } }));
+
+      expect(articlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Date),
+        'TechCrunch',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('falls back to "Unknown" for markdown when AI returns null', async () => {
+      aiService.callChat.mockResolvedValue(null);
+
+      await service.ingest(makeInput({ source: { type: 'markdown' } }));
+
+      expect(articlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Date),
+        'Unknown',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('falls back to "Unknown" for markdown when AI returns empty string', async () => {
+      aiService.callChat.mockResolvedValue('   ');
+
+      await service.ingest(makeInput({ source: { type: 'markdown' } }));
+
+      expect(articlesService.addArticle).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(Date),
+        'Unknown',
+        expect.any(String),
+        expect.any(String),
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+  });
+
+  describe('persistence', () => {
+    it('returns the newly created article after successful insertion', async () => {
+      const newArticle = makeArticle({ id: 'new-article-id' });
+      articlesService.getArticleByUrl.mockResolvedValue(null);
+      articlesService.addArticle.mockResolvedValue('new-article-id');
+      articlesService.getArticleById.mockResolvedValue(newArticle);
+
+      const result = await service.ingest(makeInput());
+
+      expect(result).toBe(newArticle);
+      expect(articlesService.getArticleById).toHaveBeenCalledWith('new-article-id');
+    });
+
+    it('handles concurrent insert race by returning the concurrently inserted article', async () => {
+      const concurrent = makeArticle();
+      articlesService.getArticleByUrl
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(concurrent);
+      articlesService.addArticle.mockResolvedValue(null);
+
+      const result = await service.ingest(makeInput());
+
+      expect(result).toBe(concurrent);
+    });
+
+    it('throws when addArticle returns null and no concurrent article is found', async () => {
+      articlesService.getArticleByUrl.mockResolvedValue(null);
+      articlesService.addArticle.mockResolvedValue(null);
+
+      await expect(service.ingest(makeInput())).rejects.toThrow(
+        'Failed to persist article: https://example.com/article',
+      );
+    });
+
+    it('throws when article cannot be found by id after insertion', async () => {
+      articlesService.getArticleByUrl.mockResolvedValue(null);
+      articlesService.addArticle.mockResolvedValue('new-article-id');
+      articlesService.getArticleById.mockResolvedValue(null);
+
+      await expect(service.ingest(makeInput())).rejects.toThrow(
+        'Article new-article-id not found after insertion',
+      );
+    });
+  });
+});

--- a/src/articles/ingestion/article-ingestion.service.ts
+++ b/src/articles/ingestion/article-ingestion.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { AiService } from '../../ai/ai.service';
+import { articleSourceExtractionPrompt } from '../../config/prompts';
+import { FeedProfile } from '../../shared/types/feed';
+import { DBArticle } from '../article.entity';
+import { ArticlesService } from '../articles.service';
+
+export type ArticleSource =
+  | { type: 'rss'; feedName: string }
+  | { type: 'manual' }
+  | { type: 'markdown' };
+
+export interface RawArticleInput {
+  url: string;
+  title: string;
+  content: string;
+  publishedDate: Date;
+  feedProfile: FeedProfile;
+  source: ArticleSource;
+  imageUrl?: string;
+  customPrompt?: string;
+}
+
+@Injectable()
+export class ArticleIngestionService {
+  constructor(
+    private readonly articlesService: ArticlesService,
+    private readonly aiService: AiService,
+  ) {}
+
+  async ingest(rawArticle: RawArticleInput): Promise<DBArticle> {
+    const existing = await this.articlesService.getArticleByUrl(rawArticle.url);
+    if (existing) {
+      return existing;
+    }
+
+    const feedSource = await this.resolveSource(rawArticle);
+
+    const articleId = await this.articlesService.addArticle(
+      rawArticle.url,
+      rawArticle.title,
+      rawArticle.publishedDate,
+      feedSource,
+      rawArticle.content,
+      rawArticle.feedProfile,
+      rawArticle.imageUrl,
+      undefined,
+      rawArticle.customPrompt,
+    );
+
+    if (!articleId) {
+      // Race: another process inserted between our check and our insert
+      const concurrent = await this.articlesService.getArticleByUrl(rawArticle.url);
+      if (concurrent) {
+        return concurrent;
+      }
+      throw new Error(`Failed to persist article: ${rawArticle.url}`);
+    }
+
+    const article = await this.articlesService.getArticleById(articleId);
+    if (!article) {
+      throw new Error(`Article ${articleId} not found after insertion`);
+    }
+
+    return article;
+  }
+
+  private async resolveSource(rawArticle: RawArticleInput): Promise<string> {
+    switch (rawArticle.source.type) {
+      case 'rss':
+        return rawArticle.source.feedName;
+      case 'manual':
+        return 'Manual';
+      case 'markdown': {
+        const result = await this.aiService.callChat(
+          articleSourceExtractionPrompt + rawArticle.content.substring(0, 2000),
+        );
+        return result?.trim() || 'Unknown';
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts `ArticleIngestionModule` with a single public `ingest(rawArticle: RawArticleInput): Promise<DBArticle>` method
- Adds `getArticleByUrl()` to `ArticlesService` for deduplication and race-condition recovery
- `ArticleSource` is a discriminated union (`rss | manual | markdown`) — the module owns all source-attribution logic

## Details

- **Deduplication**: checks by URL before inserting; returns existing article without calling `addArticle()`
- **Race-condition safety**: if `addArticle()` returns null (concurrent insert), re-fetches by URL before throwing
- **Source attribution**: RSS → feed name, manual → `"Manual"`, markdown → AI-extracted via `articleSourceExtractionPrompt` or `"Unknown"` fallback (null/empty)
- `ArticleIngestionModule` imports `ArticlesModule` directly — no `forwardRef` needed
- `AiModule` is `@Global()` so `AiService` is available without re-importing

## Tests

13 new tests, all passing (527 total):
- `getArticleByUrl`: found, not found, db error
- `ArticleIngestionService`: deduplication, all 3 source attribution paths (including null and empty AI fallback), 4 persistence paths (happy path, race, persist failure, post-insert fetch failure)

## Test plan

- [ ] `pnpm test` passes (527 tests)
- [ ] `pnpm run typecheck` clean
- [ ] Verify `ArticleIngestionModule` can be imported by a consumer module

🤖 Generated with [Claude Code](https://claude.com/claude-code)