### PR TITLE
fix: getArticleByUrl raw_content alias mismatch (#128)

### DIFF
--- a/src/articles/articles.service.spec.ts
+++ b/src/articles/articles.service.spec.ts
@@ -130,7 +130,7 @@ describe('ArticlesService', () => {
         title: 'Found article',
         published_date: '2026-05-10T08:00:00.000Z',
         feed_source: 'RSS Feed',
-        content: 'article content',
+        raw_content: 'article raw content',
         processed_content: null,
         impact_rating: null,
         feed_profile: FeedProfile.TECHNOLOGY,
@@ -149,6 +149,7 @@ describe('ArticlesService', () => {
         expect.objectContaining({
           id: 'bbbb-2222',
           url: 'https://example.com/found',
+          raw_content: 'article raw content',
           published_date: new Date('2026-05-10T08:00:00.000Z'),
           created_at: new Date('2026-05-10T08:01:00.000Z'),
           categories: ['news'],

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -23,7 +23,6 @@ interface ArticleRow {
   categories?: string | null;
   custom_prompt?: string | null;
   created_at: string;
-  content?: string;
 }
 
 interface CountRow {
@@ -269,7 +268,7 @@ export class ArticlesService {
       const query = `
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
-          raw_content as content, processed_content, impact_rating,
+          raw_content, processed_content, impact_rating,
           image_url, categories, custom_prompt, created_at
         FROM articles
         WHERE id = ANY(?::uuid[])
@@ -362,7 +361,7 @@ export class ArticlesService {
       const query = `
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
-          raw_content as content, processed_content, impact_rating,
+          raw_content, processed_content, impact_rating,
           image_url, categories, custom_prompt, created_at
         FROM articles
         WHERE id = ?
@@ -476,7 +475,7 @@ export class ArticlesService {
       let query = `
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
-          raw_content as content, processed_content, impact_rating,
+          raw_content, processed_content, impact_rating,
           image_url, categories, custom_prompt, created_at
         FROM articles
         WHERE 1=1
@@ -613,7 +612,7 @@ export class ArticlesService {
       const query = `
         SELECT
           id, url, title, published_date, feed_source, feed_profile,
-          raw_content as content, processed_content, impact_rating,
+          raw_content, processed_content, impact_rating,
           image_url, categories, custom_prompt, created_at
         FROM articles
         WHERE url = ?
@@ -668,7 +667,7 @@ export class ArticlesService {
         const relatedQuery = `
           SELECT
             id, url, title, published_date, feed_source, feed_profile,
-            raw_content as content, processed_content, impact_rating,
+            raw_content, processed_content, impact_rating,
             image_url, categories, custom_prompt, created_at
           FROM articles
           WHERE feed_profile = ?


### PR DESCRIPTION
## Summary

- Removed `raw_content as content` SQL alias from all 5 `SELECT` queries in `ArticlesService` (`getArticleByUrl`, `getArticleById`, `getArticlesByIds`, paginated list, `getRelatedArticles`)
- Dropped the vestigial `content?: string` field from the `ArticleRow` interface
- Updated `getArticleByUrl` test to assert `raw_content` is populated on the returned `DBArticle`

The `...row` spread now correctly maps the DB column to `DBArticle.raw_content`. Previously, callers accessing `article.raw_content` silently received `undefined` because the alias renamed the column to `content` at the DB driver level.

## Test plan

- [ ] `articles.service.spec.ts` — all 11 tests pass
- [ ] `pnpm exec tsc --noEmit` — no type errors

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)